### PR TITLE
fix: set composer dialog widgets to insensitive when publishing

### DIFF
--- a/src/Dialogs/Composer/Dialog.vala
+++ b/src/Dialogs/Composer/Dialog.vala
@@ -16,11 +16,6 @@ public class Tuba.Dialogs.Compose : Adw.Window {
 		set { commit_button.add_css_class (value); }
 	}
 	public bool editing { get; set; default=false; }
-	private bool _working = false;
-	public bool working {
-		get { return _working; }
-		set { _working = value; this.sensitive = !_working; }
-	}
 
 	ulong build_sigid;
 
@@ -92,11 +87,9 @@ public class Tuba.Dialogs.Compose : Adw.Window {
 
 	private void update_commit_button () {
 		var allow = false;
-		if (!working) {
-			foreach (var page in t_pages) {
-				allow = allow || (page.can_publish && page.visible);
-				if (allow) break;
-			}
+		foreach (var page in t_pages) {
+			allow = allow || (page.can_publish && page.visible);
+			if (allow) break;
 		}
 		commit_button.sensitive = allow;
 	}
@@ -197,18 +190,16 @@ public class Tuba.Dialogs.Compose : Adw.Window {
 	}
 
 	[GtkCallback] void on_commit () {
-		if (working)
-			return; // avoid double send
-		working = true;
+		this.sensitive = false;
 		transaction.begin ((obj, res) => {
 			try {
 				transaction.end (res);
 				// on_close ();
-			}
-			catch (Error e) {
-				working = false;
+			} catch (Error e) {
 				// on_error (0, e.message);
 				warning (e.message);
+			} finally {
+				this.sensitive = true;
 			}
 		});
 	}

--- a/src/Dialogs/Composer/Dialog.vala
+++ b/src/Dialogs/Composer/Dialog.vala
@@ -19,7 +19,7 @@ public class Tuba.Dialogs.Compose : Adw.Window {
 	private bool _working = false;
 	public bool working {
 		get { return _working; }
-		set { _working = value; update_commit_button (); update_pages (); }
+		set { _working = value; this.sensitive = !_working; }
 	}
 
 	ulong build_sigid;
@@ -99,18 +99,6 @@ public class Tuba.Dialogs.Compose : Adw.Window {
 			}
 		}
 		commit_button.sensitive = allow;
-	}
-
-	private void update_pages () {
-		var allow = false;
-
-		if (!working) {
-			allow = true;
-		}
-
-		foreach (var page in t_pages) {
-			page.sensitive = allow;
-		}
 	}
 
 	[GtkChild] unowned Adw.ViewSwitcherTitle title_switcher;
@@ -209,6 +197,8 @@ public class Tuba.Dialogs.Compose : Adw.Window {
 	}
 
 	[GtkCallback] void on_commit () {
+		if (working)
+			return; // avoid double send
 		working = true;
 		transaction.begin ((obj, res) => {
 			try {


### PR DESCRIPTION
Currently when sending a post, the dialog does not change. This allows the user to accidentally press "Publish" or use one of the accelerators to send the post again. It's also just not good feedback on whether the post is sending.

This commit changes the dialog such that once the publish process begins, the "Publish" button, composer pages (edit/attach/poll), and on_commit () callback are all disabled until the commit transaction fails.

---

I didn't create an issue for this because I felt it would be a good opportunity to learn a bit of Vala/Adwaita if I tackled this myself, please let me know if you have feedback 🙏️