### PR TITLE
fix(flatpak): don't separate locales

### DIFF
--- a/build-aux/dev.geopjr.Tuba.Devel.json
+++ b/build-aux/dev.geopjr.Tuba.Devel.json
@@ -8,6 +8,7 @@
         "prepend-path" : "/usr/lib/sdk/vala/bin/",
         "prepend-ld-library-path" : "/usr/lib/sdk/vala/lib"
     },
+    "separate-locales": false,
     "command": "dev.geopjr.Tuba",
     "finish-args": [
         "--device=dri",


### PR DESCRIPTION
fix: #208 

(this is only for the nightlies - the flathub release will separate locales)