### PR TITLE
fix(meson): add distro option to disable post_install

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,7 @@ project(
 )
 
 devel = get_option('devel')
+distro = get_option('distro')
 
 # Setup configuration file, accessed via vapi/build.vapi
 config = configuration_data()
@@ -85,15 +86,17 @@ executable(
 subdir('data')
 subdir('po')
 
-# gnome.post_install() is available since meson 0.59.0
 # Distributions use their own tooling (e.g. postinst, triggers, etc)
 # so it is okay if the post_install() is not run on distro builds
-if meson.version().version_compare('>=0.59.0')
-  gnome.post_install(
-    glib_compile_schemas: true,
-    gtk_update_icon_cache: true,
-    update_desktop_database: true,
-  )
-else
-  meson.add_install_script('build-aux/meson_post_install.py')
+if not distro
+  # gnome.post_install() is available since meson 0.59.0
+  if meson.version().version_compare('>=0.59.0')
+    gnome.post_install(
+      glib_compile_schemas: true,
+      gtk_update_icon_cache: true,
+      update_desktop_database: true,
+    )
+  else
+    meson.add_install_script('build-aux/meson_post_install.py')
+  endif
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,2 @@
 option('devel', type: 'boolean', value: false)
+option('distro', type: 'boolean', value: false)


### PR DESCRIPTION
As mentioned in an earlier comment, Linux distributions use their own packaging tooling to accomplish tasks such as compiling glib schemas and updating the icon cache.  This adds a "distro" meson option to allow distribution packagers to easily disable those tasks during the meson build.