### PR TITLE
feat(Timeline): entity queue

### DIFF
--- a/src/Views/ContentBase.vala
+++ b/src/Views/ContentBase.vala
@@ -5,6 +5,7 @@ public class Tuba.Views.ContentBase : Views.Base {
 	public GLib.ListStore model;
 	protected ListBox content;
 	private bool bottom_reached_locked = false;
+	protected signal void reached_close_to_top ();
 
 	public bool empty {
 		get { return model.get_n_items () <= 0; }
@@ -30,7 +31,10 @@ public class Tuba.Views.ContentBase : Views.Base {
 				on_bottom_reached ();
 			}
 			
-			scroll_to_top.visible = scrolled.vadjustment.value > 1000 && scrolled.vadjustment.value + scrolled.vadjustment.page_size + 100 < scrolled.vadjustment.upper;
+			var is_close_to_top = scrolled.vadjustment.value <= 1000;
+			scroll_to_top.visible = !is_close_to_top && scrolled.vadjustment.value + scrolled.vadjustment.page_size + 100 < scrolled.vadjustment.upper;
+
+			if (is_close_to_top) reached_close_to_top ();
 		});
 	}
 	~ContentBase () {

--- a/src/Views/Timeline.vala
+++ b/src/Views/Timeline.vala
@@ -6,14 +6,17 @@ public class Tuba.Views.Timeline : AccountHolder, Streamable, Views.ContentBase 
 	public string url { get; construct set; }
 	public bool is_public { get; construct set; default = false; }
 	public Type accepts { get; set; default = typeof (API.Status); }
+	public bool only_append_if_top { get; set; default = true; }
 
 	protected InstanceAccount? account { get; set; default = null; }
 
 	public bool is_last_page { get; set; default = false; }
 	public string? page_next { get; set; }
 	public string? page_prev { get; set; }
+	Entity[] entity_queue = {};
 
 	construct {
+		reached_close_to_top.connect (finish_queue);
 		app.refresh.connect (on_refresh);
 		status_button.clicked.connect (on_refresh);
 
@@ -28,6 +31,7 @@ public class Tuba.Views.Timeline : AccountHolder, Streamable, Views.ContentBase 
 		content.bind_model (model, on_create_model_widget);
 	}
 	~Timeline () {
+		entity_queue = {};
 		destruct_account_holder ();
 		destruct_streamable ();
 
@@ -107,6 +111,7 @@ public class Tuba.Views.Timeline : AccountHolder, Streamable, Views.ContentBase 
 	}
 
 	public virtual void on_refresh () {
+		entity_queue = {};
 		scrolled.vadjustment.value = 0;
 		status_button.sensitive = false;
 		clear ();
@@ -151,10 +156,26 @@ public class Tuba.Views.Timeline : AccountHolder, Streamable, Views.ContentBase 
 	public virtual void on_new_post (Streamable.Event ev) {
 		try {
 			var entity = Entity.from_json (accepts, ev.get_node ());
+
+			if (only_append_if_top && scrolled.vadjustment.value > 1000) {
+				entity_queue += entity;
+				return;
+			}
+
 			model.insert (0, entity);
 		} catch (Error e) {
 			warning (@"Error getting Entity from json: $(e.message)");
 		}
+	}
+
+	private void finish_queue () {
+		if (entity_queue.length == 0) return;
+
+		foreach (var entity in entity_queue) {
+			model.insert (0, entity);
+		}
+
+		entity_queue = {};
 	}
 
 	public virtual void on_edit_post (Streamable.Event ev) {


### PR DESCRIPTION
fix: #126

### How does this work?
- If the user's scroll position is near the top: new posts get prepended
- If the user's scroll position is not near the top: new posts get added into an array and when the user scrolls to near the top, they get prepended

