### PR TITLE
feat(status): cards & peertube viewer

### DIFF
--- a/data/dev.geopjr.Tuba.gschema.xml
+++ b/data/dev.geopjr.Tuba.gschema.xml
@@ -36,6 +36,9 @@
 		<key name="show-spoilers" type="b">
 			<default>false</default>
 		</key>
+		<key name="hide-preview-cards" type="b">
+			<default>false</default>
+		</key>
 		<key name="larger-font-size" type="b">
 			<default>false</default>
 		</key>

--- a/data/style.css
+++ b/data/style.css
@@ -296,3 +296,20 @@ GtkSourceAssistant.completion list row{
 .locale-dropdown-upcase {
 	text-transform: uppercase;
 }
+
+.preview_card {
+	padding: 0;
+}
+
+.preview_card_image:dir(ltr) {
+	border-radius: 6px 0px 0px 6px;
+}
+
+.preview_card_image:dir(rtl) {
+	border-radius: 0px 6px 6px 0px;
+}
+
+.preview_card_video {
+	border-radius: 6px 6px 0px 0px;
+}
+

--- a/data/ui/dialogs/preferences.ui
+++ b/data/ui/dialogs/preferences.ui
@@ -166,6 +166,17 @@
                 </child>
               </object>
             </child>
+            <child>
+              <object class="AdwActionRow">
+                <property name="title" translatable="yes">Hide link preview cards</property>
+                <property name="activatable_widget">hide_preview_cards</property>
+                <child>
+                  <object class="GtkSwitch" id="hide_preview_cards">
+                    <property name="valign">center</property>
+                  </object>
+                </child>
+              </object>
+            </child>
           </object>
         </child>
       </object>

--- a/src/API/Entity.vala
+++ b/src/API/Entity.vala
@@ -103,6 +103,12 @@ public class Tuba.Entity : GLib.Object, Widgetizable, Json.Serializable {
 				case "history":
 					contains = typeof (API.TagHistory);
 					break;
+				case "streamingPlaylists":
+					contains = typeof (API.PeerTubeStreamingPlaylist);
+					break;
+				case "files":
+					contains = typeof (API.PeerTubeFile);
+					break;
 				default:
 					contains = typeof (Entity);
 					break;

--- a/src/API/PeerTube.vala
+++ b/src/API/PeerTube.vala
@@ -1,0 +1,8 @@
+public class Tuba.API.PeerTube : Entity {
+	public string url { get; set; }
+	public Gee.ArrayList<API.PeerTubeStreamingPlaylist>? streamingPlaylists { get; set; default=null; }
+
+	public static PeerTube from (Json.Node node) throws Error {
+		return Entity.from_json (typeof (API.PeerTube), node) as API.PeerTube;
+	}
+}

--- a/src/API/PeerTube/File.vala
+++ b/src/API/PeerTube/File.vala
@@ -1,0 +1,4 @@
+public class Tuba.API.PeerTubeFile : Entity {
+	public API.PeerTubeResolution? resolution { get; set; default=null; }
+	public string? fileDownloadUrl { get; set; default=""; }
+}

--- a/src/API/PeerTube/Resolution.vala
+++ b/src/API/PeerTube/Resolution.vala
@@ -1,0 +1,3 @@
+public class Tuba.API.PeerTubeResolution : Entity {
+	public int64 id { get; set; default=0; }
+}

--- a/src/API/PeerTube/StreamingPlaylist.vala
+++ b/src/API/PeerTube/StreamingPlaylist.vala
@@ -1,0 +1,3 @@
+public class Tuba.API.PeerTubeStreamingPlaylist : Entity {
+	public Gee.ArrayList<API.PeerTubeFile>? files { get; set; default=null; }
+}

--- a/src/API/PeerTube/meson.build
+++ b/src/API/PeerTube/meson.build
@@ -1,0 +1,5 @@
+sources += files(
+    'File.vala',
+    'Resolution.vala',
+    'StreamingPlaylist.vala'
+)

--- a/src/API/Poll.vala
+++ b/src/API/Poll.vala
@@ -20,10 +20,10 @@ public class Tuba.API.Poll : GLib.Object, Json.Serializable{
 
 		//  var type = spec.value_type;
 		if (prop=="options"){
-		    return Entity.des_list (out val, node, typeof (API.PollOption));
+            return Entity.des_list (out val, node, typeof (API.PollOption));
 		}
 		if (prop=="own-votes"){
-		    return Poll.des_list_int (out val, node);
+            return Poll.des_list_int (out val, node);
 		}
 		return success;
 	}
@@ -48,7 +48,7 @@ public class Tuba.API.Poll : GLib.Object, Json.Serializable{
         return Json.gobject_deserialize (type, node) as Poll;
 	}
     public static Request vote (InstanceAccount acc,ArrayList<PollOption> options,ArrayList<string> selection, string id) {
- 		message (@"Voting poll $(id)...");
+        message (@"Voting poll $(id)...");
  		  //Creating json to send
         var builder = new Json.Builder ();
         builder.begin_object ();
@@ -58,12 +58,12 @@ public class Tuba.API.Poll : GLib.Object, Json.Serializable{
         foreach (API.PollOption p in options){
             foreach (string select in selection){
                 if (select == p.title){
-	                builder.add_string_value (row_number.to_string());
-	            }
+                    builder.add_string_value (row_number.to_string());
+                }
             }
             row_number++;
-	    }
-	    builder.end_array ();
+        }
+        builder.end_array ();
         builder.end_object ();
         var generator = new Json.Generator ();
         generator.set_root (builder.get_root ());

--- a/src/API/Status.vala
+++ b/src/API/Status.vala
@@ -35,6 +35,7 @@ public class Tuba.API.Status : Entity, Widgetizable {
     public ArrayList<API.Attachment>? media_attachments { get; set; default = null; }
     public API.Poll? poll { get; set; default = null; }
     public Gee.ArrayList<API.Emoji>? emojis { get; set; }
+    public API.PreviewCard? card { get; set; default = null; }
 
     public Gee.HashMap<string, string>? emojis_map {
 		owned get {

--- a/src/API/Status/PreviewCard.vala
+++ b/src/API/Status/PreviewCard.vala
@@ -1,0 +1,15 @@
+public class Tuba.API.PreviewCard : Entity {
+	public string url { get; set; }
+	public string title { get; set; default=""; }
+	public string description { get; set; default=""; }
+	public string kind { get; set; default="link"; }
+	public string author_name { get; set; default=""; }
+	public string author_url { get; set; default=""; }
+	public string provider_name { get; set; default=""; }
+	public string provider_url { get; set; default=""; }
+	public string? image { get; set; default=null; }
+
+    public bool is_peertube {
+        get { return kind == "video" && provider_name == "PeerTube"; }
+    }
+}

--- a/src/API/Status/meson.build
+++ b/src/API/Status/meson.build
@@ -1,4 +1,5 @@
 sources += files(
     'Application.vala',
+    'PreviewCard.vala',
     'Source.vala'
 )

--- a/src/API/meson.build
+++ b/src/API/meson.build
@@ -10,6 +10,7 @@ sources += files(
     'List.vala',
     'Mention.vala',
     'Notification.vala',
+    'PeerTube.vala',
     'Pleroma.vala',
     'Poll.vala',
     'PollOption.vala',
@@ -22,4 +23,5 @@ sources += files(
 
 subdir('Account')
 subdir('Instance')
+subdir('PeerTube')
 subdir('Status')

--- a/src/Dialogs/MainWindow.vala
+++ b/src/Dialogs/MainWindow.vala
@@ -68,6 +68,15 @@ public class Tuba.Dialogs.MainWindow: Adw.ApplicationWindow, Saveable {
 		media_viewer.set_single_paintable (url, paintable);
 	}
 
+	public void show_media_viewer_peertube(string url, Paintable? preview) {
+		if (!is_media_viewer_visible()) {
+			main_stack.visible_child_name = "media_viewer";
+			media_viewer.clear.connect(hide_media_viewer);
+		}
+
+		media_viewer.set_peertube (url, preview);
+	}
+
 	public void hide_media_viewer() {
 		if (!is_media_viewer_visible()) return;
 

--- a/src/Dialogs/Preferences.vala
+++ b/src/Dialogs/Preferences.vala
@@ -12,6 +12,7 @@ public class Tuba.Dialogs.Preferences : Adw.PreferencesWindow {
     [GtkChild] unowned Switch live_updates;
     [GtkChild] unowned Switch public_live_updates;
     [GtkChild] unowned Switch show_spoilers;
+    [GtkChild] unowned Switch hide_preview_cards;
     [GtkChild] unowned Switch larger_font_size;
     [GtkChild] unowned Switch larger_line_height;
 	
@@ -55,6 +56,7 @@ public class Tuba.Dialogs.Preferences : Adw.PreferencesWindow {
         settings.bind ("live-updates", live_updates, "active", SettingsBindFlags.DEFAULT);
         settings.bind ("public-live-updates", public_live_updates, "active", SettingsBindFlags.DEFAULT);
         settings.bind ("show-spoilers", show_spoilers, "active", SettingsBindFlags.DEFAULT);
+        settings.bind ("hide-preview-cards", hide_preview_cards, "active", SettingsBindFlags.DEFAULT);
         settings.bind ("larger-font-size", larger_font_size, "active", SettingsBindFlags.DEFAULT);
         settings.bind ("larger-line-height", larger_line_height, "active", SettingsBindFlags.DEFAULT);
 

--- a/src/Services/Settings.vala
+++ b/src/Services/Settings.vala
@@ -12,6 +12,7 @@ public class Tuba.Settings : GLib.Settings {
 	public bool live_updates { get; set; }
 	public bool public_live_updates { get; set; }
 	public bool show_spoilers { get; set; }
+	public bool hide_preview_cards { get; set; }
 	public bool larger_font_size { get; set; }
 	public bool larger_line_height { get; set; }
 	public bool aggressive_resolving { get; set; }
@@ -27,6 +28,7 @@ public class Tuba.Settings : GLib.Settings {
 		init ("live-updates");
 		init ("public-live-updates");
 		init ("show-spoilers");
+		init ("hide-preview-cards");
 		init ("larger-font-size");
 		init ("larger-line-height");
 		init ("aggressive-resolving");

--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -135,6 +135,19 @@ public class Tuba.Views.MediaViewer : Gtk.Box {
             done ();
         }
 
+        ~Item () {
+            message ("Destroying MediaViewer.Item");
+
+            if (is_video) {
+                ((Gtk.Video) child_widget).set_file (null);
+                ((Gtk.Video) child_widget).set_media_stream (null);
+            } else {
+                ((Gtk.Picture) child_widget).paintable = null;
+            }
+
+            child_widget.destroy ();
+        }
+
         public void done () {
             spinner.spinning = false;
             stack.visible_child_name = "child";
@@ -439,6 +452,19 @@ public class Tuba.Views.MediaViewer : Gtk.Box {
                 item.done ();
             }
         });
+    }
+
+    public void set_peertube (string url, Gdk.Paintable? preview) {
+        var video = new Gtk.Video ();
+        var item = new Item (video, url, preview, null, true);
+        carousel.append (item);
+        items.add (item);
+
+        File file = File.new_for_uri (url);
+		video.set_file(file);
+        video.media_stream.seekable = false;
+        item.done ();
+        carousel.page_changed (0);
     }
 
     public void set_single_paintable (string url, Gdk.Paintable paintable) {

--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -139,6 +139,7 @@ public class Tuba.Views.MediaViewer : Gtk.Box {
             message ("Destroying MediaViewer.Item");
 
             if (is_video) {
+                ((Gtk.Video) child_widget).media_stream.stream_unprepared ();
                 ((Gtk.Video) child_widget).set_file (null);
                 ((Gtk.Video) child_widget).set_media_stream (null);
             } else {
@@ -457,12 +458,14 @@ public class Tuba.Views.MediaViewer : Gtk.Box {
     public void set_peertube (string url, Gdk.Paintable? preview) {
         var video = new Gtk.Video ();
         var item = new Item (video, url, preview, null, true);
-        carousel.append (item);
-        items.add (item);
 
         File file = File.new_for_uri (url);
 		video.set_file(file);
         item.done ();
+
+        carousel.append (item);
+        items.add (item);
+
         carousel.page_changed (0);
     }
 

--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -462,7 +462,6 @@ public class Tuba.Views.MediaViewer : Gtk.Box {
 
         File file = File.new_for_uri (url);
 		video.set_file(file);
-        video.media_stream.seekable = false;
         item.done ();
         carousel.page_changed (0);
     }

--- a/src/Views/Timeline.vala
+++ b/src/Views/Timeline.vala
@@ -27,6 +27,7 @@ public class Tuba.Views.Timeline : AccountHolder, Streamable, Views.ContentBase 
 		stream_event[InstanceAccount.EVENT_EDIT_POST].connect (on_edit_post);
 		stream_event[InstanceAccount.EVENT_DELETE_POST].connect (on_delete_post);
 		settings.notify["show-spoilers"].connect (on_refresh);
+		settings.notify["hide-preview-cards"].connect (on_refresh);
 
 		content.bind_model (model, on_create_model_widget);
 	}

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -431,6 +431,7 @@ public class Tuba.Widgets.Status : ListBoxRow {
 		spoiler_stack.visible_child_name = reveal_spoiler ? "content" : "spoiler";
 	}
 
+	const string[] ALLOWED_CARD_TYPES = { "link", "video" };
 	protected virtual void bind () {
 		this.content.instance_emojis = status.formal.emojis_map;
 		this.content.content = status.formal.content;
@@ -503,6 +504,197 @@ public class Tuba.Widgets.Status : ListBoxRow {
 			poll.status_parent = status.formal;
 			poll.poll = status.formal.poll;
 		}
+
+		if (!settings.hide_preview_cards && status.formal.card != null && status.formal.card.kind in ALLOWED_CARD_TYPES) {
+			var card_obj = status.formal.card;
+			var is_video = card_obj.kind == "video";
+			var card_container = is_video ? new Gtk.Box (Orientation.VERTICAL, 0) : new Gtk.Box (Orientation.HORIZONTAL, 6);
+
+			if (card_obj.image != null) {
+				var image = new Gtk.Picture ();
+
+				#if GTK_4_8
+					image.set_property ("content-fit", 2);
+				#endif
+
+				image_cache.request_paintable (card_obj.image, (is_loaded, paintable) => {
+					image.paintable = paintable;
+				});
+
+				if (is_video) {
+					image.height_request = 250;
+					image.add_css_class ("preview_card_video");
+
+					var overlay = new Gtk.Overlay () {
+						vexpand = true,
+						hexpand = true
+					};
+
+					var icon = new Gtk.Image() {
+						valign = Gtk.Align.CENTER,
+						halign = Gtk.Align.CENTER,
+						css_classes = {"osd", "circular", "attachment-overlay-icon"},
+						icon_name = "media-playback-start-symbolic",
+						icon_size = Gtk.IconSize.LARGE
+					};
+
+					overlay.add_overlay (icon);
+					overlay.child = image;
+					card_container.append (overlay);
+				} else {
+					image.height_request = 70;
+					image.add_css_class ("preview_card_image");
+					card_container.append (image);
+				}
+
+				
+			} else if (!is_video) {
+				card_container.append (new Gtk.Image.from_icon_name("tuba-paper-symbolic") {
+					height_request = 70,
+					width_request = 70,
+					icon_size = Gtk.IconSize.LARGE
+				});
+				card_container.spacing = 0;
+			}
+
+			var body = new Gtk.Box (Orientation.VERTICAL, 6) {
+				margin_top = 6,
+				margin_bottom = 6,
+				valign = Gtk.Align.CENTER,
+				width_request = 120
+			};
+
+			if (is_video) body.margin_start = body.margin_end = 6;
+
+			var author = card_obj.provider_name;
+			if (author == "") {
+				try {
+					var uri = GLib.Uri.parse (card_obj.url, GLib.UriFlags.NONE);
+					var host = uri.get_host ();
+					if (host != null) author = host;
+				} catch {}
+			}
+
+			var author_label = new Gtk.Label (author.replace ("\n", " ")) {
+				ellipsize = Pango.EllipsizeMode.END,
+				halign = Gtk.Align.START,
+				css_classes = {"dim-label"},
+				tooltip_text = author
+			};
+			body.append (author_label);
+
+			if (card_obj.title != "") {
+				var title_label = new Gtk.Label (card_obj.title.replace ("\n", " ")) {
+					ellipsize = Pango.EllipsizeMode.END,
+					halign = Gtk.Align.START,
+					tooltip_text = card_obj.title
+				};
+				body.append (title_label);
+			}
+
+			if (card_obj.description != "") {
+				var description_label = new Gtk.Label (card_obj.description.replace ("\n", " ")) {
+					ellipsize = Pango.EllipsizeMode.END,
+					halign = Gtk.Align.START,
+					css_classes = {"dim-label"},
+					tooltip_text = card_obj.description
+				};
+				body.append (description_label);
+			}
+
+			card_container.append (body);
+
+			var card = new Gtk.Button () {
+				child = card_container,
+				css_classes = {"preview_card", "frame"}
+			};
+			card.clicked.connect (open_card_url);
+			content_box.append (card);
+		}
+	}
+
+	// Anything higher is usually very laggy
+	const int64[] IDEAL_PEERTUBE_RESOLUTION = { 720, 480, 360 };
+	void open_card_url () {
+		var peertube = status.formal.card.is_peertube;
+
+		var dlg_url = status.formal.card.url;
+		if (dlg_url.length > 64) {
+			dlg_url = status.formal.card.url.substring(0, 62) + "…";
+		}
+
+		// translators: the variable is the app name (Tuba)
+		var dlg_title = _(@"You are about to leave $(Build.NAME)");
+
+		// translators: the variable is a url
+		var dlg_body = _("If you proceed, \"%s\" will open in your browser.".printf (dlg_url));
+		if (peertube) {
+			dlg_title = _("You are about to open a PeerTube video");
+
+			// translators: the first variable is the app name (Tuba),
+			//				the second one is a url
+			dlg_body = _("If you proceed, %s will connect to \"%s\".".printf (Build.NAME, dlg_url));
+		}
+
+		var privacy_dialog = app.question (
+			dlg_title,
+			dlg_body,
+			app.main_window,
+			_("Proceed"),
+			Adw.ResponseAppearance.DESTRUCTIVE
+		);
+
+		privacy_dialog.response.connect(res => {
+			if (res == "yes") {
+				if (peertube) {
+					try {
+						var peertube_instance = GLib.Uri.parse (status.formal.card.url, GLib.UriFlags.NONE);
+						var peertube_api_video = @"https://$(peertube_instance.get_host ())/api/v1/videos/$(Path.get_basename (peertube_instance.get_path ()))";
+						new Request.GET (peertube_api_video)
+							.then ((sess, msg, in_stream) => {
+								var failed = true;
+								var parser = Network.get_parser_from_inputstream(in_stream);
+								var node = network.parse_node (parser);
+								var peertube_obj = API.PeerTube.from (node);
+
+								if (peertube_obj.url == status.formal.card.url) {
+									if (peertube_obj.streamingPlaylists != null && peertube_obj.streamingPlaylists.size > 0) {
+										var peertube_streaming_playlist = peertube_obj.streamingPlaylists.get(0);
+										if (peertube_streaming_playlist.files != null && peertube_streaming_playlist.files.size > 0) {
+											var res_url = "";
+											peertube_streaming_playlist.files.foreach (file => {
+												if (file.fileDownloadUrl == "" || file.resolution == null) return true;
+												res_url = file.fileDownloadUrl;
+
+												if (file.resolution.id in IDEAL_PEERTUBE_RESOLUTION) return false;
+												return true;
+											});
+
+											if (res_url != "") {
+												failed = false;
+												app.main_window.show_media_viewer_peertube (res_url, null);
+											}
+										}
+									}
+								}
+
+								if (failed) Host.open_uri (status.formal.card.url);
+							})
+							.on_error (() => {
+								Host.open_uri (status.formal.card.url);
+							})
+							.exec ();
+					} catch {
+						Host.open_uri (status.formal.card.url);
+					}
+				} else {
+					Host.open_uri (status.formal.card.url);
+				}
+			}
+			privacy_dialog.destroy();
+		});
+
+		privacy_dialog.present ();
 	}
 
 	protected virtual void append_actions () {

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -575,29 +575,32 @@ public class Tuba.Widgets.Status : ListBoxRow {
 				} catch {}
 			}
 
-			var author_label = new Gtk.Label (author.replace ("\n", " ")) {
+			var author_label = new Gtk.Label (author) {
 				ellipsize = Pango.EllipsizeMode.END,
 				halign = Gtk.Align.START,
 				css_classes = {"dim-label"},
-				tooltip_text = author
+				tooltip_text = author,
+				single_line_mode = true
 			};
 			body.append (author_label);
 
 			if (card_obj.title != "") {
-				var title_label = new Gtk.Label (card_obj.title.replace ("\n", " ")) {
+				var title_label = new Gtk.Label (card_obj.title) {
 					ellipsize = Pango.EllipsizeMode.END,
 					halign = Gtk.Align.START,
-					tooltip_text = card_obj.title
+					tooltip_text = card_obj.title,
+					single_line_mode = true
 				};
 				body.append (title_label);
 			}
 
 			if (card_obj.description != "") {
-				var description_label = new Gtk.Label (card_obj.description.replace ("\n", " ")) {
+				var description_label = new Gtk.Label (card_obj.description) {
 					ellipsize = Pango.EllipsizeMode.END,
 					halign = Gtk.Align.START,
 					css_classes = {"dim-label"},
-					tooltip_text = card_obj.description
+					tooltip_text = card_obj.description,
+					single_line_mode = true
 				};
 				body.append (description_label);
 			}


### PR DESCRIPTION
Cards :sparkles: 

link:
![image](https://github.com/GeopJr/Tuba/assets/18014039/a3da3147-17dd-4e69-a339-b26a1e9f7c6f)

video:
![image](https://github.com/GeopJr/Tuba/assets/18014039/145d3eb9-8f23-45c1-8eb6-681d19aca8bf)

clicking on a card will show a dialog since it's an out-of-instance request and users should confirm for privacy reasons:
![image](https://github.com/GeopJr/Tuba/assets/18014039/3d90d7cd-c5bc-4180-9cbc-07c3f9acbb4e)

PeerTube :octopus: 

PeerTube videos should now play on the built-in media viewer

:information_source: qualities higher than 720p become laggy on my machine (gstreamer backend, I haven't tested on ffmpeg) so I set some limits (720, 480, 360 are preferred unless they are not available)

Similarly, PeerTube videos require out-of-instance requests and a similar dialog shows up:
![image](https://github.com/GeopJr/Tuba/assets/18014039/723404ba-925b-4a5d-9cb2-02ce983114c1)

fix: #244 

edit:

there's an option in settings to disable cards