### PR TITLE
feat(network): remove header on insecure requests

### DIFF
--- a/src/API/Status/PreviewCard.vala
+++ b/src/API/Status/PreviewCard.vala
@@ -173,6 +173,7 @@ public class Tuba.API.PreviewCard : Entity, Widgetizable {
 				
 
 				new Request.GET (special_api_url)
+					.is_insecure ()
 					.then ((sess, msg, in_stream) => {
 						bool failed = true;
 						var parser = Network.get_parser_from_inputstream(in_stream);

--- a/src/Services/Network/Request.vala
+++ b/src/Services/Network/Request.vala
@@ -34,6 +34,7 @@ public class Tuba.Request : GLib.Object {
 	HashMap<string, string>? pars;
 	Soup.Multipart? form_data;
 	public GLib.Cancellable cancellable;
+	public bool insecure { get; set; default=false; }
 
 	weak Gtk.Widget? ctx;
 	bool has_ctx = false;
@@ -108,6 +109,11 @@ public class Tuba.Request : GLib.Object {
 		return this;
 	}
 
+	public Request is_insecure () {
+		this.insecure = true;
+		return this;
+	}
+
 	public Request with_param (string name, string val) {
 		if (pars == null)
 			pars = new HashMap<string, string> ();
@@ -165,8 +171,8 @@ public class Tuba.Request : GLib.Object {
 			msg.uri = t_uri;
 		}
 
-		if (account != null && account.access_token != null) {
-			msg.request_headers.remove ("Authorization");
+		msg.request_headers.remove ("Authorization");
+		if (account != null && account.access_token != null && !insecure) {
 			msg.request_headers.append ("Authorization", @"Bearer $(account.access_token)");
 		}
 

--- a/src/Widgets/BookWyrmPage.vala
+++ b/src/Widgets/BookWyrmPage.vala
@@ -67,6 +67,7 @@ public class Tuba.Widgets.BookWyrmPage : Gtk.Box {
 
             foreach (var author in t_obj.authors) {
                 new Request.GET (@"$author.json")
+                    .is_insecure ()
                     .then ((sess, msg, in_stream) => {
                         var parser = Network.get_parser_from_inputstream(in_stream);
                         var node = network.parse_node (parser);


### PR DESCRIPTION
if a request is known to be 100% out of instance or doesn't need auth then setting is_insecure should strip any auth headers even if with_account is explicitly set

note: with_account has two use cases:

1. if host is missing from the url it uses the account's instance 
2. set auth headers with the account's token

is_insecure will strip the auth headers

maybe should be renamed to with_auth and do the opposite?