### PR TITLE
Shiny new widgets \o/

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -1,4 +1,4 @@
-.sidebar .badge {
+.ttl-sidebar .badge {
 	padding: 2px 12px;
 	border-radius: 999px;
 	background: @accent_bg_color;

--- a/data/ui/dialogs/compose.ui
+++ b/data/ui/dialogs/compose.ui
@@ -19,7 +19,7 @@
             <property name="centering-policy">strict</property>
 
             <child type="title">
-              <object class="AdwViewSwitcherTitle" id="title_switcher">
+              <object class="AdwViewSwitcher" id="title_switcher">
                 <!-- <property name="title" translatable="yes">Title</property> -->
                 <!-- <property name="subtitle" translatable="yes">Subtitle</property> -->
               </object>
@@ -51,7 +51,6 @@
         <child>
           <object class="AdwViewSwitcherBar" id="switcher_bar">
             <property name="stack">stack</property>
-            <property name="reveal" bind-source="title_switcher" bind-property="title-visible" bind-flags="sync-create"/>
           </object>
         </child>
       </object>

--- a/data/ui/dialogs/main.ui
+++ b/data/ui/dialogs/main.ui
@@ -4,6 +4,12 @@
     <property name="width_request">360</property>
     <property name="height_request">600</property>
     <child>
+      <object class="AdwBreakpoint">
+        <condition>max-width: 700sp</condition>
+        <setter object="split_view" property="collapsed">true</setter>
+      </object>
+    </child>
+    <child>
       <object class="GtkStack" id="main_stack">
         <property name="vexpand">1</property>
         <property name="hexpand">1</property>
@@ -14,29 +20,15 @@
           <object class="GtkStackPage">
             <property name="name">main</property>
             <property name="child">
-              <object class="AdwFlap" id="flap">
-                <child type="flap">
-                  <object class="TubaViewsSidebar" id="sidebar">
-                    <style>
-                      <class name="background"/>
-                    </style>
+              <object class="AdwOverlaySplitView" id="split_view">
+                <property name="sidebar">
+                  <object class="TubaViewsSidebar" id="sidebar" />
+                </property>
+                <property name="content">
+                  <object class="AdwNavigationView" id="navigation_view">
+                    <signal name="notify::visible-page" handler="on_visible_page_changed" />
                   </object>
-                </child>
-                <!-- <child type="separator"> -->
-                <!--   <object class="GtkSeparator"> -->
-                <!--     <property name="orientation">vertical</property> -->
-                <!--   </object> -->
-                <!-- </child> -->
-                <child type="content">
-                  <object class="AdwLeaflet" id="leaflet">
-                    <property name="transition_type">over</property>
-                    <property name="can-navigate-back">1</property>
-                    <property name="can-unfold">0</property>
-                    <property name="homogeneous">0</property>
-                    <signal name="notify::child-transition-running" handler="on_child_transition"/>
-                    <signal name="notify::visible-child" handler="on_view_changed"/>
-                  </object>
-                </child>
+                </property>
               </object>
             </property>
           </object>

--- a/data/ui/dialogs/new_account.ui
+++ b/data/ui/dialogs/new_account.ui
@@ -7,83 +7,78 @@
     <property name="default_height">500</property>
     <property name="title" translatable="yes">Add Account</property>
     <child>
-      <object class="AdwLeaflet" id="deck">
-        <property name="can_unfold">0</property>
-        <property name="transition_type">slide</property>
-        <signal name="notify::visible_child" handler="on_visible_child_notify" swapped="no"/>
+      <object class="AdwNavigationView" id="deck">
+        <signal name="popped" handler="on_back_clicked" swapped="no"/>
         <child>
-          <object class="GtkBox" id="instance_step">
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="AdwHeaderBar">
-                <property name="show-end-title-buttons">false</property>
-                <property name="show-start-title-buttons">false</property>
-                <style>
-                    <class name="flat"/>
-                    <class name="no-title"/>
-                </style>
-                <child>
-                  <object class="GtkButton">
-                    <property name="label" translatable="yes">Cancel</property>
-                    <signal name="clicked" handler="gtk_window_destroy" swapped="yes"/>
-                  </object>
-                </child>
-                <child type="end">
-                  <object class="GtkButton">
-                    <property name="receives_default">1</property>
-                    <property name="label" translatable="yes">Next</property>
-                    <property name="sensitive" bind-source="TubaDialogsNewAccount" bind-property="is_working" bind-flags="sync-create|invert-boolean"/>
-                    <signal name="clicked" handler="on_next_clicked" swapped="no"/>
-                    <style>
-                      <class name="suggested-action"/>
-                    </style>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="AdwStatusPage">
-                <property name="vexpand">1</property>
-                <property name="icon_name">tuba-network-server-symbolic</property>
-                <property name="title" translatable="yes">What is your Server?</property>
-                <!-- translators: Please replace the joinmastodon.org/servers link with the one for your language if available -->
-                <property name="description" translatable="yes">If you don&apos;t have an account yet, &lt;a href=&quot;https://joinmastodon.org/servers&quot;&gt;choose a server and register one&lt;/a&gt;.</property>
-                <style>
-                    <class name="compact"/>
-                </style>
-                <child>
-                  <object class="AdwClamp">
-                    <property name="maximum-size">400</property>
+          <object class="AdwNavigationPage" id="instance_step">
+            <property name="child">
+              <object class="AdwToolbarView">
+                <child type="top">
+                  <object class="AdwHeaderBar">
                     <child>
-                      <object class="GtkBox">
-                        <property name="margin_top">24</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">12</property>
+                      <object class="GtkButton">
+                        <property name="label" translatable="yes">Cancel</property>
+                        <signal name="clicked" handler="gtk_window_destroy" swapped="yes"/>
+                      </object>
+                    </child>
+                    <child type="end">
+                      <object class="GtkButton">
+                        <property name="receives_default">1</property>
+                        <property name="label" translatable="yes">Next</property>
+                        <property name="sensitive" bind-source="TubaDialogsNewAccount" bind-property="is_working" bind-flags="sync-create|invert-boolean"/>
+                        <signal name="clicked" handler="on_next_clicked" swapped="no"/>
+                        <style>
+                          <class name="suggested-action"/>
+                        </style>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <property name="content">
+                  <object class="AdwStatusPage">
+                    <property name="vexpand">1</property>
+                    <property name="icon_name">tuba-network-server-symbolic</property>
+                    <property name="title" translatable="yes">What is your Server?</property>
+                    <!-- translators: Please replace the joinmastodon.org/servers link with the one for your language if available -->
+                    <property name="description" translatable="yes">If you don&apos;t have an account yet, &lt;a href=&quot;https://joinmastodon.org/servers&quot;&gt;choose a server and register one&lt;/a&gt;.</property>
+                    <style>
+                        <class name="compact"/>
+                    </style>
+                    <child>
+                      <object class="AdwClamp">
+                        <property name="maximum-size">400</property>
                         <child>
                           <object class="GtkBox">
+                            <property name="margin_top">24</property>
                             <property name="orientation">vertical</property>
-                            <property name="spacing">6</property>
+                            <property name="spacing">12</property>
                             <child>
-
-                              <object class="AdwPreferencesGroup">
+                              <object class="GtkBox">
+                                <property name="orientation">vertical</property>
+                                <property name="spacing">6</property>
                                 <child>
-                                  <object class="AdwEntryRow" id="instance_entry">
-                                    <property name="title" translatable="true">Server URL</property>
-                                    <property name="input_purpose">url</property>
-                                    <signal name="entry_activated" handler="on_next_clicked" swapped="no"/>
-                                    <signal name="changed" handler="clear_errors" swapped="no"/>
+
+                                  <object class="AdwPreferencesGroup">
+                                    <child>
+                                      <object class="AdwEntryRow" id="instance_entry">
+                                        <property name="title" translatable="true">Server URL</property>
+                                        <property name="input_purpose">url</property>
+                                        <signal name="entry_activated" handler="on_next_clicked" swapped="no"/>
+                                        <signal name="changed" handler="clear_errors" swapped="no"/>
+                                      </object>
+                                    </child>
+                                  </object>
+
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="instance_entry_error">
+                                    <property name="label" translatable="yes"></property>
+                                    <property name="wrap">1</property>
+                                    <style>
+                                      <class name="error"/>
+                                    </style>
                                   </object>
                                 </child>
-                              </object>
-
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="instance_entry_error">
-                                <property name="label" translatable="yes"></property>
-                                <property name="wrap">1</property>
-                                <style>
-                                  <class name="error"/>
-                                </style>
                               </object>
                             </child>
                           </object>
@@ -91,90 +86,81 @@
                       </object>
                     </child>
                   </object>
-                </child>
+                </property>
               </object>
-            </child>
+            </property>
           </object>
         </child>
         <child>
-          <object class="GtkBox" id="code_step">
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="AdwHeaderBar">
-                <property name="show-end-title-buttons">false</property>
-                <property name="show-start-title-buttons">false</property>
-                <style>
-                    <class name="flat"/>
-                    <class name="no-title"/>
-                </style>
-                <child>
-                  <object class="GtkButton">
-                    <property name="label" translatable="yes">Back</property>
-                    <signal name="clicked" handler="on_back_clicked" swapped="no"/>
+          <object class="AdwNavigationPage" id="code_step">
+            <property name="child">
+              <object class="AdwToolbarView">
+                <child type="top">
+                  <object class="AdwHeaderBar">
+                    <child type="end">
+                      <object class="GtkButton">
+                        <property name="receives_default">1</property>
+                        <property name="label" translatable="yes">Next</property>
+                        <property name="visible" bind-source="TubaDialogsNewAccount" bind-property="use-auto-auth" bind-flags="sync-create|invert-boolean"/>"
+                        <property name="sensitive" bind-source="TubaDialogsNewAccount" bind-property="is_working" bind-flags="sync-create|invert-boolean"/>
+                        <signal name="clicked" handler="on_next_clicked" swapped="no"/>"
+                        <style>
+                          <class name="suggested-action"/>
+                        </style>
+                      </object>
+                    </child>
                   </object>
                 </child>
-                <child type="end">
-                  <object class="GtkButton">
-                    <property name="receives_default">1</property>
-                    <property name="label" translatable="yes">Next</property>
-                    <property name="visible" bind-source="TubaDialogsNewAccount" bind-property="use-auto-auth" bind-flags="sync-create|invert-boolean"/>
-                    <property name="sensitive" bind-source="TubaDialogsNewAccount" bind-property="is_working" bind-flags="sync-create|invert-boolean"/>
-                    <signal name="clicked" handler="on_next_clicked" swapped="no"/>
+                <property name="content">
+                  <object class="AdwStatusPage" id="auth_page">
+                    <property name="vexpand">1</property>
+                    <property name="icon_name">tuba-key-password-symbolic</property>
+                    <property name="title" translatable="yes">Confirm Authorization</property>
                     <style>
-                      <class name="suggested-action"/>
+                        <class name="compact"/>
                     </style>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="AdwStatusPage" id="auth_page">
-                <property name="vexpand">1</property>
-                <property name="icon_name">tuba-key-password-symbolic</property>
-                <property name="title" translatable="yes">Confirm Authorization</property>
-                <style>
-                    <class name="compact"/>
-                </style>
-                <child>
-                  <object class="AdwClamp">
-                    <property name="maximum-size">400</property>
                     <child>
-                      <object class="GtkBox">
-                        <property name="margin_top">24</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">12</property>
+                      <object class="AdwClamp">
+                        <property name="maximum-size">400</property>
                         <child>
                           <object class="GtkBox">
+                            <property name="margin_top">24</property>
                             <property name="orientation">vertical</property>
-                            <property name="spacing">6</property>
+                            <property name="spacing">12</property>
                             <child>
-                              <object class="GtkLabel" id="manual_auth_label">
-                                <property name="visible" bind-source="TubaDialogsNewAccount" bind-property="use_auto_auth" bind-flags="sync-create"/>
-                                <!-- translators: Do not translate "manual_auth" -->
-                                <property name="label" translatable="yes">If something went wrong, &lt;a href=&quot;manual_auth&quot;&gt;try manual authorization&lt;/a&gt;.</property>
-                                <property name="use_markup">1</property>
-                                <property name="wrap">1</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="AdwPreferencesGroup">
-                                <property name="visible" bind-source="TubaDialogsNewAccount" bind-property="use_auto_auth" bind-flags="sync-create|invert-boolean"/>
+                              <object class="GtkBox">
+                                <property name="orientation">vertical</property>
+                                <property name="spacing">6</property>
                                 <child>
-                                  <object class="AdwEntryRow" id="code_entry">
-                                    <property name="title" translatable="true">Authorization Code</property>
-                                    <signal name="entry_activated" handler="on_next_clicked" swapped="no"/>
-                                    <signal name="changed" handler="clear_errors" swapped="no"/>
+                                  <object class="GtkLabel" id="manual_auth_label">
+                                    <property name="visible" bind-source="TubaDialogsNewAccount" bind-property="use_auto_auth" bind-flags="sync-create"/>
+                                    <!-- translators: Do not translate "manual_auth" -->
+                                    <property name="label" translatable="yes">If something went wrong, &lt;a href=&quot;manual_auth&quot;&gt;try manual authorization&lt;/a&gt;.</property>
+                                    <property name="use_markup">1</property>
+                                    <property name="wrap">1</property>
                                   </object>
                                 </child>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="code_entry_error">
-                                <property name="label" translatable="yes"></property>
-                                <property name="wrap">1</property>
-                                <style>
-                                  <class name="error"/>
-                                </style>
+                                <child>
+                                  <object class="AdwPreferencesGroup">
+                                    <property name="visible" bind-source="TubaDialogsNewAccount" bind-property="use_auto_auth" bind-flags="sync-create|invert-boolean"/>
+                                    <child>
+                                      <object class="AdwEntryRow" id="code_entry">
+                                        <property name="title" translatable="true">Authorization Code</property>
+                                        <signal name="entry_activated" handler="on_next_clicked" swapped="no"/>
+                                        <signal name="changed" handler="clear_errors" swapped="no"/>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="code_entry_error">
+                                    <property name="label" translatable="yes"></property>
+                                    <property name="wrap">1</property>
+                                    <style>
+                                      <class name="error"/>
+                                    </style>
+                                  </object>
+                                </child>
                               </object>
                             </child>
                           </object>
@@ -182,46 +168,45 @@
                       </object>
                     </child>
                   </object>
-                </child>
+                </property>
               </object>
-            </child>
+            </property>
           </object>
         </child>
         <child>
-          <object class="GtkBox" id="done_step">
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="AdwHeaderBar">
-                <property name="show-end-title-buttons">false</property>
-                <property name="show-start-title-buttons">false</property>
-                <style>
-                    <class name="flat"/>
-                    <class name="no-title"/>
-                </style>
-                <child type="end">
-                  <object class="GtkButton">
-                    <property name="receives_default">1</property>
-                    <property name="label" translatable="yes">Done</property>
-                    <property name="sensitive" bind-source="TubaDialogsNewAccount" bind-property="is_working" bind-flags="sync-create|invert-boolean"/>
-                    <signal name="clicked" handler="on_done_clicked" swapped="no"/>
-                    <style>
-                      <class name="suggested-action"/>
-                    </style>
+          <object class="AdwNavigationPage" id="done_step">
+            <property name="can-pop">0</property>
+            <property name="child">
+              <object class="AdwToolbarView">
+                <child type="top">
+                  <object class="AdwHeaderBar">
+                    <property name="show-back-button">0</property>
+                    <child type="end">
+                      <object class="GtkButton">
+                        <property name="receives_default">1</property>
+                        <property name="label" translatable="yes">Done</property>
+                        <property name="sensitive" bind-source="TubaDialogsNewAccount" bind-property="is_working" bind-flags="sync-create|invert-boolean"/>
+                        <signal name="clicked" handler="on_done_clicked" swapped="no"/>
+                        <style>
+                          <class name="suggested-action"/>
+                        </style>
+                      </object>
+                    </child>
                   </object>
                 </child>
+                <property name="content">
+                  <object class="AdwStatusPage" id="done_page">
+                    <property name="vexpand">1</property>
+                    <property name="icon_name">tuba-check-round-outline-symbolic</property>
+                    <property name="title">Hello!</property>
+                    <property name="description" translatable="true">Your account is connected and ready to use!</property>
+                    <style>
+                        <class name="compact"/>
+                    </style>
+                  </object>
+                </property>
               </object>
-            </child>
-            <child>
-              <object class="AdwStatusPage" id="done_page">
-                <property name="vexpand">1</property>
-                <property name="icon_name">tuba-check-round-outline-symbolic</property>
-                <property name="title">Hello!</property>
-                <property name="description" translatable="true">Your account is connected and ready to use!</property>
-                <style>
-                    <class name="compact"/>
-                </style>
-              </object>
-            </child>
+            </property>
           </object>
         </child>
       </object>

--- a/data/ui/dialogs/preferences.ui
+++ b/data/ui/dialogs/preferences.ui
@@ -35,78 +35,42 @@
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="larger_font_size">
                 <property name="title" translatable="yes">Larger font size</property>
-                <property name="activatable_widget">larger_font_size</property>
                 <property name="subtitle" translatable="yes">Makes the font larger for posts</property>
-                <child>
-                  <object class="GtkSwitch" id="larger_font_size">
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="larger_line_height">
                 <property name="title" translatable="yes">Larger line height</property>
-                <property name="activatable_widget">larger_line_height</property>
                 <property name="subtitle" translatable="yes">Makes the line height larger for posts</property>
-                <child>
-                  <object class="GtkSwitch" id="larger_line_height">
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="enlarge_custom_emojis">
                 <property name="title" translatable="yes">Enlarge custom emojis</property>
-                <property name="activatable_widget">enlarge_custom_emojis</property>
-                <child>
-                  <object class="GtkSwitch" id="enlarge_custom_emojis">
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="scale_emoji_hover">
                 <property name="title" translatable="yes">Scale up custom emojis on hover</property>
-                <property name="activatable_widget">scale_emoji_hover</property>
                 <property name="subtitle" translatable="yes">Makes custom emojis slightly bigger when you hover over them</property>
-                <child>
-                  <object class="GtkSwitch" id="scale_emoji_hover">
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="letterbox_media">
                 <!-- translators: if unsure, you can find the translation on glitch-soc https://github.com/glitch-soc/mastodon/tree/main/app/javascript/flavours/glitch/locales under the key "settings.media_letterbox" -->
                 <property name="title" translatable="yes">Letterbox Media</property>
-                <property name="activatable_widget">letterbox_media</property>
                 <!-- translators: if unsure, you can find the translation on glitch-soc https://github.com/glitch-soc/mastodon/tree/main/app/javascript/flavours/glitch/locales under the key "settings.media_letterbox_hint" -->
                 <property name="subtitle" translatable="yes">Scale down and letterbox media to fill the image containers instead of stretching and cropping them</property>
-                <child>
-                  <object class="GtkSwitch" id="letterbox_media">
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="media_viewer_expand_pictures">
                 <!-- translators: expand as in enlarge -->
                 <property name="title" translatable="yes">Expand pictures in media viewer</property>
-                <property name="activatable_widget">media_viewer_expand_pictures</property>
                 <!-- translators: expand as in enlarge -->
                 <property name="subtitle" translatable="yes">Expand pictures to fill the media viewer by default</property>
-                <child>
-                  <object class="GtkSwitch" id="media_viewer_expand_pictures">
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
           </object>
@@ -138,41 +102,23 @@
           <object class="AdwPreferencesGroup">
             <property name="title" translatable="yes">Behavior</property>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="autostart">
                 <property name="title" translatable="yes">Autostart</property>
-                <property name="activatable_widget">autostart</property>
                 <property name="subtitle" translatable="yes">Start minimized at boot</property>
                 <property name="sensitive">0</property>
-                <child>
-                  <object class="GtkSwitch" id="autostart">
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="work_in_background">
                 <property name="title" translatable="yes">Background work</property>
-                <property name="activatable_widget">work_in_background</property>
                 <property name="subtitle" translatable="yes">Receive notifications even when the app is closed</property>
-                <child>
-                  <object class="GtkSwitch" id="work_in_background">
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="strip_tracking">
                 <property name="title" translatable="yes">Strip tracking parameters from links</property>
-                <property name="activatable_widget">strip_tracking</property>
                 <!-- translators: Broken as in incorrect -->
                 <property name="subtitle" translatable="yes">It can lead to broken links</property>
-                <child>
-                  <object class="GtkSwitch" id="strip_tracking">
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
           </object>
@@ -181,64 +127,34 @@
           <object class="AdwPreferencesGroup">
             <property name="title" translatable="yes">Timelines</property>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSpinRow" id="timeline_page_size">
                 <property name="title" translatable="yes">Posts per load batch</property>
-                <property name="activatable_widget">timeline_page_size</property>
-                <child>
-                  <object class="GtkSpinButton" id="timeline_page_size">
-                    <property name="valign">center</property>
-                    <property name="text">10</property>
-                    <property name="adjustment">page_adjustment</property>
-                    <property name="value">10</property>
-                  </object>
-                </child>
+                <property name="text">10</property>
+                <property name="adjustment">page_adjustment</property>
+                <property name="value">10</property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow" id="live_updates_row">
+              <object class="AdwSwitchRow" id="live_updates">
                 <property name="title" translatable="yes">Stream timelines</property>
-                <property name="activatable_widget">live_updates</property>
                 <property name="subtitle" translatable="yes">Receive new posts and notifications in real-time</property>
-                <child>
-                  <object class="GtkSwitch" id="live_updates">
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
-                <property name="sensitive" bind-source="live_updates" bind-property="state" bind-flags="sync-create"/>
+              <object class="AdwSwitchRow" id="public_live_updates">
+                <property name="sensitive" bind-source="live_updates" bind-property="active" bind-flags="sync-create"/>
                 <property name="title" translatable="yes">Stream public timelines</property>
-                <property name="activatable_widget">public_live_updates</property>
                 <property name="subtitle" translatable="yes">Warning: This will increase memory usage</property>
-                <child>
-                  <object class="GtkSwitch" id="public_live_updates">
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="show_spoilers">
                 <property name="title" translatable="yes">Reveal spoilers by default</property>
-                <property name="activatable_widget">show_spoilers</property>
-                <child>
-                  <object class="GtkSwitch" id="show_spoilers">
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="hide_preview_cards">
                 <property name="title" translatable="yes">Hide link preview cards</property>
-                <property name="activatable_widget">hide_preview_cards</property>
-                <child>
-                  <object class="GtkSwitch" id="hide_preview_cards">
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
           </object>
@@ -247,87 +163,45 @@
           <object class="AdwPreferencesGroup">
             <property name="title" translatable="yes">Push Notifications</property>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="new_followers_notifications_switch">
                 <property name="title" translatable="yes">New Followers</property>
-                <property name="activatable-widget">new_followers_notifications_switch</property>
-                <child>
-                  <object class="GtkSwitch" id="new_followers_notifications_switch">
-                    <property name="valign">center</property>
-                    <property name="active">1</property>
-                  </object>
-                </child>
+                <property name="active">1</property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="new_follower_requests_notifications_switch">
                 <property name="title" translatable="yes">New Follower Requests</property>
-                <property name="activatable-widget">new_follower_requests_notifications_switch</property>
-                <child>
-                  <object class="GtkSwitch" id="new_follower_requests_notifications_switch">
-                    <property name="valign">center</property>
-                    <property name="active">1</property>
-                  </object>
-                </child>
+                <property name="active">1</property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="favorites_notifications_switch">
                 <property name="title" translatable="yes">Favorites</property>
-                <property name="activatable-widget">favorites_notifications_switch</property>
-                <child>
-                  <object class="GtkSwitch" id="favorites_notifications_switch">
-                    <property name="valign">center</property>
-                    <property name="active">1</property>
-                  </object>
-                </child>
+                <property name="active">1</property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="mentions_notifications_switch">
                 <property name="title" translatable="yes">Mentions</property>
-                <property name="activatable-widget">mentions_notifications_switch</property>
-                <child>
-                  <object class="GtkSwitch" id="mentions_notifications_switch">
-                    <property name="valign">center</property>
-                    <property name="active">1</property>
-                  </object>
-                </child>
+                <property name="active">1</property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="boosts_notifications_switch">
                 <property name="title" translatable="yes">Boosts</property>
-                <property name="activatable-widget">boosts_notifications_switch</property>
-                <child>
-                  <object class="GtkSwitch" id="boosts_notifications_switch">
-                    <property name="valign">center</property>
-                    <property name="active">1</property>
-                  </object>
-                </child>
+                <property name="active">1</property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="poll_results_notifications_switch">
                 <property name="title" translatable="yes">Poll Results</property>
-                <property name="activatable-widget">poll_results_notifications_switch</property>
-                <child>
-                  <object class="GtkSwitch" id="poll_results_notifications_switch">
-                    <property name="valign">center</property>
-                    <property name="active">1</property>
-                  </object>
-                </child>
+                <property name="active">1</property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="edits_notifications_switch">
                 <property name="title" translatable="yes">Edits</property>
-                <property name="activatable-widget">edits_notifications_switch</property>
-                <child>
-                  <object class="GtkSwitch" id="edits_notifications_switch">
-                    <property name="valign">center</property>
-                    <property name="active">1</property>
-                  </object>
-                </child>
+                <property name="active">1</property>
               </object>
             </child>
           </object>

--- a/data/ui/views/base.ui
+++ b/data/ui/views/base.ui
@@ -13,12 +13,6 @@
         <property name="centering_policy">strict</property>
         <property name="visible">True</property>
         <property name="hexpand">True</property>
-        <child>
-          <object class="GtkButton" id="back_button">
-            <property name="icon_name">tuba-left-large-symbolic</property>
-            <signal name="clicked" handler="on_close" swapped="no" />
-          </object>
-        </child>
       </object>
     </child>
 

--- a/data/ui/views/base.ui
+++ b/data/ui/views/base.ui
@@ -2,169 +2,172 @@
 <interface>
   <requires lib="gtk" version="4.0" />
   <requires lib="libadwaita" version="1.0" />
-  <template class="TubaViewsBase" parent="GtkBox">
-    <property name="orientation">vertical</property>
+  <template class="TubaViewsBase" parent="AdwBreakpointBin">
     <property name="width_request">360</property>
+    <property name="height_request">200</property>
     <style>
       <class name="background" />
     </style>
-    <child>
-      <object class="AdwHeaderBar" id="header">
-        <property name="centering_policy">strict</property>
-        <property name="visible">True</property>
-        <property name="hexpand">True</property>
-      </object>
-    </child>
 
     <child>
-      <object class="GtkOverlay" id="scrolled_overlay">
-        <child type="overlay">
-          <object class="GtkButton" id="scroll_to_top">
-            <property name="icon-name">go-top-symbolic</property>
-            <property name="valign">end</property>
-            <property name="halign">end</property>
-            <property name="margin_end">16</property>
-            <property name="margin_bottom">16</property>
-            <property name="visible">0</property>
-            <style>
-              <class name="circular" />
-              <class name="osd" />
-            </style>
-          </object>
+      <object class="AdwToolbarView" id="toolbar_view">
+
+        <child type="top">
+          <object class="AdwHeaderBar" id="header"/>
         </child>
 
-        <property name="child">
-          <object class="GtkStack" id="states">
-            <property name="vexpand">1</property>
-            <property name="vhomogeneous">0</property>
-            <property name="transition_type">crossfade</property>
-            <property name="interpolate_size">1</property>
-            <child>
-              <object class="GtkStackPage">
-                <property name="name">status</property>
-                <property name="child">
-                  <object class="GtkScrolledWindow">
-                    <property name="vexpand">1</property>
-                    <property name="hscrollbar_policy">never</property>
+        <property name="content">
+          <object class="GtkOverlay" id="scrolled_overlay">
+            <child type="overlay">
+              <object class="GtkButton" id="scroll_to_top">
+                <property name="icon-name">go-top-symbolic</property>
+                <property name="valign">end</property>
+                <property name="halign">end</property>
+                <property name="margin_end">16</property>
+                <property name="margin_bottom">16</property>
+                <property name="visible">0</property>
+                <style>
+                  <class name="circular" />
+                  <class name="osd" />
+                </style>
+              </object>
+            </child>
+
+            <property name="child">
+              <object class="GtkStack" id="states">
+                <property name="vexpand">1</property>
+                <property name="vhomogeneous">0</property>
+                <property name="transition_type">crossfade</property>
+                <property name="interpolate_size">1</property>
+                <child>
+                  <object class="GtkStackPage">
+                    <property name="name">status</property>
                     <property name="child">
-                      <object class="GtkViewport">
+                      <object class="GtkScrolledWindow">
+                        <property name="vexpand">1</property>
+                        <property name="hscrollbar_policy">never</property>
                         <property name="child">
-                          <object class="AdwClamp">
-                            <property name="vexpand">1</property>
-                            <property name="visible">True</property>
-                            <property name="maximum_size">670</property>
-                            <property name="tightening_threshold">670</property>
-                            <child>
-                              <object class="GtkBox" id="status">
-                                <property name="valign">center</property>
-                                <property name="margin_top">16</property>
-                                <property name="margin_bottom">16</property>
-                                <property name="orientation">vertical</property>
-                                <property name="spacing">16</property>
+                          <object class="GtkViewport">
+                            <property name="child">
+                              <object class="AdwClamp">
+                                <property name="vexpand">1</property>
+                                <property name="visible">True</property>
+                                <property name="maximum_size">670</property>
+                                <property name="tightening_threshold">670</property>
                                 <child>
-                                  <object class="GtkImage">
-                                    <property name="width_request">128</property>
-                                    <property name="height_request">128</property>
-                                    <property name="pixel_size">128</property>
-                                    <property name="icon_name">dev.geopjr.Tuba-symbolic</property>
-                                    <style>
-                                      <class name="dim-label" />
-                                    </style>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkStack" id="status_stack">
-                                    <property name="transition_type">crossfade</property>
+                                  <object class="GtkBox" id="status">
+                                    <property name="valign">center</property>
+                                    <property name="margin_top">16</property>
+                                    <property name="margin_bottom">16</property>
+                                    <property name="orientation">vertical</property>
+                                    <property name="spacing">16</property>
                                     <child>
-                                      <object class="GtkStackPage">
-                                        <property name="name">message</property>
-                                        <property name="child">
-                                          <object class="GtkBox">
-                                            <property name="orientation">vertical</property>
-                                            <property name="valign">center</property>
-                                            <property name="spacing">12</property>
-                                            <child>
-                                              <object class="GtkLabel" id="status_title_label">
-                                                <property name="wrap">1</property>
-                                                <property name="wrap-mode">word-char</property>
-                                                <property name="justify">center</property>
-                                                <style>
-                                                  <class name="title" />
-                                                  <class name="title-1" />
-                                                </style>
-                                              </object>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel" id="status_message_label">
-                                                <property name="wrap">1</property>
-                                                <property name="wrap-mode">word-char</property>
-                                                <property name="justify">center</property>
-                                                <style>
-                                                  <class name="body" />
-                                                  <class name="description" />
-                                                </style>
-                                              </object>
-                                            </child>
-                                          </object>
-                                        </property>
+                                      <object class="GtkImage">
+                                        <property name="width_request">128</property>
+                                        <property name="height_request">128</property>
+                                        <property name="pixel_size">128</property>
+                                        <property name="icon_name">dev.geopjr.Tuba-symbolic</property>
+                                        <style>
+                                          <class name="dim-label" />
+                                        </style>
                                       </object>
                                     </child>
                                     <child>
-                                      <object class="GtkStackPage">
-                                        <property name="name">spinner</property>
-                                        <property name="child">
-                                          <object class="GtkSpinner" id="status_spinner">
-                                            <property name="height_request">32</property>
-                                            <property name="valign">center</property>
+                                      <object class="GtkStack" id="status_stack">
+                                        <property name="transition_type">crossfade</property>
+                                        <child>
+                                          <object class="GtkStackPage">
+                                            <property name="name">message</property>
+                                            <property name="child">
+                                              <object class="GtkBox">
+                                                <property name="orientation">vertical</property>
+                                                <property name="valign">center</property>
+                                                <property name="spacing">12</property>
+                                                <child>
+                                                  <object class="GtkLabel" id="status_title_label">
+                                                    <property name="wrap">1</property>
+                                                    <property name="wrap-mode">word-char</property>
+                                                    <property name="justify">center</property>
+                                                    <style>
+                                                      <class name="title" />
+                                                      <class name="title-1" />
+                                                    </style>
+                                                  </object>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkLabel" id="status_message_label">
+                                                    <property name="wrap">1</property>
+                                                    <property name="wrap-mode">word-char</property>
+                                                    <property name="justify">center</property>
+                                                    <style>
+                                                      <class name="body" />
+                                                      <class name="description" />
+                                                    </style>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                            </property>
                                           </object>
-                                        </property>
+                                        </child>
+                                        <child>
+                                          <object class="GtkStackPage">
+                                            <property name="name">spinner</property>
+                                            <property name="child">
+                                              <object class="GtkSpinner" id="status_spinner">
+                                                <property name="height_request">32</property>
+                                                <property name="valign">center</property>
+                                              </object>
+                                            </property>
+                                          </object>
+                                        </child>
                                       </object>
                                     </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkButton" id="status_button">
-                                    <property name="visible">0</property>
-                                    <property name="halign">center</property>
-                                    <style>
-                                      <class name="pill" />
-                                    </style>
+                                    <child>
+                                      <object class="GtkButton" id="status_button">
+                                        <property name="visible">0</property>
+                                        <property name="halign">center</property>
+                                        <style>
+                                          <class name="pill" />
+                                        </style>
+                                      </object>
+                                    </child>
                                   </object>
                                 </child>
                               </object>
-                            </child>
+                            </property>
                           </object>
                         </property>
                       </object>
                     </property>
                   </object>
-                </property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkStackPage">
-                <property name="name">content</property>
-                <property name="child">
-                  <object class="GtkScrolledWindow" id="scrolled">
-                    <property name="vexpand">1</property>
-                    <property name="hscrollbar_policy">never</property>
+                </child>
+                <child>
+                  <object class="GtkStackPage">
+                    <property name="name">content</property>
                     <property name="child">
-                      <object class="AdwClampScrollable" id="content_box">
+                      <object class="GtkScrolledWindow" id="scrolled">
                         <property name="vexpand">1</property>
-                        <property name="visible">True</property>
-                        <property name="maximum_size">670</property>
-                        <property name="tightening_threshold">670</property>
-                        <style>
-                          <class name="ttl-view" />
-                        </style>
+                        <property name="hscrollbar_policy">never</property>
+                        <property name="child">
+                          <object class="AdwClampScrollable" id="content_box">
+                            <property name="vexpand">1</property>
+                            <property name="visible">True</property>
+                            <property name="maximum_size">670</property>
+                            <property name="tightening_threshold">670</property>
+                            <style>
+                              <class name="ttl-view" />
+                            </style>
+                          </object>
+                        </property>
                       </object>
                     </property>
                   </object>
-                </property>
+                </child>
               </object>
-            </child>
+            </property>
           </object>
         </property>
+
       </object>
     </child>
 

--- a/data/ui/views/sidebar/view.ui
+++ b/data/ui/views/sidebar/view.ui
@@ -1,138 +1,139 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <template class="TubaViewsSidebar" parent="GtkBox">
+  <template class="TubaViewsSidebar" parent="GtkWidget">
     <property name="width_request">200</property>
-    <property name="orientation">vertical</property>
     <property name="hexpand">false</property>
 
     <child>
-      <object class="AdwHeaderBar" id="sb_header">
-        <child type="start">
-          <object class="GtkButton" id="compose_button">
-            <property name="icon-name">document-edit-symbolic</property>
-            <property name="action-name">app.compose</property>
-            <property name="tooltip_text" translatable="yes">Compose</property>
+      <object class="AdwToolbarView">
+        <child type="top">
+          <object class="AdwHeaderBar">
+            <child type="start">
+              <object class="GtkButton" id="compose_button">
+                <property name="icon-name">document-edit-symbolic</property>
+                <property name="action-name">app.compose</property>
+                <property name="tooltip_text" translatable="yes">Compose</property>
+              </object>
+            </child>
+            <child type="end">
+              <object class="GtkToggleButton" id="accounts_button">
+                <property name="icon-name">tuba-people-symbolic</property>
+                <signal name="toggled" handler="on_mode_changed"/>
+                <property name="tooltip_text" translatable="yes">Switch Account</property>
+              </object>
+            </child>
           </object>
         </child>
-        <child type="end">
-          <object class="GtkToggleButton" id="accounts_button">
-            <property name="icon-name">tuba-people-symbolic</property>
-            <signal name="toggled" handler="on_mode_changed"/>
-            <property name="tooltip_text" translatable="yes">Switch Account</property>
-          </object>
-        </child>
-      </object>
-    </child>
 
-    <child>
-      <object class="GtkScrolledWindow">
-        <property name="vexpand">1</property>
-        <property name="child">
-          <object class="GtkViewport">
-            <child>
-              <object class="GtkStack" id="mode">
-                <property name="transition_type">crossfade</property>
-
-                <!-- Account actions -->
+        <property name="content">
+          <object class="GtkScrolledWindow">
+            <property name="vexpand">1</property>
+            <property name="child">
+              <object class="GtkViewport">
                 <child>
-                <object class="GtkStackPage">
-                <property name="name">items</property>
-                <property name="child">
-                  <object class="GtkBox">
-                  <property name="orientation">vertical</property>
+                  <object class="GtkStack" id="mode">
+                    <property name="transition_type">crossfade</property>
 
-                  <!-- Header -->
-                  <child>
-                    <object class="GtkButton">
-                      <signal name="clicked" handler="on_open"/>
+                    <!-- Account actions -->
+                    <child>
+                    <object class="GtkStackPage">
+                    <property name="name">items</property>
+                    <property name="child">
+                      <object class="GtkBox">
+                      <property name="orientation">vertical</property>
+
+                      <!-- Header -->
                       <child>
-                        <object class="GtkBox">
-                          <property name="orientation">vertical</property>
-                          <property name="margin-start">12</property>
-                          <property name="margin-end">12</property>
-                          <property name="margin-top">12</property>
-                          <property name="margin-bottom">12</property>
-                          <property name="spacing">12</property>
-                          <child>
-                            <object class="TubaWidgetsAvatar" id="avatar">
-                              <property name="size">48</property>
-                              <property name="halign">start</property>
-                            </object>
-                          </child>
+                        <object class="GtkButton">
+                          <signal name="clicked" handler="on_open"/>
                           <child>
                             <object class="GtkBox">
                               <property name="orientation">vertical</property>
-                              <property name="valign">center</property>
-                              <property name="hexpand">true</property>
-                              <property name="spacing">4</property>
+                              <property name="margin-start">12</property>
+                              <property name="margin-end">12</property>
+                              <property name="margin-top">12</property>
+                              <property name="margin-bottom">12</property>
+                              <property name="spacing">12</property>
                               <child>
-                                <object class="TubaWidgetsEmojiLabel" id="title">
+                                <object class="TubaWidgetsAvatar" id="avatar">
+                                  <property name="size">48</property>
+                                  <property name="halign">start</property>
                                 </object>
                               </child>
                               <child>
-                                <object class="GtkLabel" id="subtitle">
-                                  <property name="label">Handle</property>
-                                  <property name="xalign">0</property>
-                                  <property name="lines">0</property>
-                                  <property name="wrap">1</property>
-                                  <property name="wrap_mode">word-char</property>
-                                  <style>
-                                    <class name="body"/>
-                                    <class name="dim-label"/>
-                                  </style>
+                                <object class="GtkBox">
+                                  <property name="orientation">vertical</property>
+                                  <property name="valign">center</property>
+                                  <property name="hexpand">true</property>
+                                  <property name="spacing">4</property>
+                                  <child>
+                                    <object class="TubaWidgetsEmojiLabel" id="title">
+                                    </object>
+                                  </child>
+                                  <child>
+                                    <object class="GtkLabel" id="subtitle">
+                                      <property name="label">Handle</property>
+                                      <property name="xalign">0</property>
+                                      <property name="lines">0</property>
+                                      <property name="wrap">1</property>
+                                      <property name="wrap_mode">word-char</property>
+                                      <style>
+                                        <class name="body"/>
+                                        <class name="dim-label"/>
+                                      </style>
+                                    </object>
+                                  </child>
                                 </object>
                               </child>
                             </object>
                           </child>
+                          <style>
+                            <class name="flat"/>
+                            <class name="no-border-radius"/>
+                          </style>
                         </object>
                       </child>
-                      <style>
-                        <class name="flat"/>
-                        <class name="no-border-radius"/>
-                      </style>
-                    </object>
+
+                    <child>
+                      <object class="GtkSeparator">
+                      </object>
+                    </child>
+
+                      <child>
+                        <object class="GtkListBox" id="items">
+                          <property name="selection_mode">single</property>
+                          <signal name="row_activated" handler="on_item_activated"/>
+                          <style>
+                            <class name="navigation-sidebar"/>
+                          </style>
+                        </object>
+                      </child>
+
+                  </object>
+                  </property>
+                  </object>
                   </child>
 
-                <child>
-                  <object class="GtkSeparator">
-                  </object>
-                </child>
-
-                  <child>
-                    <object class="GtkListBox" id="items">
+                    <!-- Active account menu -->
+                    <child><object class="GtkStackPage"><property name="name">saved_accounts</property><property name="child">
+                    <object class="GtkListBox" id="saved_accounts">
                       <property name="selection_mode">single</property>
-                      <signal name="row_activated" handler="on_item_activated"/>
+                      <signal name="row_activated" handler="on_account_activated"/>
                       <style>
                         <class name="navigation-sidebar"/>
                       </style>
                     </object>
-                  </child>
+                    </property>
+                    </object></child>
 
+                  </object>
+                </child>
               </object>
-              </property>
-              </object>
-              </child>
-
-                <!-- Active account menu -->
-                <child><object class="GtkStackPage"><property name="name">saved_accounts</property><property name="child">
-                <object class="GtkListBox" id="saved_accounts">
-                  <property name="selection_mode">single</property>
-                  <signal name="row_activated" handler="on_account_activated"/>
-                  <style>
-                    <class name="navigation-sidebar"/>
-                  </style>
-                </object>
-                </property>
-                </object></child>
-
-              </object>
-            </child>
+            </property>
           </object>
         </property>
       </object>
     </child>
-
-
     <style>
       <class name="ttl-sidebar"/>
     </style>

--- a/data/ui/views/sidebar/view.ui
+++ b/data/ui/views/sidebar/view.ui
@@ -7,8 +7,6 @@
 
     <child>
       <object class="AdwHeaderBar" id="sb_header">
-        <property name="show-start-title-buttons">0</property>
-        <property name="show-end-title-buttons">0</property>
         <child type="start">
           <object class="GtkButton" id="compose_button">
             <property name="icon-name">document-edit-symbolic</property>
@@ -136,7 +134,7 @@
 
 
     <style>
-      <class name="sidebar"/>
+      <class name="ttl-sidebar"/>
     </style>
 
   </template>

--- a/meson.build
+++ b/meson.build
@@ -61,7 +61,7 @@ asresources = gnome.compile_resources(
 )
 
 libgtk_dep = dependency('gtk4', version: '>=4.10.0', required: true)
-libadwaita_dep = dependency('libadwaita-1', version: '>=1.2', required: true)
+libadwaita_dep = dependency('libadwaita-1', version: '>=1.4', required: true)
 gtksourceview_dep = dependency('gtksourceview-5', required: true, version: '>=5.6.0')
 libwebp_dep = dependency('libwebp', required: false)
 gspell = dependency('gspell-4', required: false)

--- a/src/API/Attachment.vala
+++ b/src/API/Attachment.vala
@@ -25,7 +25,7 @@ public class Tuba.API.Attachment : Entity, Widgetizable {
 	//  }
 
 	public static async Attachment upload (string uri) throws Error {
-		message (@"Uploading new media: $(uri)…");
+		debug (@"Uploading new media: $(uri)…");
 
 		uint8[] contents;
 		string mime;
@@ -67,7 +67,7 @@ public class Tuba.API.Attachment : Entity, Widgetizable {
 			var parser = Network.get_parser_from_inputstream (in_stream);
 			var node = network.parse_node (parser);
 			var entity = accounts.active.create_entity<API.Attachment> (node);
-			message (@"OK! ID $(entity.id)");
+			debug (@"OK! ID $(entity.id)");
 			return entity;
 		}
 	}

--- a/src/API/Poll.vala
+++ b/src/API/Poll.vala
@@ -50,7 +50,7 @@ public class Tuba.API.Poll : GLib.Object, Json.Serializable {
         Gee.ArrayList<string> selection,
         string id
     ) {
-        message (@"Voting poll $(id)…");
+        debug (@"Voting poll $(id)…");
  		  //Creating json to send
         var builder = new Json.Builder ();
         builder.begin_object ();

--- a/src/API/Relationship.vala
+++ b/src/API/Relationship.vala
@@ -43,7 +43,7 @@ public class Tuba.API.Relationship : Entity {
 				var parser = Network.get_parser_from_inputstream (in_stream);
 				var node = network.parse_node (parser);
 				invalidate (node);
-				message (@"Performed \"$operation\" on Relationship $id");
+				debug (@"Performed \"$operation\" on Relationship $id");
 			});
 
 		if (param != null)

--- a/src/API/Status.vala
+++ b/src/API/Status.vala
@@ -1,7 +1,7 @@
 public class Tuba.API.Status : Entity, Widgetizable {
 
 	~Status () {
-		message (@"[OBJ] Destroyed $(uri ?? "")");
+		debug (@"[OBJ] Destroyed $(uri ?? "")");
 	}
 
     public string id { get; set; }

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -116,7 +116,7 @@ namespace Tuba {
 			try {
 				var lines = troubleshooting.split ("\n");
 				foreach (unowned string line in lines) {
-					message (line);
+					debug (line);
 				}
 				Adw.init ();
 				GtkSource.init ();
@@ -189,12 +189,12 @@ namespace Tuba {
 			if (accounts.saved.is_empty) {
 				if (main_window != null && destroy_main)
 					main_window.hide ();
-				message ("Presenting NewAccount dialog");
+				debug ("Presenting NewAccount dialog");
 				if (add_account_window == null)
 					new Dialogs.NewAccount ();
 				add_account_window.present ();
 			} else {
-				message ("Presenting MainWindow");
+				debug ("Presenting MainWindow");
 				if (main_window == null) {
 					main_window = new Dialogs.MainWindow (this);
 					is_rtl = Gtk.Widget.get_default_direction () == Gtk.TextDirection.RTL;

--- a/src/Dialogs/Composer/AttachmentsPage.vala
+++ b/src/Dialogs/Composer/AttachmentsPage.vala
@@ -114,7 +114,7 @@ public class Tuba.AttachmentsPage : ComposerPage {
 
 	private bool show_context_menu (double x, double y) {
 		if (!add_media_action_button.sensitive) return false;
-		message ("Context menu triggered");
+		debug ("Context menu triggered");
 
 		Gdk.Rectangle rectangle = {
 			(int) x,

--- a/src/Dialogs/Composer/AttachmentsPageAttachment.vala
+++ b/src/Dialogs/Composer/AttachmentsPageAttachment.vala
@@ -10,7 +10,7 @@ public class Tuba.AttachmentsPageAttachment : Widgets.Attachment.Item {
 
 	~AttachmentsPageAttachment () {
 		close_dialog ();
-		message ("Destroying AttachmentsPageAttachment");
+		debug ("Destroying AttachmentsPageAttachment");
 	}
 
     public AttachmentsPageAttachment (

--- a/src/Dialogs/Composer/Completion/CompletionProvider.vala
+++ b/src/Dialogs/Composer/Completion/CompletionProvider.vala
@@ -19,10 +19,10 @@ public abstract class Tuba.CompletionProvider: Object, GtkSource.CompletionProvi
 	protected bool set_input_capture (bool state) {
 		this.is_capturing_input = state;
 		if (state) {
-			message ("Capturing input");
+			debug ("Capturing input");
 		}
 		else {
-			message ("Stopped capturing input");
+			debug ("Stopped capturing input");
 			this.empty_triggers = 0;
 		}
 		return state;
@@ -66,7 +66,7 @@ public abstract class Tuba.CompletionProvider: Object, GtkSource.CompletionProvi
 
 		var word = context.get_word ();
 		if (word == "") {
-			message ("Empty trigger");
+			debug ("Empty trigger");
 			this.empty_triggers++;
 
 			if (this.empty_triggers > 1) {

--- a/src/Dialogs/Composer/Dialog.vala
+++ b/src/Dialogs/Composer/Dialog.vala
@@ -157,6 +157,7 @@ public class Tuba.Dialogs.Compose : Adw.Window {
 		add_binding_action (Gdk.Key.Q, Gdk.ModifierType.CONTROL_MASK, "composer.exit", null);
 
 		transient_for = app.main_window;
+		title_switcher.policy = WIDE;
 		title_switcher.stack = stack;
 
 		build_sigid = notify["status"].connect (() => {
@@ -252,7 +253,7 @@ public class Tuba.Dialogs.Compose : Adw.Window {
 		commit_button.sensitive = allow;
 	}
 
-	[GtkChild] unowned Adw.ViewSwitcherTitle title_switcher;
+	[GtkChild] unowned Adw.ViewSwitcher title_switcher;
 	[GtkChild] unowned Gtk.Button commit_button;
 
 	[GtkChild] unowned Adw.ViewStack stack;

--- a/src/Dialogs/Composer/Dialog.vala
+++ b/src/Dialogs/Composer/Dialog.vala
@@ -167,7 +167,7 @@ public class Tuba.Dialogs.Compose : Adw.Window {
 		});
 	}
 	~Compose () {
-		message ("Destroying composer");
+		debug ("Destroying composer");
 		foreach (var page in t_pages) {
 			page.dispose ();
 		}
@@ -437,7 +437,7 @@ public class Tuba.Dialogs.Compose : Adw.Window {
 		var parser = Network.get_parser_from_inputstream (publish_req.response_body);
 		var node = network.parse_node (parser);
 		var status = API.Status.from (node);
-		message (@"Published post with id $(status.id)");
+		debug (@"Published post with id $(status.id)");
 		if (cb != null) cb (status);
 
 		on_close ();

--- a/src/Dialogs/Composer/Page.vala
+++ b/src/Dialogs/Composer/Page.vala
@@ -28,7 +28,7 @@ public class Tuba.ComposerPage : Gtk.Box {
 	}
 
 	~ComposerPage () {
-		message (@"Destroying $title Page");
+		debug (@"Destroying $title Page");
 	}
 
 	construct {

--- a/src/Dialogs/ListEdit.vala
+++ b/src/Dialogs/ListEdit.vala
@@ -1,7 +1,7 @@
 [GtkTemplate (ui = "/dev/geopjr/Tuba/ui/dialogs/list_edit.ui")]
 public class Tuba.Dialogs.ListEdit : Adw.PreferencesWindow {
 	~ListEdit () {
-		message ("Destroying ListEdit");
+		debug ("Destroying ListEdit");
 	}
 
     public enum RepliesPolicy {

--- a/src/Dialogs/NewAccount.vala
+++ b/src/Dialogs/NewAccount.vala
@@ -75,7 +75,7 @@ public class Tuba.Dialogs.NewAccount: Adw.Window {
 	}
 
 	void reset () {
-		message ("Reset state");
+		debug ("Reset state");
 		clear_errors ();
 		use_auto_auth = true;
 		account = new InstanceAccount.empty (account.instance);
@@ -103,7 +103,7 @@ public class Tuba.Dialogs.NewAccount: Adw.Window {
 	}
 
 	void setup_instance () throws Error {
-		message ("Checking instance URL");
+		debug ("Checking instance URL");
 
 		var str = instance_entry.text
 			.replace ("/", "")
@@ -118,7 +118,7 @@ public class Tuba.Dialogs.NewAccount: Adw.Window {
 	}
 
 	async void register_client () throws Error {
-		message ("Registering client");
+		debug ("Registering client");
 
 		var msg = new Request.POST ("/api/v1/apps")
 			.with_account (account)
@@ -136,14 +136,14 @@ public class Tuba.Dialogs.NewAccount: Adw.Window {
 
 		account.client_id = root.get_string_member ("client_id");
 		account.client_secret = root.get_string_member ("client_secret");
-		message ("OK: Instance registered client");
+		debug ("OK: Instance registered client");
 
 		deck.visible_child = code_step;
 		open_confirmation_page ();
 	}
 
 	void open_confirmation_page () {
-		message ("Opening permission request page");
+		debug ("Opening permission request page");
 
 		var esc_scopes = Uri.escape_string (SCOPES);
 		var esc_redirect = Uri.escape_string (redirect_uri);
@@ -156,7 +156,7 @@ public class Tuba.Dialogs.NewAccount: Adw.Window {
 		if (code_entry.text.char_count () <= 10)
 			throw new Oopsie.USER (_("Please enter a valid authorization code"));
 
-		message ("Requesting access token");
+		debug ("Requesting access token");
 		var token_req = new Request.POST ("/oauth/token")
 			.with_account (account)
 			.with_form_data ("client_id", account.client_id)
@@ -177,19 +177,19 @@ public class Tuba.Dialogs.NewAccount: Adw.Window {
 
 		account = accounts.create_account (account.to_json ());
 
-		message ("Saving account");
+		debug ("Saving account");
 		accounts.add (account);
 
 		done_page.title = _("Hello, %s!").printf (account.display_name);
 		deck.visible_child = done_step;
 
-		message ("Switching to account");
+		debug ("Switching to account");
 		accounts.activate (account);
 	}
 
 	public void redirect (string t_uri) {
 		present ();
-		message (@"Received uri: $t_uri");
+		debug (@"Received uri: $t_uri");
 
 		string code_from_params = "";
 		try {

--- a/src/Dialogs/NewAccount.vala
+++ b/src/Dialogs/NewAccount.vala
@@ -10,10 +10,10 @@ public class Tuba.Dialogs.NewAccount: Adw.Window {
 	protected bool use_auto_auth { get; set; default = true; }
 	protected InstanceAccount account { get; set; default = new InstanceAccount.empty (""); }
 
-	[GtkChild] unowned Adw.Leaflet deck;
-	[GtkChild] unowned Gtk.Box instance_step;
-	[GtkChild] unowned Gtk.Box code_step;
-	[GtkChild] unowned Gtk.Box done_step;
+	[GtkChild] unowned Adw.NavigationView deck;
+	[GtkChild] unowned Adw.NavigationPage instance_step;
+	[GtkChild] unowned Adw.NavigationPage code_step;
+	[GtkChild] unowned Adw.NavigationPage done_step;
 
 	[GtkChild] unowned Adw.EntryRow instance_entry;
 	[GtkChild] unowned Gtk.Label instance_entry_error;
@@ -79,7 +79,7 @@ public class Tuba.Dialogs.NewAccount: Adw.Window {
 		clear_errors ();
 		use_auto_auth = true;
 		account = new InstanceAccount.empty (account.instance);
-		deck.visible_child = instance_step;
+		deck.pop_to_page (instance_step);
 	}
 
 	void oopsie (string title, string msg = "") {
@@ -89,7 +89,7 @@ public class Tuba.Dialogs.NewAccount: Adw.Window {
 	}
 
 	async void step () throws Error {
-		if (deck.visible_child == instance_step) {
+		if (deck.visible_page == instance_step) {
 			setup_instance ();
 			yield accounts.guess_backend (account);
 		}
@@ -138,7 +138,9 @@ public class Tuba.Dialogs.NewAccount: Adw.Window {
 		account.client_secret = root.get_string_member ("client_secret");
 		debug ("OK: Instance registered client");
 
-		deck.visible_child = code_step;
+		if (deck.visible_page != code_step) {
+			deck.push (code_step);
+		}
 		open_confirmation_page ();
 	}
 
@@ -181,7 +183,7 @@ public class Tuba.Dialogs.NewAccount: Adw.Window {
 		accounts.add (account);
 
 		done_page.title = _("Hello, %s!").printf (account.display_name);
-		deck.visible_child = done_step;
+		deck.push (done_step);
 
 		debug ("Switching to account");
 		accounts.activate (account);
@@ -257,13 +259,5 @@ public class Tuba.Dialogs.NewAccount: Adw.Window {
 	[GtkCallback]
 	void on_back_clicked () {
 		reset ();
-	}
-
-	[GtkCallback]
-	void on_visible_child_notify () {
-		if (!deck.child_transition_running && deck.visible_child == instance_step)
-			reset ();
-
-		deck.can_navigate_back = deck.visible_child != done_step;
 	}
 }

--- a/src/Dialogs/Preferences.vala
+++ b/src/Dialogs/Preferences.vala
@@ -1,35 +1,35 @@
 [GtkTemplate (ui = "/dev/geopjr/Tuba/ui/dialogs/preferences.ui")]
 public class Tuba.Dialogs.Preferences : Adw.PreferencesWindow {
 	struct NotificationTypeMute {
-		public Gtk.Switch switch_widget;
+		public Adw.SwitchRow switch_widget;
 		public string event;
 	}
 
     [GtkChild] unowned Adw.ComboRow scheme_combo_row;
     [GtkChild] unowned Adw.ComboRow post_visibility_combo_row;
     [GtkChild] unowned Adw.ComboRow default_language_combo_row;
-    [GtkChild] unowned Gtk.Switch autostart;
-    [GtkChild] unowned Gtk.Switch work_in_background;
-    [GtkChild] unowned Gtk.SpinButton timeline_page_size;
-    [GtkChild] unowned Gtk.Switch live_updates;
-    [GtkChild] unowned Gtk.Switch public_live_updates;
-    [GtkChild] unowned Gtk.Switch show_spoilers;
-    [GtkChild] unowned Gtk.Switch hide_preview_cards;
-    [GtkChild] unowned Gtk.Switch larger_font_size;
-    [GtkChild] unowned Gtk.Switch larger_line_height;
-    [GtkChild] unowned Gtk.Switch scale_emoji_hover;
-    [GtkChild] unowned Gtk.Switch strip_tracking;
-    [GtkChild] unowned Gtk.Switch letterbox_media;
-    [GtkChild] unowned Gtk.Switch media_viewer_expand_pictures;
-    [GtkChild] unowned Gtk.Switch enlarge_custom_emojis;
+    [GtkChild] unowned Adw.SwitchRow autostart;
+    [GtkChild] unowned Adw.SwitchRow work_in_background;
+    [GtkChild] unowned Adw.SpinRow timeline_page_size;
+    [GtkChild] unowned Adw.SwitchRow live_updates;
+    [GtkChild] unowned Adw.SwitchRow public_live_updates;
+    [GtkChild] unowned Adw.SwitchRow show_spoilers;
+    [GtkChild] unowned Adw.SwitchRow hide_preview_cards;
+    [GtkChild] unowned Adw.SwitchRow larger_font_size;
+    [GtkChild] unowned Adw.SwitchRow larger_line_height;
+    [GtkChild] unowned Adw.SwitchRow scale_emoji_hover;
+    [GtkChild] unowned Adw.SwitchRow strip_tracking;
+    [GtkChild] unowned Adw.SwitchRow letterbox_media;
+    [GtkChild] unowned Adw.SwitchRow media_viewer_expand_pictures;
+    [GtkChild] unowned Adw.SwitchRow enlarge_custom_emojis;
 
-    [GtkChild] unowned Gtk.Switch new_followers_notifications_switch;
-    [GtkChild] unowned Gtk.Switch new_follower_requests_notifications_switch;
-    [GtkChild] unowned Gtk.Switch favorites_notifications_switch;
-    [GtkChild] unowned Gtk.Switch mentions_notifications_switch;
-    [GtkChild] unowned Gtk.Switch boosts_notifications_switch;
-    [GtkChild] unowned Gtk.Switch poll_results_notifications_switch;
-    [GtkChild] unowned Gtk.Switch edits_notifications_switch;
+    [GtkChild] unowned Adw.SwitchRow new_followers_notifications_switch;
+    [GtkChild] unowned Adw.SwitchRow new_follower_requests_notifications_switch;
+    [GtkChild] unowned Adw.SwitchRow favorites_notifications_switch;
+    [GtkChild] unowned Adw.SwitchRow mentions_notifications_switch;
+    [GtkChild] unowned Adw.SwitchRow boosts_notifications_switch;
+    [GtkChild] unowned Adw.SwitchRow poll_results_notifications_switch;
+    [GtkChild] unowned Adw.SwitchRow edits_notifications_switch;
 
 	NotificationTypeMute[] notification_type_mutes;
 

--- a/src/Dialogs/ProfileEdit.vala
+++ b/src/Dialogs/ProfileEdit.vala
@@ -1,12 +1,12 @@
 [GtkTemplate (ui = "/dev/geopjr/Tuba/ui/dialogs/profile_edit.ui")]
 public class Tuba.Dialogs.ProfileEdit : Adw.Window {
 	~ProfileEdit () {
-		message (@"Destroying ProfileEdit for $(profile.handle)");
+		debug (@"Destroying ProfileEdit for $(profile.handle)");
 	}
 
 	public class Field : Adw.ExpanderRow {
 		~Field () {
-			message ("Destroying ProfileEdit.Field");
+			debug ("Destroying ProfileEdit.Field");
 		}
 
 		Adw.EntryRow key_row;

--- a/src/Services/Accounts/AccountStore.vala
+++ b/src/Services/Accounts/AccountStore.vala
@@ -44,7 +44,7 @@ public abstract class Tuba.AccountStore : GLib.Object {
 	}
 
 	public virtual void add (InstanceAccount account) throws GLib.Error {
-		message (@"Adding new account: $(account.handle)");
+		debug (@"Adding new account: $(account.handle)");
 		saved.add (account);
 		changed (saved);
 		save ();
@@ -52,7 +52,7 @@ public abstract class Tuba.AccountStore : GLib.Object {
 	}
 
 	public virtual void remove (InstanceAccount account) throws GLib.Error {
-		message (@"Removing account: $(account.handle)");
+		debug (@"Removing account: $(account.handle)");
 		account.removed ();
 		saved.remove (account);
 		changed (saved);
@@ -77,10 +77,10 @@ public abstract class Tuba.AccountStore : GLib.Object {
 			active.deactivated ();
 
 		if (account == null) {
-			message ("Reset active account");
+			debug ("Reset active account");
 			return;
 		} else {
-			message (@"Activating $(account.handle)…");
+			debug (@"Activating $(account.handle)…");
 			entity_cache.nuke ();
 			account.verify_credentials.begin ((obj, res) => {
 				try {
@@ -151,7 +151,7 @@ public abstract class Tuba.AccountStore : GLib.Object {
 			throw new Oopsie.INTERNAL ("This instance is unsupported.");
 		else {
 			account.backend = backend;
-			message (@"$(account.instance) is using $(account.backend)");
+			debug (@"$(account.instance) is using $(account.backend)");
 		}
 	}
 

--- a/src/Services/Accounts/InstanceAccount.vala
+++ b/src/Services/Accounts/InstanceAccount.vala
@@ -130,14 +130,14 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 		var updated = API.Account.from (node);
 		patch (updated);
 
-		message (@"$handle: profile updated");
+		debug (@"$handle: profile updated");
 	}
 
 	public async Entity resolve (string url) throws Error {
-		message (@"Resolving URL: \"$url\"…");
+		debug (@"Resolving URL: \"$url\"…");
 		var results = yield API.SearchResults.request (url, this);
 		var entity = results.first ();
-		message (@"Found $(entity.get_class ().get_name ())");
+		debug (@"Found $(entity.get_class ().get_name ())");
 		return entity;
 	}
 
@@ -265,7 +265,7 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 	}
 
 	public void read_notifications (int up_to_id) {
-		message (@"Reading notifications up to id $up_to_id");
+		debug (@"Reading notifications up to id $up_to_id");
 
 		if (up_to_id > last_read_id) {
 			last_read_id = up_to_id;
@@ -306,7 +306,7 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 
 	//  public void read_notification (int id) {
 	//  	if (id <= last_read_id) {
-	//  		message (@"Read notification with id: $id");
+	//  		debug (@"Read notification with id: $id");
 	//  		app.withdraw_notification (id.to_string ());
 	//  		unread_toasts.unset (id);
 	//  	}

--- a/src/Services/Accounts/SecretAccountStore.vala
+++ b/src/Services/Accounts/SecretAccountStore.vala
@@ -6,7 +6,7 @@ public class Tuba.SecretAccountStore : AccountStore {
 	GLib.HashTable<string,Secret.SchemaAttributeType> schema_attributes;
 
 	public override void init () throws GLib.Error {
-		message (@"Using libsecret v$(Secret.MAJOR_VERSION).$(Secret.MINOR_VERSION).$(Secret.MICRO_VERSION)");
+		debug (@"Using libsecret v$(Secret.MAJOR_VERSION).$(Secret.MINOR_VERSION).$(Secret.MICRO_VERSION)");
 
 		schema_attributes = new GLib.HashTable<string,Secret.SchemaAttributeType> (str_hash, str_equal);
 		schema_attributes["login"] = Secret.SchemaAttributeType.STRING;
@@ -91,7 +91,7 @@ public class Tuba.SecretAccountStore : AccountStore {
 		});
 		changed (saved);
 
-		message (@"Loaded $(saved.size) accounts");
+		debug (@"Loaded $(saved.size) accounts");
 	}
 
 	public override void save () throws GLib.Error {
@@ -99,7 +99,7 @@ public class Tuba.SecretAccountStore : AccountStore {
 			account_to_secret (account);
 			return true;
 		});
-		message (@"Saved $(saved.size) accounts");
+		debug (@"Saved $(saved.size) accounts");
 	}
 
 	public override void remove (InstanceAccount account) throws GLib.Error {
@@ -213,7 +213,7 @@ public class Tuba.SecretAccountStore : AccountStore {
 			(obj, async_res) => {
 				try {
 					Secret.password_store.end (async_res);
-					message (@"Saved secret for $(account.handle)");
+					debug (@"Saved secret for $(account.handle)");
 				}
 				catch (GLib.Error e) {
 					warning (e.message);

--- a/src/Services/Cache/AbstractCache.vala
+++ b/src/Services/Cache/AbstractCache.vala
@@ -35,7 +35,7 @@ public class Tuba.AbstractCache : Object {
 	}
 
 	bool maintenance_func () {
-		// message ("maintenance start");
+		// debug ("maintenance start");
 		if (size > 0) {
 			uint cleared = 0;
 			var iter = items.map_iterator ();
@@ -51,17 +51,17 @@ public class Tuba.AbstractCache : Object {
 				// }
 				if (obj.ref_count < min_ref_count) {
 					cleared++;
-					message (@"Freeing: $(iter.get_key ())");
+					debug (@"Freeing: $(iter.get_key ())");
 					iter.unset ();
 					obj.dispose ();
 				}
 			}
 
 			if (cleared > 0)
-				message (@"Freed $cleared items from cache. Size: $size");
+				debug (@"Freed $cleared items from cache. Size: $size");
 		}
 
-		// message ("maintenance end");
+		// debug ("maintenance end");
 		return Source.CONTINUE;
 	}
 
@@ -87,7 +87,7 @@ public class Tuba.AbstractCache : Object {
 
 	protected string insert (string id, owned Object obj) {
 		var key = get_key (id);
-		message (@"Inserting: $key");
+		debug (@"Inserting: $key");
 		items.@set (key, (owned) obj);
 
 		var nobj = items.@get (key);
@@ -97,7 +97,7 @@ public class Tuba.AbstractCache : Object {
 	}
 
 	public void nuke () {
-		message ("Clearing cache");
+		debug ("Clearing cache");
 		items.clear ();
 		items_in_progress.clear ();
 	}

--- a/src/Services/Cache/EntityCache.vala
+++ b/src/Services/Cache/EntityCache.vala
@@ -24,7 +24,7 @@ public class Tuba.EntityCache : AbstractCache {
 			// Entity can be reused from cache
 			if (!force && contains (id)) {
 				entity = lookup (get_key (id)) as Entity;
-				message (@"Reused: $id");
+				debug (@"Reused: $id");
 			}
 			// It's a new instance and we need to store it
 			else {

--- a/src/Services/Cache/ImageCache.vala
+++ b/src/Services/Cache/ImageCache.vala
@@ -40,7 +40,7 @@ public class Tuba.ImageCache : AbstractCache {
                         return;
                     }
 
-                    // message (@"[*] $key");
+                    // debug (@"[*] $key");
                     insert (url, paintable);
                     Signal.emit_by_name (download_msg, "finished");
 
@@ -58,7 +58,7 @@ public class Tuba.ImageCache : AbstractCache {
 		else {
 			// This image is either cached or already downloading, so we can serve the result immediately.
 
-            //message ("[/]: %s", key);
+            //debug ("[/]: %s", key);
             ulong id = 0;
             id = download_msg.finished.connect (() => {
                 cb (true, lookup (key) as Gdk.Paintable);

--- a/src/Services/Network/Network.vala
+++ b/src/Services/Network/Network.vala
@@ -31,7 +31,7 @@ public class Tuba.Network : GLib.Object {
 		requests_processing++;
 		started ();
 
-		message (@"$(msg.method): $(msg.uri.to_string ())");
+		debug (@"$(msg.method): $(msg.uri.to_string ())");
 
 		session.send_async.begin (msg, 0, cancellable, (obj, res) => {
 			try {

--- a/src/Services/Network/Request.vala
+++ b/src/Services/Network/Request.vala
@@ -62,7 +62,7 @@ public class Tuba.Request : GLib.Object {
 	}
 
 	// ~Request () {
-	// 	message ("Destroy req: "+url);
+	// 	debug ("Destroy req: "+url);
 	// }
 
 	private string? content_type = null;

--- a/src/Services/Network/Streamable.vala
+++ b/src/Services/Network/Streamable.vala
@@ -59,7 +59,7 @@ public abstract interface Tuba.Streamable : Object {
 	}
 
 	protected void update_stream () {
-		// message (get_subscriber_name ()+": UPDATED to "+subscribed.to_string ());
+		// debug (get_subscriber_name ()+": UPDATED to "+subscribed.to_string ());
 
 		unsubscribe ();
 		if (subscribed)

--- a/src/Services/Network/Streams.vala
+++ b/src/Services/Network/Streams.vala
@@ -62,7 +62,7 @@ public class Tuba.Streams : Object {
 		}
 
 		public bool start () {
-			message (@"Opening stream: $name");
+			debug (@"Opening stream: $name");
 			network.session.websocket_connect_async.begin (msg, null, null, 0, null, (obj, res) => {
 				try {
 					socket = network.session.websocket_connect_async.end (res);
@@ -90,7 +90,7 @@ public class Tuba.Streams : Object {
 			}
 
 			if (subscribers.size <= 0) {
-				message (@"Closing: $name");
+				debug (@"Closing: $name");
 				closing = true;
 				if (socket != null)
 					socket.close (0, null);
@@ -112,7 +112,7 @@ public class Tuba.Streams : Object {
 				GLib.Timeout.add_seconds (timeout, start);
 				timeout = int.min (timeout * 2, 6);
 			}
-			message (@"Closing stream: $name");
+			debug (@"Closing stream: $name");
 		}
 
 		protected virtual void on_message (int i, Bytes bytes) {
@@ -121,7 +121,7 @@ public class Tuba.Streams : Object {
 				decode (bytes, out ev);
 
 				subscribers.@foreach (s => {
-					message (@"$(name): $(ev.type) for $(s.get_subscriber_name ())");
+					debug (@"$(name): $(ev.type) for $(s.get_subscriber_name ())");
 					s.stream_event[ev.type] (ev);
 					return true;
 				});

--- a/src/Utils/Host.vala
+++ b/src/Utils/Host.vala
@@ -8,7 +8,7 @@ public class Tuba.Host {
 
 		if (settings.strip_tracking)
 			uri = Tracking.strip_utm (uri);
-		message (@"Opening URI: $uri");
+		debug (@"Opening URI: $uri");
 		try {
 			var success = AppInfo.launch_default_for_uri (uri, null);
 			if (!success)
@@ -43,7 +43,7 @@ public class Tuba.Host {
 	}
 
 	public async static string download (string url) throws Error {
-		message (@"Downloading file: $url…");
+		debug (@"Downloading file: $url…");
 
 		var file_name = Path.get_basename (url);
 		var dir_name = Path.get_dirname (url);
@@ -73,10 +73,10 @@ public class Tuba.Host {
 			FileOutputStream stream = yield file.create_async (FileCreateFlags.PRIVATE);
 			yield stream.splice_async (data, OutputStreamSpliceFlags.CLOSE_SOURCE | OutputStreamSpliceFlags.CLOSE_TARGET);
 
-			message (@"   OK: File written to: $file_path");
+			debug (@"   OK: File written to: $file_path");
 		}
 		else
-			message ("   OK: File already exists");
+			debug ("   OK: File already exists");
 
 		return file_path;
 	}

--- a/src/Views/Base.vala
+++ b/src/Views/Base.vala
@@ -1,5 +1,5 @@
 [GtkTemplate (ui = "/dev/geopjr/Tuba/ui/views/base.ui")]
-public class Tuba.Views.Base : Gtk.Box {
+public class Tuba.Views.Base : Adw.BreakpointBin {
 	// translators: Shown when there are 0 results
 	public static string STATUS_EMPTY = _("Nothing to see here"); // vala-lint=naming-convention
 
@@ -29,6 +29,7 @@ public class Tuba.Views.Base : Gtk.Box {
 	}
 
 	[GtkChild] protected unowned Adw.HeaderBar header;
+	[GtkChild] protected unowned Adw.ToolbarView toolbar_view;
 
 	[GtkChild] protected unowned Gtk.ScrolledWindow scrolled;
 	[GtkChild] protected unowned Gtk.Overlay scrolled_overlay;
@@ -76,8 +77,6 @@ public class Tuba.Views.Base : Gtk.Box {
 			_base_status = value;
 		}
 	}
-
-
 	construct {
 		build_actions ();
 		build_header ();

--- a/src/Views/Base.vala
+++ b/src/Views/Base.vala
@@ -99,7 +99,7 @@ public class Tuba.Views.Base : Adw.BreakpointBin {
 		scroll_to_top.clicked.connect (on_scroll_to_top);
 	}
 	~Base () {
-		message (@"Destroying base $label");
+		debug (@"Destroying base $label");
 	}
 
 	private void on_scroll_to_top () {

--- a/src/Views/ContentBase.vala
+++ b/src/Views/ContentBase.vala
@@ -38,7 +38,7 @@ public class Tuba.Views.ContentBase : Views.Base {
 		});
 	}
 	~ContentBase () {
-		message ("Destroying ContentBase");
+		debug ("Destroying ContentBase");
 	}
 
 	private void bind_listitem_cb (GLib.Object item) {

--- a/src/Views/Lists.vala
+++ b/src/Views/Lists.vala
@@ -167,7 +167,7 @@ public class Tuba.Views.Lists : Views.Timeline {
 		child_box.append (add_button);
 
 		add_action_bar.set_center_widget (child_box);
-		insert_child_after (add_action_bar, header);
+		toolbar_view.add_top_bar (add_action_bar);
 	}
 
 	~Lists () {

--- a/src/Views/Lists.vala
+++ b/src/Views/Lists.vala
@@ -171,7 +171,7 @@ public class Tuba.Views.Lists : Views.Timeline {
 	}
 
 	~Lists () {
-		message ("Destroying Lists view");
+		debug ("Destroying Lists view");
 	}
 
     public override void on_request_finish () {

--- a/src/Views/Main.vala
+++ b/src/Views/Main.vala
@@ -9,7 +9,6 @@ public class Tuba.Views.Main : Views.TabbedBase {
 
 	public override void build_header () {
 		base.build_header ();
-		back_button.hide ();
 
 		var search_button = new Gtk.Button ();
 		search_button.icon_name = "tuba-loupe-large-symbolic";
@@ -21,41 +20,25 @@ public class Tuba.Views.Main : Views.TabbedBase {
 		header.pack_start (sidebar_button);
 		sidebar_button.icon_name = "tuba-dock-left-symbolic";
 
-		header.show_start_title_buttons = false;
 		app.notify["main-window"].connect (() => {
 			if (app.main_window == null) {
 				sidebar_button.hide ();
 				return;
 			}
 
-			app.main_window.flap.bind_property (
-				"folded",
+			app.main_window.split_view.bind_property (
+				"collapsed",
 				sidebar_button,
 				"visible",
-				BindingFlags.SYNC_CREATE,
-				(b, src, ref target) => {
-					var state = src.get_boolean ();
-					target.set_boolean (state);
-
-					var sidebar = app.main_window.flap.flap as Views.Sidebar;
-					if (sidebar != null) sidebar.show_window_controls = !state;
-					header.show_start_title_buttons = state;
-
-					return true;
-				}
+				BindingFlags.SYNC_CREATE
 			);
 
-			app.main_window.flap.bind_property (
-				"reveal-flap",
+			app.main_window.split_view.bind_property (
+				"show-sidebar",
 				sidebar_button,
 				"active",
 				BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL
 			);
-			//  app.main_window.flap.bind_property ("reveal-flap", sidebar_button, "icon-name", BindingFlags.SYNC_CREATE, (b, src, ref target) => {
-			//  	var state = src.get_boolean ();
-			//  	target.set_string (state ? "sidebar-hide-symbolic" : "sidebar-show-symbolic" );
-			//  	return true;
-			//  });
 		});
 
 	}

--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -157,7 +157,7 @@ public class Tuba.Views.MediaViewer : Gtk.Box {
 		}
 
 		~Item () {
-			message ("Destroying MediaViewer.Item");
+			debug ("Destroying MediaViewer.Item");
 
 			if (is_video) {
 				last_used_volume = ((Gtk.Video) child_widget).media_stream.muted ? 0.0 : ((Gtk.Video) child_widget).media_stream.volume;
@@ -330,7 +330,7 @@ public class Tuba.Views.MediaViewer : Gtk.Box {
 		setup_double_click ();
 	}
 	~MediaViewer () {
-		message ("Destroying MediaViewer");
+		debug ("Destroying MediaViewer");
 	}
 
 	int? old_height;

--- a/src/Views/Profile.vala
+++ b/src/Views/Profile.vala
@@ -37,7 +37,7 @@ public class Tuba.Views.Profile : Views.Timeline {
 		content.header_factory = header_factory;
 	}
 	~Profile () {
-		message ("Destroying Profile view");
+		debug ("Destroying Profile view");
 	}
 
 	private void on_create_header (Object object) {
@@ -108,7 +108,7 @@ public class Tuba.Views.Profile : Views.Timeline {
 		[GtkChild] public unowned Widgets.RelationshipButton rsbtn;
 
 		~Cover () {
-			message ("Destroying Profile Cover");
+			debug ("Destroying Profile Cover");
 		}
 
 		void toggle_scale_emoji_hover () {

--- a/src/Views/Search.vala
+++ b/src/Views/Search.vala
@@ -16,8 +16,7 @@ public class Tuba.Views.Search : Views.TabbedBase {
 		bar = new Gtk.SearchBar () {
 			search_mode_enabled = true
 		};
-		prepend (bar);
-		reorder_child_after (bar, header);
+		toolbar_view.add_top_bar (bar);
 
 		entry = new Gtk.SearchEntry () {
 			width_chars = 25,

--- a/src/Views/Sidebar.vala
+++ b/src/Views/Sidebar.vala
@@ -1,5 +1,5 @@
 [GtkTemplate (ui = "/dev/geopjr/Tuba/ui/views/sidebar/view.ui")]
-public class Tuba.Views.Sidebar : Gtk.Box, AccountHolder {
+public class Tuba.Views.Sidebar : Gtk.Widget, AccountHolder {
 
 	[GtkChild] unowned Gtk.ToggleButton accounts_button;
 	[GtkChild] unowned Gtk.Stack mode;
@@ -47,6 +47,7 @@ public class Tuba.Views.Sidebar : Gtk.Box, AccountHolder {
 
 	static construct {
 		typeof (Widgets.EmojiLabel).ensure ();
+		set_layout_manager_type (typeof (Gtk.BinLayout));
 	}
 
 	construct {

--- a/src/Views/Sidebar.vala
+++ b/src/Views/Sidebar.vala
@@ -9,18 +9,6 @@ public class Tuba.Views.Sidebar : Gtk.Box, AccountHolder {
 	[GtkChild] unowned Widgets.Avatar avatar;
 	[GtkChild] unowned Widgets.EmojiLabel title;
 	[GtkChild] unowned Gtk.Label subtitle;
-	[GtkChild] unowned Adw.HeaderBar sb_header;
-
-	private bool _show_window_controls = false;
-	public bool show_window_controls {
-		get {
-			return _show_window_controls;
-		}
-		set {
-			_show_window_controls = value;
-			sb_header.show_start_title_buttons = value;
-		}
-	}
 
 	protected InstanceAccount? account { get; set; default = null; }
 
@@ -56,6 +44,10 @@ public class Tuba.Views.Sidebar : Gtk.Box, AccountHolder {
 				app.lookup_action ("about").activate (null);
 			}
 	};
+
+	static construct {
+		typeof (Widgets.EmojiLabel).ensure ();
+	}
 
 	construct {
 		app_items = new GLib.ListStore (typeof (Place));
@@ -149,9 +141,9 @@ public class Tuba.Views.Sidebar : Gtk.Box, AccountHolder {
 		if (account == null) return;
 		account.open ();
 
-		var flap = app.main_window.flap;
-        if (flap.folded)
-			flap.reveal_flap = false;
+        var split_view = app.main_window.split_view;
+        if (split_view.collapsed)
+			split_view.show_sidebar = false;
 	}
 
 
@@ -188,9 +180,9 @@ public class Tuba.Views.Sidebar : Gtk.Box, AccountHolder {
 		if (row.place.open_func != null)
 			row.place.open_func (app.main_window);
 
-        var flap = app.main_window.flap;
-        if (flap.folded)
-			flap.reveal_flap = false;
+        var split_view = app.main_window.split_view;
+        if (split_view.collapsed)
+			split_view.show_sidebar = false;
 	}
 
 	void on_item_header_update (Gtk.ListBoxRow _row, Gtk.ListBoxRow? _before) {

--- a/src/Views/TabbedBase.vala
+++ b/src/Views/TabbedBase.vala
@@ -32,7 +32,7 @@ public class Tuba.Views.TabbedBase : Views.Base {
 	}
 
 	~TabbedBase () {
-		message ("Destroying TabbedBase");
+		debug ("Destroying TabbedBase");
 
 		foreach (var tab in views) {
 			stack.remove (tab);

--- a/src/Views/TabbedBase.vala
+++ b/src/Views/TabbedBase.vala
@@ -2,7 +2,7 @@ public class Tuba.Views.TabbedBase : Views.Base {
 
 	static int id_counter = 0;
 
-	protected Adw.ViewSwitcherTitle switcher_title;
+	protected Adw.ViewSwitcher switcher;
 	protected Adw.ViewSwitcherBar switcher_bar;
 	protected Adw.ViewStack stack;
 
@@ -22,13 +22,13 @@ public class Tuba.Views.TabbedBase : Views.Base {
 		var scrolled_overlay_box = scrolled_overlay.get_parent () as Gtk.Box;
 		if (scrolled_overlay_box != null)
 			scrolled_overlay_box.remove (scrolled_overlay);
-		insert_child_after (states, header);
+		toolbar_view.content = states;
 
-		stack = new Adw.ViewStack ();
+		stack = new Adw.ViewStack () { vexpand = true };
 		stack.notify["visible-child"].connect (on_view_switched);
 		scrolled.child = stack;
 
-		switcher_bar.stack = switcher_title.stack = stack;
+		switcher_bar.stack = switcher.stack = stack;
 	}
 
 	~TabbedBase () {
@@ -42,14 +42,20 @@ public class Tuba.Views.TabbedBase : Views.Base {
 	}
 
 	public override void build_header () {
-		switcher_title = new Adw.ViewSwitcherTitle ();
-		bind_property ("label", switcher_title, "title", BindingFlags.SYNC_CREATE);
-		// header.bind_property ("subtitle", switcher_title, "subtitle", BindingFlags.SYNC_CREATE);
-		header.title_widget = switcher_title;
+		switcher = new Adw.ViewSwitcher () { policy = Adw.ViewSwitcherPolicy.WIDE };
+		header.title_widget = switcher;
 
 		switcher_bar = new Adw.ViewSwitcherBar ();
-		switcher_title.bind_property ("title-visible", switcher_bar, "reveal", BindingFlags.SYNC_CREATE);
-		append (switcher_bar);
+		toolbar_view.add_bottom_bar (switcher_bar);
+
+		var condition = new Adw.BreakpointCondition.length (
+			Adw.BreakpointConditionLengthType.MAX_WIDTH,
+			550, Adw.LengthUnit.SP
+		);
+		var breakpoint = new Adw.Breakpoint (condition);
+		breakpoint.add_setter (header, "title-widget", (Gtk.Widget ?) null);
+		breakpoint.add_setter (switcher_bar, "reveal", true);
+		add_breakpoint (breakpoint);
 	}
 
 	public void add_tab (Views.Base view) {

--- a/src/Views/Thread.vala
+++ b/src/Views/Thread.vala
@@ -37,7 +37,7 @@ public class Tuba.Views.Thread : Views.ContentBase, AccountHolder {
 		construct_account_holder ();
 	}
 	~Thread () {
-		message ("Destroying Thread");
+		debug ("Destroying Thread");
 		destruct_account_holder ();
 	}
 

--- a/src/Views/Timeline.vala
+++ b/src/Views/Timeline.vala
@@ -99,7 +99,7 @@ public class Tuba.Views.Timeline : AccountHolder, Streamable, Views.ContentBase 
         this.add_controller (drag);
 	}
 	~Timeline () {
-		message (@"Destroying Timeline $label");
+		debug (@"Destroying Timeline $label");
 
 		entity_queue = {};
 		destruct_account_holder ();

--- a/src/Views/Timeline.vala
+++ b/src/Views/Timeline.vala
@@ -22,11 +22,11 @@ public class Tuba.Views.Timeline : AccountHolder, Streamable, Views.ContentBase 
 			if (_is_pulling != value) {
 				if (value) {
 					pull_to_refresh_spinner.spinning = true;
-					this.insert_child_after (pull_to_refresh_spinner, header);
+					scrolled_overlay.add_overlay (pull_to_refresh_spinner);
 					scrolled.sensitive = false;
 				} else {
 					pull_to_refresh_spinner.spinning = false;
-					this.remove (pull_to_refresh_spinner);
+					scrolled_overlay.remove_overlay (pull_to_refresh_spinner);
 					scrolled.sensitive = true;
 					pull_to_refresh_spinner.margin_top = 32;
 					pull_to_refresh_spinner.height_request = 32;
@@ -70,7 +70,9 @@ public class Tuba.Views.Timeline : AccountHolder, Streamable, Views.ContentBase 
 		pull_to_refresh_spinner = new Gtk.Spinner () {
 			height_request = 32,
 			margin_top = 32,
-			margin_bottom = 32
+			margin_bottom = 32,
+			halign = Gtk.Align.FILL,
+			valign = Gtk.Align.START
 		};
 
 		reached_close_to_top.connect (finish_queue);

--- a/src/Widgets/Attachment/Item.vala
+++ b/src/Widgets/Attachment/Item.vala
@@ -41,7 +41,7 @@ public class Tuba.Widgets.Attachment.Item : Adw.Bin {
 			try {
 				var file = chooser.save.end (res);
 				if (file != null) {
-					message (@"Downloading file: $(url)…");
+					debug (@"Downloading file: $(url)…");
 					download.begin (url, file, (obj, res) => {
 						download.end (res);
 					});
@@ -62,7 +62,7 @@ public class Tuba.Widgets.Attachment.Item : Adw.Bin {
 			try {
 				stream.splice (data, OutputStreamSpliceFlags.CLOSE_SOURCE | OutputStreamSpliceFlags.CLOSE_TARGET);
 
-				message (@"   OK: File written to: $(file.get_path ())");
+				debug (@"   OK: File written to: $(file.get_path ())");
 			} catch (GLib.IOError e) {
 				warning (e.message);
 				//  app.inform (Gtk.MessageType.ERROR, _("Error"), e.message);
@@ -124,7 +124,7 @@ public class Tuba.Widgets.Attachment.Item : Adw.Bin {
 		child = overlay;
 	}
 	~Item () {
-		message ("Destroying Attachment.Item widget");
+		debug ("Destroying Attachment.Item widget");
 		context_menu.unparent ();
 	}
 

--- a/src/Widgets/BookWyrmPage.vala
+++ b/src/Widgets/BookWyrmPage.vala
@@ -23,7 +23,7 @@ public class Tuba.Widgets.BookWyrmPage : Gtk.Box {
     }
 
     ~BookWyrmPage () {
-		message ("Destroying BookWyrmPage");
+		debug ("Destroying BookWyrmPage");
 	}
 
     public BookWyrmPage (API.BookWyrm t_obj) {

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -203,7 +203,7 @@ public class Tuba.Widgets.Status : Adw.Bin {
 		init_menu_button ();
 	}
 	~Status () {
-		message ("Destroying Status widget");
+		debug ("Destroying Status widget");
 		if (context_menu != null) {
 			context_menu.menu_model = null;
 			context_menu.dispose ();

--- a/src/Widgets/Status/ActionsRow.vala
+++ b/src/Widgets/Status/ActionsRow.vala
@@ -123,7 +123,7 @@ public class Tuba.Widgets.ActionsRow : Gtk.Box {
 			req = this.status.unbookmark_req ();
 		}
 
-		message (@"Performing status action '$action'…");
+		debug (@"Performing status action '$action'…");
 		mastodon_action (status_btn, req, action);
 	}
 
@@ -145,7 +145,7 @@ public class Tuba.Widgets.ActionsRow : Gtk.Box {
 		}
 		status_btn.amount += status_btn.active ? 1 : -1;
 
-		message (@"Performing status action '$action'…");
+		debug (@"Performing status action '$action'…");
 		mastodon_action (status_btn, req, action, "favourites-count");
 	}
 
@@ -167,7 +167,7 @@ public class Tuba.Widgets.ActionsRow : Gtk.Box {
 		}
 		status_btn.amount += status_btn.active ? 1 : -1;
 
-		message (@"Performing status action '$action'…");
+		debug (@"Performing status action '$action'…");
 		mastodon_action (status_btn, req, action, "reblogs-count");
 	}
 
@@ -202,7 +202,7 @@ public class Tuba.Widgets.ActionsRow : Gtk.Box {
 				//  }
 
 				//  this.status.patch (e);
-				message (@"Status action '$action' complete");
+				debug (@"Status action '$action' complete");
 			} catch (Error e) {
 				warning (@"Couldn't perform action \"$action\" on a Status:");
 				warning (e.message);


### PR DESCRIPTION
Hi,

this is an attempt to port Tuba to the new libadwaita widgetry ([click](https://blogs.gnome.org/alicem/2023/06/15/rethinking-adaptivity/), [click](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/migrating-to-breakpoints.html)). I'm not an expert in GTK, nor in Tuba's codebase, so I most likely messed something up — please let me know!

This PR only touches the main window (and not even all of its views?), not the compose dialog.

![Screenshot from 2023-07-22 22-13-46](https://github.com/GeopJr/Tuba/assets/10091584/4bc2682d-4d6d-4318-9d44-43024f7ea586)
![Screenshot from 2023-07-22 23-55-08](https://github.com/GeopJr/Tuba/assets/10091584/1df3c8df-4669-4b08-8ce4-43ebc34ca6b3)
![Screenshot from 2023-07-22 23-55-59](https://github.com/GeopJr/Tuba/assets/10091584/78421d06-34b9-4f2e-b43b-255eae7105d5)
![Screenshot from 2023-07-22 23-56-53](https://github.com/GeopJr/Tuba/assets/10091584/35fcb2e2-622c-4401-915b-27f9a4412c2b)

