### PR TITLE
fix(network): re-use functions and parsers

### DIFF
--- a/src/API/Attachment.vala
+++ b/src/API/Attachment.vala
@@ -64,7 +64,8 @@ public class Tuba.API.Attachment : Entity, Widgetizable {
 		if (error != null || in_stream == null)
 			throw new Oopsie.INSTANCE (error);
 		else {
-			var node = network.parse_node (in_stream);
+			var parser = Network.get_parser_from_inputstream(in_stream);
+			var node = network.parse_node (parser);
 			var entity = accounts.active.create_entity<API.Attachment> (node);
 			message (@"OK! ID $(entity.id)");
 			return entity;

--- a/src/API/Relationship.vala
+++ b/src/API/Relationship.vala
@@ -22,7 +22,7 @@ public class Tuba.API.Relationship : Entity {
 			.with_account (accounts.active)
 			.with_param ("id", id)
 			.then ((sess, msg, in_stream) => {
-				Network.parse_array (msg, in_stream, node => {
+				Network.parse_array (msg, in_stream, null, node => {
 					invalidate (node);
 				});
 			})

--- a/src/API/Relationship.vala
+++ b/src/API/Relationship.vala
@@ -22,7 +22,8 @@ public class Tuba.API.Relationship : Entity {
 			.with_account (accounts.active)
 			.with_param ("id", id)
 			.then ((sess, msg, in_stream) => {
-				Network.parse_array (msg, in_stream, null, node => {
+				var parser = Network.get_parser_from_inputstream(in_stream);
+				Network.parse_array (msg, parser, node => {
 					invalidate (node);
 				});
 			})
@@ -39,7 +40,8 @@ public class Tuba.API.Relationship : Entity {
 		var req = new Request.POST (@"/api/v1/accounts/$id/$operation")
 			.with_account (accounts.active)
 			.then ((sess, msg, in_stream) => {
-				var node = network.parse_node (in_stream);
+				var parser = Network.get_parser_from_inputstream(in_stream);
+				var node = network.parse_node (parser);
 				invalidate (node);
 				message (@"Performed \"$operation\" on Relationship $id");
 			});

--- a/src/API/SearchResults.vala
+++ b/src/API/SearchResults.vala
@@ -28,7 +28,8 @@ public class Tuba.API.SearchResults : Entity {
 			.with_param ("q", Uri.escape_string (q));
 		yield req.await ();
 
-		return from (network.parse_node (req.response_body));
+		var parser = Network.get_parser_from_inputstream(req.response_body);
+		return from (network.parse_node (parser));
 	}
 
 }

--- a/src/Dialogs/Composer/Completion/HandleProvider.vala
+++ b/src/Dialogs/Composer/Completion/HandleProvider.vala
@@ -25,7 +25,8 @@ public class Tuba.HandleProvider: Tuba.CompletionProvider {
 		yield req.await();
 
 		var results = new GLib.ListStore (typeof (Object));
-		Network.parse_array (req.msg, req.response_body, null, node => {
+		var parser = Network.get_parser_from_inputstream(req.response_body);
+		Network.parse_array (req.msg, parser, node => {
 			var entity = entity_cache.lookup_or_insert (node, typeof (API.Account));
 			if (entity is API.Account) {
 				var proposal = new Proposal (entity as API.Account);

--- a/src/Dialogs/Composer/Completion/HandleProvider.vala
+++ b/src/Dialogs/Composer/Completion/HandleProvider.vala
@@ -25,7 +25,7 @@ public class Tuba.HandleProvider: Tuba.CompletionProvider {
 		yield req.await();
 
 		var results = new GLib.ListStore (typeof (Object));
-		Network.parse_array (req.msg, req.response_body, node => {
+		Network.parse_array (req.msg, req.response_body, null, node => {
 			var entity = entity_cache.lookup_or_insert (node, typeof (API.Account));
 			if (entity is API.Account) {
 				var proposal = new Proposal (entity as API.Account);

--- a/src/Dialogs/Composer/Completion/HashtagProvider.vala
+++ b/src/Dialogs/Composer/Completion/HashtagProvider.vala
@@ -25,7 +25,8 @@ public class Tuba.HashtagProvider: Tuba.CompletionProvider {
 		yield req.await();
 
 		var suggestions = new GLib.ListStore (typeof (Object));
-		var results = API.SearchResults.from (network.parse_node (req.response_body));
+		var parser = Network.get_parser_from_inputstream(req.response_body);
+		var results = API.SearchResults.from (network.parse_node (parser));
 		results?.hashtags.foreach (tag => {
 			var proposal = new Proposal (tag);
 			suggestions.append (proposal);

--- a/src/Dialogs/Composer/Dialog.vala
+++ b/src/Dialogs/Composer/Dialog.vala
@@ -167,7 +167,8 @@ public class Tuba.Dialogs.Compose : Adw.Window {
 		modify_req (publish_req);
 		yield publish_req.await ();
 
-		var node = network.parse_node (publish_req.response_body);
+		var parser = Network.get_parser_from_inputstream(publish_req.response_body);
+		var node = network.parse_node (parser);
 		var status = API.Status.from (node);
 		message (@"Published post with id $(status.id)");
 

--- a/src/Dialogs/NewAccount.vala
+++ b/src/Dialogs/NewAccount.vala
@@ -131,7 +131,8 @@ public class Tuba.Dialogs.NewAccount: Adw.Window {
 			.with_form_data ("website", Build.WEBSITE);
 		yield msg.await ();
 
-		var root = network.parse (msg.response_body);
+		var parser = Network.get_parser_from_inputstream(msg.response_body);
+		var root = network.parse (parser);
 		account.client_id = root.get_string_member ("client_id");
 		account.client_secret = root.get_string_member ("client_secret");
 		message ("OK: Instance registered client");
@@ -162,7 +163,8 @@ public class Tuba.Dialogs.NewAccount: Adw.Window {
 			.with_param ("code", code_entry.text);
 		yield token_req.await ();
 
-		var root = network.parse (token_req.response_body);
+		var parser = Network.get_parser_from_inputstream(token_req.response_body);
+		var root = network.parse (parser);
 		account.access_token = root.get_string_member ("access_token");
 
 		if (account.access_token == null)

--- a/src/Services/Accounts/AccountStore.vala
+++ b/src/Services/Accounts/AccountStore.vala
@@ -137,7 +137,8 @@ public abstract class Tuba.AccountStore : GLib.Object {
 			.with_account (account);
 		yield req.await ();
 
-		var root = network.parse (req.response_body);
+		var parser = Network.get_parser_from_inputstream(req.response_body);
+		var root = network.parse (parser);
 
 		string? backend = null;
 		backend_tests.foreach (test => {

--- a/src/Services/Accounts/InstanceAccount.vala
+++ b/src/Services/Accounts/InstanceAccount.vala
@@ -112,7 +112,8 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 		var req = new Request.GET ("/api/v1/accounts/verify_credentials").with_account (this);
 		yield req.await ();
 
-		var node = network.parse_node (req.response_body);
+		var parser = Network.get_parser_from_inputstream(req.response_body);
+		var node = network.parse_node (parser);
 		var updated = API.Account.from (node);
 		patch (updated);
 
@@ -189,7 +190,8 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 		new Request.GET ("/api/v1/instance")
 			.with_account (this)
 			.then ((sess, msg, in_stream) => {
-				var node = network.parse_node (in_stream);
+				var parser = Network.get_parser_from_inputstream(in_stream);
+				var node = network.parse_node (parser);
 				instance_info = API.Instance.from (node);
 			})
 			.exec ();
@@ -199,7 +201,8 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 		new Request.GET ("/api/v1/custom_emojis")
 			.with_account (this)
 			.then ((sess, msg, in_stream) => {
-				var node = network.parse_node (in_stream);
+				var parser = Network.get_parser_from_inputstream(in_stream);
+				var node = network.parse_node (parser);
 				Value res_emojis;
 				Entity.des_list(out res_emojis, node, typeof (API.Emoji));
 				instance_emojis = (Gee.ArrayList<Tuba.API.Emoji>) res_emojis;
@@ -214,7 +217,8 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 			.with_account (this)
 			.with_param ("min_id", @"$last_read_id")
 			.then ((sess, msg, in_stream) => {
-				var array = Network.get_array_mstd(in_stream);
+				var parser = Network.get_parser_from_inputstream(in_stream);
+				var array = Network.get_array_mstd(parser);
 				if (array != null) {
 					unread_count = (int)array.get_length();
 					if (unread_count > 0) {
@@ -231,7 +235,8 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 		new Request.GET ("/api/v1/markers?timeline[]=notifications")
 			.with_account (this)
 			.then ((sess, msg, in_stream) => {
-				var root = network.parse (in_stream);
+				var parser = Network.get_parser_from_inputstream(in_stream);
+				var root = network.parse (parser);
 				if (!root.has_member("notifications")) return;
 				var notifications = root.get_object_member ("notifications");
 				last_read_id = int.parse (notifications.get_string_member_with_default ("last_read_id", "-1") );

--- a/src/Services/Accounts/SecretAccountStore.vala
+++ b/src/Services/Accounts/SecretAccountStore.vala
@@ -39,7 +39,8 @@ public class Tuba.SecretAccountStore : AccountStore {
 				new Request.GET (@"/api/v1/accounts/$(account.id)")
 					.with_account (account)
 					.then ((sess, msg, in_stream) => {
-						var node = network.parse_node (in_stream);
+						var parser = Network.get_parser_from_inputstream(in_stream);
+						var node = network.parse_node (parser);
 						var acc = API.Account.from (node);
 
 						if (account.display_name != acc.display_name || account.avatar != acc.avatar) {

--- a/src/Services/Network/Network.vala
+++ b/src/Services/Network/Network.vala
@@ -74,22 +74,23 @@ public class Tuba.Network : GLib.Object {
 		return parse_node (in_stream).get_object ();
 	}
 
-	public static Json.Array? get_array_mstd (InputStream in_stream) throws Error {
+	public static Json.Parser get_parser_from_inputstream (InputStream in_stream) {
 		var parser = new Json.Parser ();
 		parser.load_from_stream (in_stream);
+		return parser;
+	}
+
+	public static Json.Array? get_array_mstd (InputStream? in_stream, Json.Parser? t_parser = null) throws Error {
+		Json.Parser parser = t_parser ?? get_parser_from_inputstream(in_stream);
 		return parser.get_root ().get_array ();
 	}
 
-	public static uint get_array_size (InputStream in_stream) throws Error {
-		var parser = new Json.Parser ();
-		parser.load_from_stream (in_stream);
-		return parser.get_root ().get_array ().get_length();
+	public static uint get_array_size (InputStream? in_stream, Json.Parser? t_parser = null) throws Error {
+		return get_array_mstd(in_stream, t_parser).get_length();
 	}
 
-	public static void parse_array (Soup.Message msg, InputStream in_stream, owned NodeCallback cb) throws Error {
-		var parser = new Json.Parser ();
-		parser.load_from_stream (in_stream);
-		parser.get_root ().get_array ().foreach_element ((array, i, node) => {
+	public static void parse_array (Soup.Message msg, InputStream? in_stream, Json.Parser? t_parser = null, owned NodeCallback cb) throws Error {
+		get_array_mstd(in_stream, t_parser).foreach_element ((array, i, node) => {
 			try {
 				cb (node, msg);
 			} catch (Error e) {

--- a/src/Services/Network/Network.vala
+++ b/src/Services/Network/Network.vala
@@ -74,7 +74,7 @@ public class Tuba.Network : GLib.Object {
 		return parse_node (in_stream).get_object ();
 	}
 
-	public static Json.Parser get_parser_from_inputstream (InputStream in_stream) {
+	public static Json.Parser get_parser_from_inputstream (InputStream in_stream) throws Error {
 		var parser = new Json.Parser ();
 		parser.load_from_stream (in_stream);
 		return parser;
@@ -89,7 +89,7 @@ public class Tuba.Network : GLib.Object {
 		return get_array_mstd(in_stream, t_parser).get_length();
 	}
 
-	public static void parse_array (Soup.Message msg, InputStream? in_stream, Json.Parser? t_parser = null, owned NodeCallback cb) throws Error {
+	public static void parse_array (Soup.Message msg, InputStream? in_stream, Json.Parser? t_parser, owned NodeCallback cb) throws Error {
 		get_array_mstd(in_stream, t_parser).foreach_element ((array, i, node) => {
 			try {
 				cb (node, msg);

--- a/src/Services/Network/Network.vala
+++ b/src/Services/Network/Network.vala
@@ -64,14 +64,12 @@ public class Tuba.Network : GLib.Object {
 		app.toast (message);
 	}
 
-	public Json.Node parse_node (InputStream in_stream) throws Error {
-		var parser = new Json.Parser ();
-		parser.load_from_stream (in_stream);
+	public Json.Node parse_node (Json.Parser parser) {
 		return parser.get_root ();
 	}
 
-	public Json.Object parse (InputStream in_stream) throws Error {
-		return parse_node (in_stream).get_object ();
+	public Json.Object parse (Json.Parser parser) {
+		return parse_node (parser).get_object ();
 	}
 
 	public static Json.Parser get_parser_from_inputstream (InputStream in_stream) throws Error {
@@ -80,17 +78,16 @@ public class Tuba.Network : GLib.Object {
 		return parser;
 	}
 
-	public static Json.Array? get_array_mstd (InputStream? in_stream, Json.Parser? t_parser = null) throws Error {
-		Json.Parser parser = t_parser ?? get_parser_from_inputstream(in_stream);
+	public static Json.Array? get_array_mstd (Json.Parser parser) {
 		return parser.get_root ().get_array ();
 	}
 
-	public static uint get_array_size (InputStream? in_stream, Json.Parser? t_parser = null) throws Error {
-		return get_array_mstd(in_stream, t_parser).get_length();
+	public static uint get_array_size (Json.Parser parser) {
+		return get_array_mstd(parser).get_length();
 	}
 
-	public static void parse_array (Soup.Message msg, InputStream? in_stream, Json.Parser? t_parser, owned NodeCallback cb) throws Error {
-		get_array_mstd(in_stream, t_parser).foreach_element ((array, i, node) => {
+	public static void parse_array (Soup.Message msg, Json.Parser parser, owned NodeCallback cb) throws Error {
+		get_array_mstd(parser).foreach_element ((array, i, node) => {
 			try {
 				cb (node, msg);
 			} catch (Error e) {

--- a/src/Services/Network/Request.vala
+++ b/src/Services/Network/Request.vala
@@ -77,7 +77,7 @@ public class Tuba.Request : GLib.Object {
 
 	public Request then_parse_array (owned Network.NodeCallback _cb) {
 		this.cb = (sess, msg, in_stream) => {
-			Network.parse_array (msg, in_stream, (owned) _cb);
+			Network.parse_array (msg, in_stream, null, (owned) _cb);
 		};
     return this;
 }

--- a/src/Services/Network/Request.vala
+++ b/src/Services/Network/Request.vala
@@ -77,7 +77,8 @@ public class Tuba.Request : GLib.Object {
 
 	public Request then_parse_array (owned Network.NodeCallback _cb) {
 		this.cb = (sess, msg, in_stream) => {
-			Network.parse_array (msg, in_stream, null, (owned) _cb);
+			var parser = Network.get_parser_from_inputstream(in_stream);
+			Network.parse_array (msg, parser, (owned) _cb);
 		};
     return this;
 }

--- a/src/Views/FollowRequests.vala
+++ b/src/Views/FollowRequests.vala
@@ -25,7 +25,8 @@ public class Tuba.Views.FollowRequests : Views.Timeline {
         new Request.POST (@"/api/v1/follow_requests/$(widget_status.kind_instigator.id)/authorize")
 			.with_account (accounts.active)
 			.then ((sess, msg, in_stream) => {
-				var node = network.parse_node (in_stream);
+                var parser = Network.get_parser_from_inputstream(in_stream);
+				var node = network.parse_node (parser);
 				var relationship = Entity.from_json (typeof (API.Relationship), node) as API.Relationship;
                 if (relationship.followed_by == true) {
                     uint indx;

--- a/src/Views/Hashtag.vala
+++ b/src/Views/Hashtag.vala
@@ -53,7 +53,8 @@ public class Tuba.Views.Hashtag : Views.Timeline {
         new Request.POST (@"/api/v1/tags/$t_tag/$action")
             .with_account (accounts.active)
             .then ((sess, msg, in_stream) => {
-                var root = network.parse (in_stream);
+                var parser = Network.get_parser_from_inputstream(in_stream);
+                var root = network.parse (parser);
 				if (!root.has_member("following")) {
                     update_button();
                 };
@@ -65,7 +66,8 @@ public class Tuba.Views.Hashtag : Views.Timeline {
         new Request.GET (@"/api/v1/tags/$t_tag")
             .with_account (accounts.active)
             .then ((sess, msg, in_stream) => {
-                var node = network.parse_node (in_stream);
+                var parser = Network.get_parser_from_inputstream(in_stream);
+                var node = network.parse_node (parser);
 				var tag_info = API.Tag.from (node);
                 t_following = tag_info.following;
                 create_follow_button();

--- a/src/Views/Lists.vala
+++ b/src/Views/Lists.vala
@@ -165,7 +165,7 @@ public class Tuba.Views.Lists : Views.Timeline {
 				.with_account (accounts.active)
 				.then ((sess, msg, in_stream) => {
 					var parser = Network.get_parser_from_inputstream(in_stream);
-					if (Network.get_array_size(null, parser) > 0) {
+					if (Network.get_array_size(parser) > 0) {
 						var list_settings_page_members = new Adw.PreferencesPage() {
 							icon_name = "tuba-people-symbolic",
 							title = _("Members")
@@ -175,7 +175,7 @@ public class Tuba.Views.Lists : Views.Timeline {
 							title = _("Remove Members")
 						};
 
-						Network.parse_array (msg, null, parser, node => {
+						Network.parse_array (msg, parser, node => {
 							var member = API.Account.from (node);
 							var avi = new Widgets.Avatar() {
 								account = member,
@@ -291,7 +291,8 @@ public class Tuba.Views.Lists : Views.Timeline {
 			.with_account (accounts.active)
 			.with_param ("title", HtmlUtils.uri_encode(list_name))
 			.then ((sess, msg, in_stream) => {
-				var node = network.parse_node (in_stream);
+				var parser = Network.get_parser_from_inputstream(in_stream);
+				var node = network.parse_node (parser);
 				var list = API.List.from (node);
 				model.insert (0, list);
 			})

--- a/src/Views/Lists.vala
+++ b/src/Views/Lists.vala
@@ -164,7 +164,8 @@ public class Tuba.Views.Lists : Views.Timeline {
 			new Request.GET (@"/api/v1/lists/$(t_list.id)/accounts")
 				.with_account (accounts.active)
 				.then ((sess, msg, in_stream) => {
-					if (Network.get_array_size(in_stream) > 0) {
+					var parser = Network.get_parser_from_inputstream(in_stream);
+					if (Network.get_array_size(null, parser) > 0) {
 						var list_settings_page_members = new Adw.PreferencesPage() {
 							icon_name = "tuba-people-symbolic",
 							title = _("Members")
@@ -174,7 +175,7 @@ public class Tuba.Views.Lists : Views.Timeline {
 							title = _("Remove Members")
 						};
 
-						Network.parse_array (msg, in_stream, node => {
+						Network.parse_array (msg, null, parser, node => {
 							var member = API.Account.from (node);
 							var avi = new Widgets.Avatar() {
 								account = member,

--- a/src/Views/Profile.vala
+++ b/src/Views/Profile.vala
@@ -51,7 +51,7 @@ public class Tuba.Views.Profile : Views.Timeline {
 			.with_param ("pinned", "true")
 			.with_ctx (this)
 			.then ((sess, msg, in_stream) => {
-				Network.parse_array (msg, in_stream, node => {
+				Network.parse_array (msg, in_stream, null, node => {
 					var e = entity_cache.lookup_or_insert (node, typeof (API.Status));
 					var e_status = e as API.Status;
 					if (e_status != null) e_status.pinned = true;
@@ -417,7 +417,8 @@ public class Tuba.Views.Profile : Views.Timeline {
 			.with_ctx (this)
 			.on_error (on_error)
 			.then ((sess, msg, in_stream) => {
-				if (Network.get_array_size(in_stream) > 0) {
+				var parser = Network.get_parser_from_inputstream(in_stream);
+				if (Network.get_array_size(null, parser) > 0) {
 					new Request.GET (@"/api/v1/accounts/$(profile.id)/lists")
 					.with_account (accounts.active)
 					.with_ctx (this)
@@ -426,11 +427,11 @@ public class Tuba.Views.Profile : Views.Timeline {
 						var added = false;
 						var in_list = new Gee.ArrayList<string>();
 
-						Network.parse_array (msg2, in_stream2, node => {
+						Network.parse_array (msg2, in_stream2, null, node => {
 							var list = API.List.from (node);
 							in_list.add(list.id);
 						});
-						Network.parse_array (msg, in_stream, node => {
+						Network.parse_array (msg, null, parser, node => {
 							var list = API.List.from (node);
 							var is_already = in_list.contains(list.id);
 

--- a/src/Views/Thread.vala
+++ b/src/Views/Thread.vala
@@ -59,7 +59,8 @@ public class Tuba.Views.Thread : Views.ContentBase, AccountHolder {
 			.with_account (account)
 			.with_ctx (this)
 			.then ((sess, msg, in_stream) => {
-				var root = network.parse (in_stream);
+				var parser = Network.get_parser_from_inputstream(in_stream);
+				var root = network.parse (parser);
 
 				var ancestors = root.get_array_member ("ancestors");
 				ancestors.foreach_element ((array, i, node) => {
@@ -96,7 +97,8 @@ public class Tuba.Views.Thread : Views.ContentBase, AccountHolder {
 			.with_param ("q", q)
 			.with_param ("resolve", "true")
 			.then ((sess, msg, in_stream) => {
-				var root = network.parse (in_stream);
+				var parser = Network.get_parser_from_inputstream(in_stream);
+				var root = network.parse (parser);
 				var statuses = root.get_array_member ("statuses");
 				var node = statuses.get_element (0);
 				if (node != null){

--- a/src/Views/Timeline.vala
+++ b/src/Views/Timeline.vala
@@ -91,7 +91,7 @@ public class Tuba.Views.Timeline : AccountHolder, Streamable, Views.ContentBase 
 			.with_account (account)
 			.with_ctx (this)
 			.then ((sess, msg, in_stream) => {
-				Network.parse_array (msg, in_stream, node => {
+				Network.parse_array (msg, in_stream, null, node => {
 					var e = entity_cache.lookup_or_insert (node, accepts);
 					model.append (e); //FIXME: use splice();
 				});

--- a/src/Views/Timeline.vala
+++ b/src/Views/Timeline.vala
@@ -91,7 +91,8 @@ public class Tuba.Views.Timeline : AccountHolder, Streamable, Views.ContentBase 
 			.with_account (account)
 			.with_ctx (this)
 			.then ((sess, msg, in_stream) => {
-				Network.parse_array (msg, in_stream, null, node => {
+				var parser = Network.get_parser_from_inputstream(in_stream);
+				Network.parse_array (msg, parser, node => {
 					var e = entity_cache.lookup_or_insert (node, accepts);
 					model.append (e); //FIXME: use splice();
 				});

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -261,7 +261,8 @@ public class Tuba.Widgets.Status : ListBoxRow {
 				new Request.DELETE (@"/api/v1/statuses/$(status.formal.id)")
 					.with_account (accounts.active)
 					.then ((sess, msg, in_stream) => {
-						var root = network.parse (in_stream);
+						var parser = Network.get_parser_from_inputstream(in_stream);
+						var root = network.parse (parser);
 						if (root.has_member("error")) {
 							// TODO: Handle error (probably a toast?)
 						};

--- a/src/Widgets/StatusActionButton.vala
+++ b/src/Widgets/StatusActionButton.vala
@@ -147,7 +147,8 @@ public class Tuba.StatusActionButton : LockableToggleButton {
 		req.await.begin ((o, res) => {
 			try {
 				var msg = req.await.end (res);
-				var node = network.parse_node (msg.response_body);
+				var parser = Network.get_parser_from_inputstream(msg.response_body);
+				var node = network.parse_node (parser);
 
 				var jobj = node.get_object ();
 				var received_value = jobj.get_boolean_member (prop_name);

--- a/src/Widgets/VoteBox.vala
+++ b/src/Widgets/VoteBox.vala
@@ -21,7 +21,8 @@ public class Tuba.Widgets.VoteBox: Box {
         button_vote.clicked.connect ((button) =>{
             Request voting=API.Poll.vote(accounts.active,poll.options,selectedIndex,poll.id);
  			voting.then ((sess, mess, in_stream) => {
-	            status_parent.poll=API.Poll.from_json(typeof(API.Poll),network.parse_node (in_stream));
+                var parser = Network.get_parser_from_inputstream(in_stream);
+	            status_parent.poll=API.Poll.from_json(typeof(API.Poll),network.parse_node (parser));
             })
             .on_error ((code, reason) => {}).exec ();
         });


### PR DESCRIPTION
fix: #192 

During the libsoup3 migration we switched to inputstreams. The main issue is that once read it cannot be reused. This PR adds a parser parameter to supply our own parser instead of creating a new one. Additionally since all the array network functions were using the same code from `get_array_mstd`, I just made them call it.

I'm leaning towards making them use a user-provided parser only and get rid of handling inputstreams directly.