### PR TITLE
feat(media_viewer): match loupe

### DIFF
--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -5,7 +5,7 @@ public class Tuba.Views.MediaViewer : Gtk.Box {
         private Gtk.Stack stack;
         private Gtk.Overlay overlay;
         private Gtk.Spinner spinner;
-        private Gtk.Widget child_widget;
+        public Gtk.Widget child_widget { get; private set; }
         private Gtk.ScrolledWindow scroller;
         public bool is_video { get; private set; default=false; }
         public string url { get; private set; }
@@ -296,7 +296,9 @@ public class Tuba.Views.MediaViewer : Gtk.Box {
 	}
 
     private void on_drag_end (double x, double y) {
-        if (!items.get((int) carousel.position).is_video && !((Gtk.Picture) items.get((int) carousel.position)).can_shrink) return;
+        var pic = (items.get((int) carousel.position)).child_widget as Gtk.Picture;
+        if (pic != null && !pic.can_shrink) return;
+
         if (Math.fabs(y) >= 200) {
             on_back_clicked();
         }

--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -85,6 +85,10 @@ public class Tuba.Views.MediaViewer : Gtk.Box {
             css_classes = {"osd"}
         };
 
+        var keypresscontroller = new Gtk.EventControllerKey ();
+        keypresscontroller.key_pressed.connect (on_keypress);
+        add_controller (keypresscontroller);
+
         var overlay = new Gtk.Overlay () {
             vexpand = true,
             hexpand = true
@@ -154,6 +158,25 @@ public class Tuba.Views.MediaViewer : Gtk.Box {
 	~MediaViewer () {
 		message ("Destroying MediaViewer");
 	}
+
+    protected bool on_keypress (uint keyval, uint keycode, Gdk.ModifierType state) {
+        if (state != 0) return false;
+
+        switch (keyval) {
+            case Gdk.Key.Left:
+            case Gdk.Key.KP_Left:
+                scroll_to (((int) carousel.position) - 1, false);
+                break;
+            case Gdk.Key.Right:
+            case Gdk.Key.KP_Right:
+                scroll_to (((int) carousel.position) + 1, false);
+                break;
+            default:
+                return false;
+        }
+
+        return true;
+    }
 
     protected void on_back_clicked() {
         clear();


### PR DESCRIPTION
It's better to match Loupe's design and functions so users have a familiar experience between them:

- [X] pagination buttons
- [x] zoom functions (fix: #160)
- [x] gestures
- [X] arrow navigation (fix: #147)

Loupe:
![image](https://user-images.githubusercontent.com/18014039/233849017-7d56216a-5e58-44cf-8419-f54862537dd9.png)

Progress so far:
![image](https://user-images.githubusercontent.com/18014039/233849106-2ecbc34f-3bc7-45fa-96ce-e4d772993dae.png)

(pagination buttons are only visible if there are more than 1 items in the carousel)