### PR TITLE
fix: add .flatpak-builder/ directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ subprojects/packagecache
 *~
 builddir
 *.snap
+.flatpak-builder


### PR DESCRIPTION
When building the app with `flatpak-builder`, a `.flatpak-builder/` directory is created for the build environment.

_Since (afaik) build directories/environments shouldn't be pushed to repositories, it would be logical to add this exception._

<sub>This is my first pull request, please let me know if I did anything wrong; any and all criticism is very much appreciated!</sub>