### PR TITLE
fix: Escape markup in poll options

### DIFF
--- a/src/Widgets/VoteBox.vala
+++ b/src/Widgets/VoteBox.vala
@@ -1,6 +1,7 @@
 using Gtk;
 using Gdk;
 using Gee;
+using GLib;
 
 [GtkTemplate (ui = "/dev/geopjr/Tuba/ui/widgets/votebox.ui")]
 public class Tuba.Widgets.VoteBox: Box {
@@ -86,10 +87,10 @@ public class Tuba.Widgets.VoteBox: Box {
                 }
 
                 row.subtitle = "%.1f%%".printf (percentage);
-                row.title = p.title;
+                row.title = Markup.escape_text (p.title);
                 poll_box.append (row);
             } else {
-                row.title = p.title;
+                row.title = Markup.escape_text (p.title);
                 var check_option = new Widgets.VoteCheckButton ();
 
                 if (!poll.multiple) {

--- a/src/Widgets/VoteBox.vala
+++ b/src/Widgets/VoteBox.vala
@@ -1,7 +1,6 @@
 using Gtk;
 using Gdk;
 using Gee;
-using GLib;
 
 [GtkTemplate (ui = "/dev/geopjr/Tuba/ui/widgets/votebox.ui")]
 public class Tuba.Widgets.VoteBox: Box {
@@ -63,7 +62,8 @@ public class Tuba.Widgets.VoteBox: Box {
 		//creates the entries of poll
         foreach (API.PollOption p in poll.options) {
             var row = new Adw.ActionRow () {
-                css_classes = { "ttl-poll-row" }
+                css_classes = { "ttl-poll-row" },
+                use_markup = false
             };
 
             //if it is own poll
@@ -87,10 +87,10 @@ public class Tuba.Widgets.VoteBox: Box {
                 }
 
                 row.subtitle = "%.1f%%".printf (percentage);
-                row.title = Markup.escape_text (p.title);
+                row.title = p.title;
                 poll_box.append (row);
             } else {
-                row.title = Markup.escape_text (p.title);
+                row.title = p.title;
                 var check_option = new Widgets.VoteCheckButton ();
 
                 if (!poll.multiple) {


### PR DESCRIPTION
Poll option titles can currently be interpreted as html, causing them to be displayed incorrectly at times. This is inconsistent with other Mastodon/ActivityPub clients. All documentation on how poll options should be formatted also seems to point to them only ever being plain text.

This small change escapes characters that can be interpreted as markup when rendering polls.

Before:
![screenshot_2023-07-14T09:13:48](https://github.com/GeopJr/Tuba/assets/7573/29662a9c-b2dc-471a-9eaa-24bb776b1104)

After:
![screenshot_2023-07-14T09:11:44](https://github.com/GeopJr/Tuba/assets/7573/dddfa6d4-c6e1-4302-9a15-19a5ea39b1cd)

