### PR TITLE
fix(Timeline): refresh performance

### DIFF
--- a/src/Views/ContentBase.vala
+++ b/src/Views/ContentBase.vala
@@ -75,7 +75,13 @@ public class Tuba.Views.ContentBase : Views.Base {
 	}
 
 	public virtual void on_bottom_reached () {
-		bottom_reached_locked = false;
+		uint timeout = 0;
+		timeout = Timeout.add (1000, () => {
+			bottom_reached_locked = false;
+			GLib.Source.remove(timeout);
+
+			return true;
+		}, Priority.LOW);
 	}
 
 	public virtual void on_content_item_activated (ListBoxRow row) {

--- a/src/Views/Profile.vala
+++ b/src/Views/Profile.vala
@@ -52,13 +52,17 @@ public class Tuba.Views.Profile : Views.Timeline {
 			.with_ctx (this)
 			.then ((sess, msg, in_stream) => {
 				var parser = Network.get_parser_from_inputstream(in_stream);
+
+				Object[] to_add = {};
 				Network.parse_array (msg, parser, node => {
 					var e = entity_cache.lookup_or_insert (node, typeof (API.Status));
 					var e_status = e as API.Status;
 					if (e_status != null) e_status.pinned = true;
 
-					model.append (e); //FIXME: use splice();
+					to_add += e_status;
 				});
+				model.splice (0, 0, to_add);
+
 			})
 			.exec ();
 	}

--- a/src/Views/Timeline.vala
+++ b/src/Views/Timeline.vala
@@ -86,22 +86,25 @@ public class Tuba.Views.Timeline : AccountHolder, Streamable, Views.ContentBase 
 	}
 
 	public virtual bool request () {
-		var req = append_params (new Request.GET (get_req_url ()))
+		append_params (new Request.GET (get_req_url ()))
 			.with_account (account)
 			.with_ctx (this)
 			.then ((sess, msg, in_stream) => {
 				var parser = Network.get_parser_from_inputstream(in_stream);
+
+				Object[] to_add = {};
 				Network.parse_array (msg, parser, node => {
 					var e = entity_cache.lookup_or_insert (node, accepts);
-					model.append (e); //FIXME: use splice();
+					to_add += e;
 				});
+				model.splice (model.n_items, 0, to_add);
 
 				get_pages (msg.response_headers.get_one ("Link"));
 				on_content_changed ();
 				on_request_finish ();
 			})
-			.on_error (on_error);
-		req.exec ();
+			.on_error (on_error)
+			.exec ();
 
 		return GLib.Source.REMOVE;
 	}

--- a/src/Views/Timeline.vala
+++ b/src/Views/Timeline.vala
@@ -173,10 +173,7 @@ public class Tuba.Views.Timeline : AccountHolder, Streamable, Views.ContentBase 
 
 	private void finish_queue () {
 		if (entity_queue.length == 0) return;
-
-		foreach (var entity in entity_queue) {
-			model.insert (0, entity);
-		}
+		model.splice (0, 0, entity_queue);
 
 		entity_queue = {};
 	}

--- a/src/Views/Timeline.vala
+++ b/src/Views/Timeline.vala
@@ -6,7 +6,7 @@ public class Tuba.Views.Timeline : AccountHolder, Streamable, Views.ContentBase 
 	public string url { get; construct set; }
 	public bool is_public { get; construct set; default = false; }
 	public Type accepts { get; set; default = typeof (API.Status); }
-	public bool only_append_if_top { get; set; default = true; }
+	public bool use_queue { get; set; default = true; }
 
 	protected InstanceAccount? account { get; set; default = null; }
 
@@ -160,7 +160,7 @@ public class Tuba.Views.Timeline : AccountHolder, Streamable, Views.ContentBase 
 		try {
 			var entity = Entity.from_json (accepts, ev.get_node ());
 
-			if (only_append_if_top && scrolled.vadjustment.value > 1000) {
+			if (use_queue && scrolled.vadjustment.value > 1000) {
 				entity_queue += entity;
 				return;
 			}


### PR DESCRIPTION
This (when it's done) + #232 should fix: #182

The lag on refresh is not really a network issue, but rather a widget creation one.

As of now, I migrated ListStore #insert => #splice (which is more efficient).

~~What I want to try is using threads or~~ attempting to convert more sync operations to async before marking as ready
