### PR TITLE
feat: refactor net status view

### DIFF
--- a/data/ui/views/base.ui
+++ b/data/ui/views/base.ui
@@ -124,6 +124,7 @@
                                                 <property name="child">
                                                   <object class="GtkSpinner" id="status_spinner">
                                                     <property name="height_request">32</property>
+                                                    <property name="valign">center</property>
                                                   </object>
                                                 </property>
                                               </object>

--- a/src/Views/Base.vala
+++ b/src/Views/Base.vala
@@ -38,10 +38,10 @@ public class Tuba.Views.Base : Box {
 		public bool loading = false;
 	}
 
-	private StatusMessage? _status = null;
-	public StatusMessage? status {
+	private StatusMessage? _base_status = null;
+	public StatusMessage? base_status {
 		get {
-			return _status;
+			return _base_status;
 		}
 		set {
 			if (value == null) {
@@ -61,7 +61,7 @@ public class Tuba.Views.Base : Box {
 						status_message_label.label = value.message;
 				}
 			}
-			_status = value;
+			_base_status = value;
 		}
 	}
 
@@ -71,7 +71,7 @@ public class Tuba.Views.Base : Box {
 		build_header ();
 
 		status_button.label = _("Reload");
-		status = new StatusMessage () { loading = true };
+		base_status = new StatusMessage () { loading = true };
 
 		notify["current"].connect (() => {
 			if (current)
@@ -106,7 +106,7 @@ public class Tuba.Views.Base : Box {
 	}
 
 	public virtual void clear () {
-		status = null;
+		base_status = null;
 	}
 
 	public virtual void on_shown () {
@@ -121,7 +121,7 @@ public class Tuba.Views.Base : Box {
 	public virtual void on_content_changed () {}
 
 	public virtual void on_error (int32 code, string reason) {
-		status = new StatusMessage () {
+		base_status = new StatusMessage () {
 			title = _("An Error Occurred"),
 			message = reason
 		};

--- a/src/Views/Base.vala
+++ b/src/Views/Base.vala
@@ -32,46 +32,46 @@ public class Tuba.Views.Base : Box {
 	[GtkChild] unowned Label status_message_label;
 	[GtkChild] unowned Spinner status_spinner;
 
-	public string state { get; set; default = "status"; }
-	public string status_title { get; set; default = STATUS_EMPTY; }
-	public string status_message { get; set; default = STATUS_EMPTY; }
-	public bool status_loading { get; set; default = false; }
+	public class StatusMessage : Object {
+		public string title = STATUS_EMPTY;
+		public string? message = null;
+		public bool loading = false;
+	}
+
+	private StatusMessage? _status = null;
+	public StatusMessage? status {
+		get {
+			return _status;
+		}
+		set {
+			if (value == null) {
+				states.visible_child_name = "content";
+				status_spinner.spinning = false;
+			} else {
+				states.visible_child_name = "status";
+				if (value.loading) {
+					status_stack.visible_child_name = "spinner";
+					status_spinner.spinning = true;
+				} else {
+					status_stack.visible_child_name = "message";
+					status_spinner.spinning = false;
+
+					status_title_label.label = value.title;
+					if (value.message != null)
+						status_message_label.label = value.message;
+				}
+			}
+			_status = value;
+		}
+	}
+
 
 	construct {
-	    build_actions ();
-	    build_header ();
+		build_actions ();
+		build_header ();
 
 		status_button.label = _("Reload");
-		bind_property ("state", states, "visible-child-name", BindingFlags.SYNC_CREATE, (b, src, ref target) => {
-			target.set_string (src.get_string ());
-			if (src.get_string () != "status") status_spinner.spinning = false;
-
-			return true;
-		});
-		bind_property ("status-loading", status_stack, "visible-child-name", BindingFlags.SYNC_CREATE, (b, src, ref target) => {
-			target.set_string (src.get_boolean ()  ? "spinner" : "message");
-			status_spinner.spinning = src.get_boolean ();
-
-			return true;
-		});
-		bind_property ("status-message", status_message_label, "label", BindingFlags.SYNC_CREATE, (b, src, ref target) => {
-			var src_s = src.get_string ();
-			target.set_string (src_s);
-			status_message_label.visible = src_s != STATUS_EMPTY && src_s != "";
-			return true;
-		});
-		bind_property ("status-title", status_title_label, "label", BindingFlags.SYNC_CREATE, (b, src, ref target) => {
-			var src_s = src.get_string ();
-			target.set_string (src_s);
-			status_message = STATUS_EMPTY;
-			status_loading = src_s == "";
-			return true;
-		});
-
-		notify["status-title"].connect (() => {
-			status_title_label.label = status_title;
-			status_message = STATUS_EMPTY;
-		});
+		status = new StatusMessage () { loading = true };
 
 		notify["current"].connect (() => {
 			if (current)
@@ -106,7 +106,7 @@ public class Tuba.Views.Base : Box {
 	}
 
 	public virtual void clear () {
-		state = "status";
+		status = null;
 	}
 
 	public virtual void on_shown () {
@@ -121,11 +121,13 @@ public class Tuba.Views.Base : Box {
 	public virtual void on_content_changed () {}
 
 	public virtual void on_error (int32 code, string reason) {
-		status_title = _("An Error Occurred");
-		status_message = reason;
+		status = new StatusMessage () {
+			title = _("An Error Occurred"),
+			message = reason
+		};
+
 		status_button.visible = true;
 		status_button.sensitive = true;
-		state = "status";
 	}
 
 	[GtkCallback]

--- a/src/Views/ContentBase.vala
+++ b/src/Views/ContentBase.vala
@@ -50,11 +50,10 @@ public class Tuba.Views.ContentBase : Views.Base {
 
 	public override void on_content_changed () {
 		if (empty) {
-			status_title = STATUS_EMPTY;
-			state = "status";
+			status = new StatusMessage ();
 		}
 		else {
-			state = "content";
+			status = null;
 		}
 	}
 

--- a/src/Views/ContentBase.vala
+++ b/src/Views/ContentBase.vala
@@ -50,10 +50,10 @@ public class Tuba.Views.ContentBase : Views.Base {
 
 	public override void on_content_changed () {
 		if (empty) {
-			status = new StatusMessage ();
+			base_status = new StatusMessage ();
 		}
 		else {
-			status = null;
+			base_status = null;
 		}
 	}
 

--- a/src/Views/Search.vala
+++ b/src/Views/Search.vala
@@ -62,14 +62,12 @@ public class Tuba.Views.Search : Views.TabbedBase {
 		query = entry.text.chug ().chomp ();
 		if (query == "") {
 			clear ();
-			state = "status";
-			status_title = _("Enter Query");
+			status = new StatusMessage () { title = _("Enter Query") };
 			return;
 		}
 
 		clear ();
-		state = "status";
-		status_loading = true;
+		status = new StatusMessage () { loading = true };
 		API.SearchResults.request.begin (query, accounts.active, (obj, res) => {
 			try {
 				var results = API.SearchResults.request.end (res);
@@ -99,7 +97,7 @@ public class Tuba.Views.Search : Views.TabbedBase {
 					});
 				}
 
-				status_title = STATUS_EMPTY;
+				status = new StatusMessage ();
 
 				on_content_changed ();
 			}

--- a/src/Views/Search.vala
+++ b/src/Views/Search.vala
@@ -62,12 +62,12 @@ public class Tuba.Views.Search : Views.TabbedBase {
 		query = entry.text.chug ().chomp ();
 		if (query == "") {
 			clear ();
-			status = new StatusMessage () { title = _("Enter Query") };
+			base_status = new StatusMessage () { title = _("Enter Query") };
 			return;
 		}
 
 		clear ();
-		status = new StatusMessage () { loading = true };
+		base_status = new StatusMessage () { loading = true };
 		API.SearchResults.request.begin (query, accounts.active, (obj, res) => {
 			try {
 				var results = API.SearchResults.request.end (res);
@@ -97,7 +97,7 @@ public class Tuba.Views.Search : Views.TabbedBase {
 					});
 				}
 
-				status = new StatusMessage ();
+				base_status = new StatusMessage ();
 
 				on_content_changed ();
 			}

--- a/src/Views/TabbedBase.vala
+++ b/src/Views/TabbedBase.vala
@@ -11,7 +11,7 @@ public class Tuba.Views.TabbedBase : Views.Base {
 	Views.Base? last_view = null;
 
 	construct {
-		state = "content";
+		status = null;
 
 		var states_box = states.get_parent () as Box;
 		if (states_box != null)
@@ -100,7 +100,7 @@ public class Tuba.Views.TabbedBase : Views.Base {
 
 			tab.on_content_changed ();
 		});
-		state = "content";
+		status = null;
 
 		// if (empty) {
 		// 	state = "status";

--- a/src/Views/TabbedBase.vala
+++ b/src/Views/TabbedBase.vala
@@ -11,7 +11,7 @@ public class Tuba.Views.TabbedBase : Views.Base {
 	Views.Base? last_view = null;
 
 	construct {
-		status = null;
+		base_status = null;
 
 		var states_box = states.get_parent () as Box;
 		if (states_box != null)
@@ -100,7 +100,7 @@ public class Tuba.Views.TabbedBase : Views.Base {
 
 			tab.on_content_changed ();
 		});
-		status = null;
+		base_status = null;
 
 		// if (empty) {
 		// 	state = "status";

--- a/src/Views/Thread.vala
+++ b/src/Views/Thread.vala
@@ -9,7 +9,7 @@ public class Tuba.Views.Thread : Views.ContentBase, AccountHolder {
 	public Thread (API.Status status) {
 		Object (
 			root_status: status,
-			status: new StatusMessage () { loading = true },
+			base_status: new StatusMessage () { loading = true },
 			label: _("Conversation")
 		);
 		construct_account_holder ();

--- a/src/Views/Thread.vala
+++ b/src/Views/Thread.vala
@@ -9,7 +9,7 @@ public class Tuba.Views.Thread : Views.ContentBase, AccountHolder {
 	public Thread (API.Status status) {
 		Object (
 			root_status: status,
-			status_loading: true,
+			status: new StatusMessage () { loading = true },
 			label: _("Conversation")
 		);
 		construct_account_holder ();

--- a/src/Views/Timeline.vala
+++ b/src/Views/Timeline.vala
@@ -82,7 +82,7 @@ public class Tuba.Views.Timeline : AccountHolder, Streamable, Views.ContentBase 
 	}
 
 	public virtual void on_request_finish () {
-		status = null;
+		base_status = null;
 		base.on_bottom_reached ();
 	}
 
@@ -111,7 +111,7 @@ public class Tuba.Views.Timeline : AccountHolder, Streamable, Views.ContentBase 
 		scrolled.vadjustment.value = 0;
 		status_button.sensitive = false;
 		clear ();
-		status = new StatusMessage () { loading = true };
+		base_status = new StatusMessage () { loading = true };
 		GLib.Idle.add (request);
 	}
 

--- a/src/Views/Timeline.vala
+++ b/src/Views/Timeline.vala
@@ -82,7 +82,7 @@ public class Tuba.Views.Timeline : AccountHolder, Streamable, Views.ContentBase 
 	}
 
 	public virtual void on_request_finish () {
-		status_loading = false;
+		status = null;
 		base.on_bottom_reached ();
 	}
 
@@ -111,7 +111,7 @@ public class Tuba.Views.Timeline : AccountHolder, Streamable, Views.ContentBase 
 		scrolled.vadjustment.value = 0;
 		status_button.sensitive = false;
 		clear ();
-		status_loading = true;
+		status = new StatusMessage () { loading = true };
 		GLib.Idle.add (request);
 	}
 


### PR DESCRIPTION
fix: #145 (again)

1/2 of #204 

The network status / message view was messy since it had 3 different properties that had to change the view and keep track of the other widgets and sub-stacks (e.g. if the title was set, it had to change the sub-stack to "message" and check if there's a "message" (and whether it's empty) etc etc etc)

It's now a bit easier to maintain by setting `status` to `StatusMessage?`

(should probably be renamed from `status` to something else as it might conflict with fedi's statuses)
