### PR TITLE
feat: libspelling support

### DIFF
--- a/build-aux/dev.geopjr.Tuba.Devel.json
+++ b/build-aux/dev.geopjr.Tuba.Devel.json
@@ -55,19 +55,16 @@
             ]
         },
         {
-            "name" : "gspell-4",
+            "name" : "libspelling",
             "buildsystem" : "meson",
             "config-opts" : [
-                "-Dgi_doc=false",
-                "-Dgtk_doc=false",
-                "-Ddemo=false"
+                "-Ddocs=false"
             ],
             "sources" : [
                 {
                     "type" : "git",
-                    "url" : "https://github.com/geopjr-forks/gspell-4.git",
-                    "branch" : "main",
-                    "commit": "3daa2cf19b17d04bf142ad35e4abfeba811a7b4f"
+                    "url" : "https://gitlab.gnome.org/chergert/libspelling.git",
+                    "branch" : "main"
                 }
             ]
         },

--- a/meson.build
+++ b/meson.build
@@ -60,6 +60,7 @@ libadwaita_dep = dependency('libadwaita-1', version: '>=1.2', required: true)
 gtksourceview_dep = dependency('gtksourceview-5', required: false, version: '>=5.6.0')
 libwebp_dep = dependency('libwebp', required: false)
 gspell = dependency('gspell-4', required: false)
+libspelling = dependency('libspelling-1', required: false)
 
 if not libwebp_dep.found ()
   warning('WebP support might be missing, please install webp-pixbuf-loader.')
@@ -71,6 +72,10 @@ endif
 
 if libgtk_dep.version().version_compare('>=4.10.0')
   add_project_arguments(['--define=GTK_4_10'], language: 'vala')
+endif
+
+if libspelling.found ()
+  add_project_arguments(['--define=LIBSPELLING'], language: 'vala')
 endif
 
 if gspell.found ()
@@ -97,6 +102,7 @@ final_deps = [
   dependency('libxml-2.0'),
   dependency('libsecret-1', required: true),
   gspell,
+  libspelling,
   gtksourceview_dep,
   libgtk_dep,
   libadwaita_dep

--- a/src/Dialogs/Composer/EditorPage.vala
+++ b/src/Dialogs/Composer/EditorPage.vala
@@ -121,7 +121,15 @@ public class Tuba.EditorPage : ComposerPage {
 			wrap_mode = WrapMode.WORD_CHAR
 		};
 
-		#if GSPELL
+		#if LIBSPELLING && !MISSING_GTKSOURCEVIEW
+			var adapter = new Spelling.TextBufferAdapter ((GtkSource.Buffer) editor.buffer, Spelling.Checker.get_default ());
+
+			editor.extra_menu = adapter.get_menu_model ();
+			editor.insert_action_group ("spelling", adapter);
+			adapter.enabled = true;
+		#endif
+
+		#if GSPELL && (MISSING_GTKSOURCEVIEW || !LIBSPELLING)
 			var gspell_view = Gspell.TextView.get_from_gtk_text_view (editor);
 			gspell_view.basic_setup ();
 		#endif


### PR DESCRIPTION
gspell-4 is still available as a fallback

The only difference I noticed (apart from some UI) is that your cursor needs to be on the word you are looking suggestions up for.

cursor next to word:
![image](https://github.com/GeopJr/Tuba/assets/18014039/78c2ce89-56d9-4de5-86e4-b7bdb234ab9c)

cursor in word:
![image](https://github.com/GeopJr/Tuba/assets/18014039/f47552ba-ce3f-4384-a3ce-e92f270a79ff)

:warning: If GtkSourceView is missing, then only gspell-4 is available