### PR TITLE
feat(Image): letterbox setting

### DIFF
--- a/data/dev.geopjr.Tuba.gschema.xml
+++ b/data/dev.geopjr.Tuba.gschema.xml
@@ -51,6 +51,9 @@
 		<key name="strip-tracking" type="b">
 			<default>true</default>
 		</key>
+		<key name="letterbox-media" type="b">
+			<default>false</default>
+		</key>
 
 		<key name="window-x" type="i">
 			<default>-1</default>

--- a/data/ui/dialogs/preferences.ui
+++ b/data/ui/dialogs/preferences.ui
@@ -58,6 +58,20 @@
                 </child>
               </object>
             </child>
+            <child>
+              <object class="AdwActionRow">
+                <!-- translators: if unsure, you can find the translation on glitch-soc https://github.com/glitch-soc/mastodon/tree/main/app/javascript/flavours/glitch/locales under the key "settings.media_letterbox" -->
+                <property name="title" translatable="yes">Letterbox Media</property>
+                <property name="activatable_widget">letterbox_media</property>
+                <!-- translators: if unsure, you can find the translation on glitch-soc https://github.com/glitch-soc/mastodon/tree/main/app/javascript/flavours/glitch/locales under the key "settings.media_letterbox_hint" -->
+                <property name="subtitle" translatable="yes">Scale down and letterbox media to fill the image containers instead of stretching and cropping them</property>
+                <child>
+                  <object class="GtkSwitch" id="letterbox_media">
+                    <property name="valign">center</property>
+                  </object>
+                </child>
+              </object>
+            </child>
           </object>
         </child>
         <child>

--- a/src/Dialogs/Preferences.vala
+++ b/src/Dialogs/Preferences.vala
@@ -16,6 +16,7 @@ public class Tuba.Dialogs.Preferences : Adw.PreferencesWindow {
     [GtkChild] unowned Switch larger_font_size;
     [GtkChild] unowned Switch larger_line_height;
     [GtkChild] unowned Switch strip_tracking;
+    [GtkChild] unowned Switch letterbox_media;
 
 	private bool lang_changed { get; set; default=false; }
 
@@ -67,6 +68,7 @@ public class Tuba.Dialogs.Preferences : Adw.PreferencesWindow {
         settings.bind ("larger-font-size", larger_font_size, "active", SettingsBindFlags.DEFAULT);
         settings.bind ("larger-line-height", larger_line_height, "active", SettingsBindFlags.DEFAULT);
         settings.bind ("strip-tracking", strip_tracking, "active", SettingsBindFlags.DEFAULT);
+        settings.bind ("letterbox-media", letterbox_media, "active", SettingsBindFlags.DEFAULT);
 
 		post_visibility_combo_row.notify["selected-item"].connect (on_post_visibility_changed);
 

--- a/src/Services/Settings.vala
+++ b/src/Services/Settings.vala
@@ -17,6 +17,7 @@ public class Tuba.Settings : GLib.Settings {
 	public bool larger_line_height { get; set; }
 	public bool aggressive_resolving { get; set; }
 	public bool strip_tracking { get; set; }
+	public bool letterbox_media { get; set; }
 
 	public Settings () {
 		Object (schema_id: Build.DOMAIN);
@@ -34,6 +35,7 @@ public class Tuba.Settings : GLib.Settings {
 		init ("larger-line-height");
 		init ("aggressive-resolving");
 		init ("strip-tracking");
+		init ("letterbox-media");
 	}
 
 	void init (string key) {

--- a/src/Widgets/Attachment/Image.vala
+++ b/src/Widgets/Attachment/Image.vala
@@ -26,6 +26,10 @@ public class Tuba.Widgets.Attachment.Image : Widgets.Attachment.Item {
 		}
 	}
 
+	void cover_content_fit () {
+		pic.set_property ("content-fit", settings.letterbox_media ? 1 : 2);
+	}
+
 	construct {
 		pic = new Picture () {
 			hexpand = true,
@@ -37,7 +41,8 @@ public class Tuba.Widgets.Attachment.Image : Widgets.Attachment.Item {
 		};
 
 		#if GTK_4_8
-			pic.set_property ("content-fit", 2);
+			cover_content_fit ();
+			settings.notify["letterbox-media"].connect (cover_content_fit);
 		#endif
 
 		media_overlay = new Overlay ();

--- a/src/Widgets/Attachment/Image.vala
+++ b/src/Widgets/Attachment/Image.vala
@@ -26,9 +26,11 @@ public class Tuba.Widgets.Attachment.Image : Widgets.Attachment.Item {
 		}
 	}
 
-	void cover_content_fit () {
-		pic.set_property ("content-fit", settings.letterbox_media ? 1 : 2);
-	}
+	#if GTK_4_8
+		void update_pic_content_fit () {
+			pic.set_property ("content-fit", settings.letterbox_media ? 1 : 2);
+		}
+	#endif
 
 	construct {
 		pic = new Picture () {
@@ -41,8 +43,8 @@ public class Tuba.Widgets.Attachment.Image : Widgets.Attachment.Item {
 		};
 
 		#if GTK_4_8
-			cover_content_fit ();
-			settings.notify["letterbox-media"].connect (cover_content_fit);
+			update_pic_content_fit ();
+			settings.notify["letterbox-media"].connect (update_pic_content_fit);
 		#endif
 
 		media_overlay = new Overlay ();


### PR DESCRIPTION
Adds a setting to letterbox media instead of stretching and cropping (cover). This is especially important for art communities as viewing the full image in attachments is generally preferred over cover.