### PR TITLE
fix(network): streaming

### DIFF
--- a/src/Services/Accounts/InstanceAccount.vala
+++ b/src/Services/Accounts/InstanceAccount.vala
@@ -312,7 +312,7 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 
 	public virtual string? get_stream_url () {
 		if (instance == null || access_token == null) return null;
-		return @"$instance/api/v1/streaming/?stream=user&access_token=$access_token";
+		return @"$instance/api/v1/streaming/?stream=user:notification&access_token=$access_token";
 	}
 
 	public virtual void on_notification_event (Streamable.Event ev) {

--- a/src/Services/Accounts/InstanceAccount.vala
+++ b/src/Services/Accounts/InstanceAccount.vala
@@ -7,6 +7,7 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 	public const string EVENT_EDIT_POST = "status.update";
 	public const string EVENT_DELETE_POST = "delete";
 	public const string EVENT_NOTIFICATION = "notification";
+	public const string EVENT_CONVERSATION = "conversation";
 
 	public const string KIND_MENTION = "mention";
 	public const string KIND_REBLOG = "reblog";

--- a/src/Services/Network/Streamable.vala
+++ b/src/Services/Network/Streamable.vala
@@ -36,7 +36,7 @@ public abstract interface Tuba.Streamable : Object {
 	}
 
 	void unsubscribe () {
-		streams.unsubscribe (get_stream_url (), this);
+		streams.unsubscribe (t_connection_url, this);
 		t_connection_url = null;
 	}
 

--- a/src/Views/Conversations.vala
+++ b/src/Views/Conversations.vala
@@ -1,5 +1,4 @@
 public class Tuba.Views.Conversations : Views.Timeline {
-
     public Conversations () {
         Object (
             url: "/api/v1/conversations",
@@ -7,11 +6,10 @@ public class Tuba.Views.Conversations : Views.Timeline {
             icon: "tuba-mail-symbolic"
         );
         accepts = typeof (API.Conversation);
+        stream_event[InstanceAccount.EVENT_CONVERSATION].connect (on_new_post);
     }
 
-	// TODO: Reload when an update is received
-    // public override string? get_stream_url () {
-    //     return @"/api/v1/streaming/?stream=direct&access_token=$(account.access_token)";
-    // }
-
+    public override string? get_stream_url () {
+		return account != null ? @"$(account.instance)/api/v1/streaming/?stream=direct&access_token=$(account.access_token)" : null;
+    }
 }

--- a/src/Views/Home.vala
+++ b/src/Views/Home.vala
@@ -1,5 +1,4 @@
 public class Tuba.Views.Home : Views.Timeline {
-
     public Home () {
         Object (
             url: "/api/v1/timelines/home",
@@ -11,5 +10,4 @@ public class Tuba.Views.Home : Views.Timeline {
     public override string? get_stream_url () {
         return account != null ? @"$(account.instance)/api/v1/streaming/?stream=user&access_token=$(account.access_token)" : null;
     }
-
 }

--- a/src/Views/Home.vala
+++ b/src/Views/Home.vala
@@ -2,14 +2,14 @@ public class Tuba.Views.Home : Views.Timeline {
 
     public Home () {
         Object (
-        	url: "/api/v1/timelines/home",
-        	label: _("Home"),
-        	icon: "tuba-home-symbolic"
+            url: "/api/v1/timelines/home",
+            label: _("Home"),
+            icon: "tuba-home-symbolic"
         );
     }
 
     public override string? get_stream_url () {
-        return account.get_stream_url ();
+        return account != null ? @"$(account.instance)/api/v1/streaming/?stream=user&access_token=$(account.access_token)" : null;
     }
 
 }

--- a/src/Views/List.vala
+++ b/src/Views/List.vala
@@ -1,13 +1,12 @@
 public class Tuba.Views.List : Views.Timeline {
-
 	public API.List list { get; set; }
 
     public List (API.List l) {
         Object (
-        	url: @"/api/v1/timelines/list/$(l.id)",
-        	label: l.title,
-        	icon: "tuba-list-compact-symbolic",
-        	list: l
+            url: @"/api/v1/timelines/list/$(l.id)",
+            label: l.title,
+            icon: "tuba-list-compact-symbolic",
+            list: l
         );
 
         update_stream ();
@@ -18,5 +17,4 @@ public class Tuba.Views.List : Views.Timeline {
             return null;
         return account != null ? @"$(account.instance)/api/v1/streaming/?stream=list&list=$(list.id)&access_token=$(account.access_token)" : null;
     }
-
 }


### PR DESCRIPTION
Several streaming bugs and disabled features:

- Stream conversations
- Connect to all accounts' notifications and NOT `user` - this will save bandwidth
- fix: #131 - when unsubscribing, `get_stream_url` might have already changed (or rather return null) so instead use `t_connection_url`