### PR TITLE
fix: encode all params on exec

### DIFF
--- a/src/API/Account.vala
+++ b/src/API/Account.vala
@@ -78,7 +78,7 @@ public class Tuba.API.Account : Entity, Widgetizable {
 	public static Request search (string query) throws Error {
 		return new Request.GET ("/api/v1/accounts/search")
 			.with_account (accounts.active)
-			.with_param ("q", Uri.escape_string (query))
+			.with_param ("q", query)
 			.with_param ("resolve", "false")
 			.with_param ("limit", "4");
 	}

--- a/src/API/SearchResults.vala
+++ b/src/API/SearchResults.vala
@@ -25,7 +25,7 @@ public class Tuba.API.SearchResults : Entity {
 		var req = new Request.GET ("/api/v2/search")
 			.with_account (account)
 			.with_param ("resolve", "true")
-			.with_param ("q", Uri.escape_string (q));
+			.with_param ("q", q);
 		yield req.await ();
 
 		var parser = Network.get_parser_from_inputstream(req.response_body);

--- a/src/API/Tag.vala
+++ b/src/API/Tag.vala
@@ -14,7 +14,7 @@ public class Tuba.API.Tag : Entity, Widgetizable {
 	public static Request search (string query) throws Error {
 		return new Request.GET ("/api/v2/search")
 			.with_account (accounts.active)
-			.with_param ("q", Uri.escape_string (query))
+			.with_param ("q", query)
 			.with_param ("resolve", "hashtags")
 			.with_param ("exclude_unreviewed", "true")
 			.with_param ("limit", "4");

--- a/src/Dialogs/Composer/AttachmentsPageAttachment.vala
+++ b/src/Dialogs/Composer/AttachmentsPageAttachment.vala
@@ -154,7 +154,7 @@ public class Tuba.AttachmentsPageAttachment : Widgets.Attachment.Item {
 			}
 			new Request.PUT (@"/api/v1/media/$(id)")
 				.with_account (accounts.active)
-				.with_param ("description", HtmlUtils.uri_encode (alt_text))
+				.with_param ("description", alt_text)
 				.then(() => {})
 				.exec ();
 			dialog.destroy();

--- a/src/Services/Network/Request.vala
+++ b/src/Services/Network/Request.vala
@@ -134,7 +134,7 @@ public class Tuba.Request : GLib.Object {
 			pars.@foreach (entry => {
 				parameters_counter++;
 				var key = (string) entry.key;
-				var val = (string) entry.value;
+				var val = Uri.escape_string ((string) entry.value);
 				parameters += @"$key=$val";
 
 				if (parameters_counter < pars.size)

--- a/src/Views/Lists.vala
+++ b/src/Views/Lists.vala
@@ -230,7 +230,7 @@ public class Tuba.Views.Lists : Views.Timeline {
 				this.list.replies_policy = replies_policy;
 				new Request.PUT (@"/api/v1/lists/$(t_list.id)")
 					.with_account (accounts.active)
-					.with_param ("title", HtmlUtils.uri_encode(title))
+					.with_param ("title", title)
 					.with_param ("replies_policy", replies_policy)
 					.then(() => {})
 					.exec ();
@@ -289,7 +289,7 @@ public class Tuba.Views.Lists : Views.Timeline {
 	public void create_list(string list_name) {
 		new Request.POST ("/api/v1/lists")
 			.with_account (accounts.active)
-			.with_param ("title", HtmlUtils.uri_encode(list_name))
+			.with_param ("title", list_name)
 			.then ((sess, msg, in_stream) => {
 				var parser = Network.get_parser_from_inputstream(in_stream);
 				var node = network.parse_node (parser);


### PR DESCRIPTION
fix: #246 

Let's just encode all params on exec instead of when constructing requests since we missed some more than once