### PR TITLE
feat(Status): dynamically construct non-static widgets

### DIFF
--- a/data/ui/widgets/status.ui
+++ b/data/ui/widgets/status.ui
@@ -12,33 +12,6 @@
         <property name="orientation">vertical</property>
         <property name="column_spacing">8</property>
         <child>
-          <object class="GtkImage" id="header_icon">
-            <property name="visible">0</property>
-            <property name="halign">end</property>
-            <!-- <property name="margin_bottom">8</property> -->
-            <property name="icon_name">oops</property>
-            <property name="icon_size">1</property>
-            <layout>
-              <property name="column">0</property>
-              <property name="row">0</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="TubaWidgetsRichLabelContainer" id="header_label">
-            <property name="visible">0</property>
-            <!-- <property name="ellipsize">end</property> -->
-            <!-- <property name="margin-bottom">8</property> -->
-            <style>
-              <class name="font-bold"/>
-            </style>
-            <layout>
-              <property name="column">1</property>
-              <property name="row">0</property>
-            </layout>
-          </object>
-        </child>
-        <child>
           <object class="GtkGrid">
             <property name="vexpand">1</property>
             <property name="row_homogeneous">1</property>
@@ -217,13 +190,6 @@
                             <property name="hexpand">True</property>
                           </object>
                         </child>
-                        <child>
-                              <object class="TubaWidgetsVoteBox" id="poll">
-                              </object>
-                        </child>
-                        <child>
-                          <object class="TubaWidgetsAttachmentBox" id="attachments"/>
-                        </child>
                       </object>
                     </property>
                   </object>
@@ -254,53 +220,8 @@
               </object>
             </child>
             <child>
-              <object class="GtkFlowBox" id="emoji_reactions">
-                <property name="visible">0</property>
-                <property name="column_spacing">6</property>
-                <property name="row_spacing">6</property>
-                <!-- Lower values leave space between items -->
-                <property name="max_children_per_line">100</property>
-              </object>
-            </child>
-            <child>
               <object class="GtkBox" id="actions">
                 <property name="spacing">6</property>
-                <style>
-                  <class name="ttl-post-actions"/>
-                </style>
-              </object>
-            </child>
-            <child>
-              <object class="GtkBox" id="fr_actions">
-                <property name="visible">0</property>
-                <property name="homogeneous">1</property>
-                <property name="spacing">6</property>
-                <child>
-                  <object class="GtkButton" id="decline_fr_button">
-                      <property name="label" translatable="yes">Decline</property>
-                      <property name="tooltip_text" translatable="yes">Decline</property>
-                      <property name="icon_name">tuba-cross-large-symbolic</property>
-                      <property name="halign">center</property>
-                      <style>
-                        <class name="flat"/>
-                        <class name="circular"/>
-                        <class name="error"/>
-                      </style>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkButton" id="accept_fr_button">
-                      <property name="label" translatable="yes">Accept</property>
-                      <property name="tooltip_text" translatable="yes">Accept</property>
-                      <property name="icon_name">tuba-check-round-outline-symbolic</property>
-                      <property name="halign">center</property>
-                      <style>
-                        <class name="flat"/>
-                        <class name="circular"/>
-                        <class name="success"/>
-                      </style>
-                  </object>
-                </child>
                 <style>
                   <class name="ttl-post-actions"/>
                 </style>

--- a/src/Views/FollowRequests.vala
+++ b/src/Views/FollowRequests.vala
@@ -12,6 +12,7 @@ public class Tuba.Views.FollowRequests : Views.Timeline {
 		var widget_status = widget as Widgets.Status;
 
 		if (widget_status != null) {
+            widget_status.create_follow_request_actions();
             widget_status.fr_actions.visible = true;
             widget_status.decline_fr_button.clicked.connect(() => on_decline(widget_status, obj as Widgetizable));
             widget_status.accept_fr_button.clicked.connect(() => on_accept(widget_status, obj as Widgetizable));


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/18014039/227998463-55d56454-53a2-4838-a7af-340de8dc350e.png)

After:

![image](https://user-images.githubusercontent.com/18014039/227998777-891817ef-19eb-428f-881a-ea073104b7d4.png)

I don't really see any difference in memory usage but it might have positive effects on low-end devices.

We need to go through the bindings to be honest (on a different issue), since they are *not* emitted after initialization but they shouldn't either. Status edits are not a matter of binding as they replace the whole status on streaming, making most of the bindings useless anyway (edited indicator, content, polls, attachments etc are part of the edit event).

fix: #57 (?)