### PR TITLE
feat: v0.4.1

### DIFF
--- a/data/dev.geopjr.Tuba.metainfo.xml.in
+++ b/data/dev.geopjr.Tuba.metainfo.xml.in
@@ -54,6 +54,24 @@
     <control>touch</control>
   </recommends>
   <releases>
+    <release version="0.4.1" date="2023-08-05">
+        <description translatable="no">
+          <ul>
+              <li>Fixed News' discussed label not being aligned properly</li>
+              <li>Fixed some strings being untranslatable</li>
+              <li>Fixed sidebar having horizontal overflow in some languages</li>
+              <li>Fixed custom emoji chooser not getting dismissed on Esc</li>
+              <li>Added showing error dialogs when composer fails</li>
+              <li>Fixed work-in-background setting not being able to be saved</li>
+              <li>Reverted the media viewer background color change</li>
+              <li>Fixed volume on videos not matching the actual value</li>
+              <li>Fixed videos playing even when not visible</li>
+              <li>Fixed custom emoji picker not listing emojis alphabetically</li>
+              <li>Fixed custom emoji picker button being visible even if there are no emojis</li>
+              <li>Read the full changelog on the repo</li>
+          </ul>
+        </description>
+    </release>
     <release version="0.4.0" date="2023-07-19">
         <description translatable="no">
           <ul>

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'dev.geopjr.Tuba',
     ['c', 'vala'],
-    version: '0.4.0',
+    version: '0.4.1',
     meson_version: '>= 0.56.0',
     default_options: [
         'warning_level=2',


### PR DESCRIPTION
```
# Added

- Error dialogs on errors during on_commit for the composer
- Hide CustomEmojiChooser button when there are no emojis available

# Fixed

- 'Discussed' label not filling up the full available width of PreviewCards used in the News tab (#400)
- Marked alternative text dialog titles as translatable (#394, thanks [at]LukaszH77)
- Sidebar having horizontal overflow due to some strings in some languages being too long by ellipsizing them (#403)
- Renamed appdata file to metainfo per spec (#416, thanks [at]carlwgeorge)
- Validate metainfo with `--nonet` for environments without a network connection (#416, thanks [at]carlwgeorge)
- CustomEmojiChooser not dismissing on Esc
- Compiling without GtkSourceView
- Compiling with GTK < 4.10
- Not being able to save the `work-in-background` setting due to settings being saved only on app shutdown
- Building with clang
- Reverted changing MediaViewer to not use osd for the background
- MediaViewer's videos' volume not matching the volume of the controls
- MediaViewer's videos playing even when not visible (#399)
- CustomEmojiChooser's emojis and categories not being sorted alphabetically (#395)
- FileChooserNative (compat) not being modals
- LabelWithWidgets re-do the infinite loop fix
- Alternative text dialog title using the media type from the server (thanks [at]LukaszH77)

# Package maintainers

- The metainfo file rename shouldn't cause any issues or require any action from your side if you are using meson
```