### PR TITLE
revert: "fix: missing underline on some links"

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -91,9 +91,6 @@ namespace Tuba {
 				warning (e.message);
 			}
 
-			// Fix some links not getting underlined
-			Environment.set_variable ("GSK_RENDERER", "cairo", false);
-
 			Intl.setlocale (LocaleCategory.ALL, "");
 			Intl.bindtextdomain(Build.GETTEXT_PACKAGE, Build.LOCALEDIR);
 			Intl.textdomain(Build.GETTEXT_PACKAGE);


### PR DESCRIPTION
This reverts commit 491c28f70c4417f04532ddfc6a724919e5d01167.

fix: #267
unfix: #197