### PR TITLE
fix(ContentBase): ListView items style

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -426,15 +426,15 @@ video > overlay > revealer > controls {
 	box-shadow: none;
 }
 
-.ttl-view .content :first-child .card.card-spacing {
+.ttl-view .content .card.card-spacing :first-child {
 	margin-top: 0px;
 }
 
-.ttl-view .content :last-child .card.card-spacing {
+.ttl-view .content .card.card-spacing:last-child {
 	margin-bottom: 0px;
 }
 
-.ttl-view .small.content row .card {
+.ttl-view .small.content .card {
 	border-left: none;
 	border-right: none;
 	border-radius: 0px;
@@ -470,7 +470,7 @@ video > overlay > revealer > controls {
 	padding-bottom: 32px;
 }
 
-.ttl-view .small.content :not(:last-child) .card {
+.ttl-view .small.content .card:not(:last-child) {
 	border-bottom: 1px @borders solid;
 }
 

--- a/data/style.css
+++ b/data/style.css
@@ -426,11 +426,11 @@ video > overlay > revealer > controls {
 	box-shadow: none;
 }
 
-.ttl-view .content .card.card-spacing :first-child {
+.ttl-view .content row:first-child {
 	margin-top: 0px;
 }
 
-.ttl-view .content .card.card-spacing:last-child {
+.ttl-view .content row:last-child {
 	margin-bottom: 0px;
 }
 

--- a/data/ui/widgets/announcement.ui
+++ b/data/ui/widgets/announcement.ui
@@ -149,9 +149,6 @@
     </property>
     <style>
       <class name="ttl-post" />
-      <class name="card-spacing" />
-      <class name="card" />
-      <class name="activatable" />
     </style>
   </template>
 </interface>

--- a/data/ui/widgets/status.ui
+++ b/data/ui/widgets/status.ui
@@ -316,9 +316,6 @@
     </property>
     <style>
       <class name="ttl-post" />
-      <class name="card-spacing" />
-      <class name="card" />
-      <class name="activatable" />
     </style>
   </template>
 </interface>

--- a/src/API/Tag.vala
+++ b/src/API/Tag.vala
@@ -37,8 +37,7 @@ public class Tuba.API.Tag : Entity, Widgetizable {
 	public override Gtk.Widget to_widget () {
 		var w = new Adw.ActionRow () {
 			title = @"#$name",
-			activatable = true,
-			css_classes = { "card", "activatable", "card-spacing" }
+			activatable = true
 		};
 
 		if (history != null && history.size > 0) {

--- a/src/Views/ContentBase.vala
+++ b/src/Views/ContentBase.vala
@@ -45,6 +45,15 @@ public class Tuba.Views.ContentBase : Views.Base {
 
 	private void bind_listitem_cb (GLib.Object item) {
 		((Gtk.ListItem) item).child = on_create_model_widget (((Gtk.ListItem) item).item);
+
+		var gtklistitemwidget = ((Gtk.ListItem) item).child.get_parent ();
+		if (gtklistitemwidget != null) {
+			gtklistitemwidget.add_css_class ("card");
+			gtklistitemwidget.add_css_class ("card-spacing");
+
+			// Thread lines overflow slightly
+			gtklistitemwidget.overflow = Gtk.Overflow.HIDDEN;
+		}
 	}
 
 	public override void dispose () {

--- a/src/Views/ContentBase.vala
+++ b/src/Views/ContentBase.vala
@@ -50,6 +50,7 @@ public class Tuba.Views.ContentBase : Views.Base {
 		if (gtklistitemwidget != null) {
 			gtklistitemwidget.add_css_class ("card");
 			gtklistitemwidget.add_css_class ("card-spacing");
+			gtklistitemwidget.focusable = true;
 
 			// Thread lines overflow slightly
 			gtklistitemwidget.overflow = Gtk.Overflow.HIDDEN;

--- a/src/Views/Lists.vala
+++ b/src/Views/Lists.vala
@@ -30,8 +30,6 @@ public class Tuba.Views.Lists : Views.Timeline {
 
 			this.activatable = true;
 			this.add_suffix (action_box);
-			this.add_css_class ("card");
-			this.add_css_class ("card-spacing");
 		}
 
 		public Row (API.List? list) {

--- a/src/Widgets/PreviewCard.vala
+++ b/src/Widgets/PreviewCard.vala
@@ -92,9 +92,7 @@ public class Tuba.Widgets.PreviewCard : Gtk.Button {
         if (card_obj.kind == "link" && card_obj.history != null && card_obj.history.size > 0) {
 				this.remove_css_class ("frame");
 				this.add_css_class ("explore");
-				this.add_css_class ("card-spacing");
-				this.add_css_class ("card");
-				this.add_css_class ("activatable");
+				this.add_css_class ("flat");
 
 				this.clicked.connect (() => Host.open_uri (card_obj.url));
 


### PR DESCRIPTION
Let's assume that all listview items are cards with card-spacing instead. This sets the styles on the listviewitemwidgets instead of the children

edit: it also makes them hide the overflow as the threadlines would slightly overflow