### PR TITLE
fix(HtmlUtils): do not remove newlines if there are no brs

### DIFF
--- a/src/Utils/Html.vala
+++ b/src/Utils/Html.vala
@@ -72,8 +72,7 @@ public class Tuba.HtmlUtils {
 	}
 
 	public static string replace_with_pango_markup (string str) {
-		return str
-			.replace ("\n", "")
+		var res = str
 			.replace ("<strong>", "<b>")
 			.replace ("</strong>", "</b>")
 			.replace ("<em>", "<i>")
@@ -82,6 +81,9 @@ public class Tuba.HtmlUtils {
 			//  .replace("</code>", "</span>\n")
 			.replace ("<del>", "<s>")
 			.replace ("</del>", "</s>");
+
+		if ("<br" in str) res = res.replace ("\n", "");
+		return res;
 	}
 
 	public static string uri_encode (string str) {


### PR DESCRIPTION
*oma uses newlines, Pixelfed uses both `<br />` and newline at the same time

only remove newlines if there are br's