### PR TITLE
fix(bookwyrm): do not rely on title for bookwyrm detection

### DIFF
--- a/src/API/Status/PreviewCard.vala
+++ b/src/API/Status/PreviewCard.vala
@@ -137,10 +137,9 @@ public class Tuba.API.PreviewCard : Entity {
 
 	public bool is_bookwyrm {
         get {
-			bool title_bw = title.last_index_of ("- BookWyrm") > 0;
-			bool url_bw = url.last_index_of ("/book/") > -1;
-
-			return kind == "link" && title_bw && url_bw;
+			Regex regex_bw = new GLib.Regex ("/book/\\d+/s/[-_a-z0-9]*");
+			
+			return kind == "link" && regex_bw.match (url);
 		}
     }
 

--- a/src/API/Status/PreviewCard.vala
+++ b/src/API/Status/PreviewCard.vala
@@ -137,9 +137,7 @@ public class Tuba.API.PreviewCard : Entity {
 
 	public bool is_bookwyrm {
         get {
-			Regex regex_bw = new GLib.Regex ("/book/\\d+/s/[-_a-z0-9]*");
-			
-			return kind == "link" && regex_bw.match (url);
+			return kind == "link" && bookwyrm_regex.match (url);
 		}
     }
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -18,6 +18,7 @@ namespace Tuba {
 	public static EntityCache entity_cache;
 	public static ImageCache image_cache;
 
+	public static GLib.Regex bookwyrm_regex;
 	public static GLib.Regex custom_emoji_regex;
 	public static GLib.Regex rtl_regex;
 	public static bool is_rtl;
@@ -76,6 +77,12 @@ namespace Tuba {
 				opt_context.parse (ref args);
 			}
 			catch (GLib.OptionError e) {
+				warning (e.message);
+			}
+
+			try {
+				bookwyrm_regex = new GLib.Regex ("/book/\\d+/s/[-_a-z0-9]*", GLib.RegexCompileFlags.OPTIMIZE);
+			} catch (GLib.RegexError e) {
 				warning (e.message);
 			}
 


### PR DESCRIPTION
This was preventing preview on BW instances that changes the title (e.g. https://velhaestante.com.br/book/11624/s/the-name-of-the-wind ).

The regular expression used here is the same one used by BW itself (see [BOOK_PATH][bw-path], [SLUG][bw-slug], and [full path][bw-view]).

[bw-slug]: https://github.com/bookwyrm-social/bookwyrm/blob/ee1dd612fb223bf44f98026b8f42991cff97279f/bookwyrm/utils/regex.py#LL9C10-L9C34
[bw-path]: https://github.com/bookwyrm-social/bookwyrm/blob/ee1dd612fb223bf44f98026b8f42991cff97279f/bookwyrm/urls.py#L26
[bw-view]: https://github.com/bookwyrm-social/bookwyrm/blob/ee1dd612fb223bf44f98026b8f42991cff97279f/bookwyrm/urls.py#L649