### PR TITLE
fix(Status): expanded application label large font setting

### DIFF
--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -686,7 +686,8 @@ public class Tuba.Widgets.Status : Adw.Bin {
 			var application_label = new Gtk.Label (application_link) {
 				wrap = true,
 				use_markup = has_link,
-				halign = Gtk.Align.START
+				halign = Gtk.Align.START,
+				css_classes = { "body" }
 			};
 
 			// If it's not an anchor, it should follow the styling of the other items


### PR DESCRIPTION
seen on #480

application label seems to be affected by the large font setting when it shouldn't(?) or at least should be the same as the date label