### PR TITLE
feat: remove Entity Queue

### DIFF
--- a/src/Views/ContentBase.vala
+++ b/src/Views/ContentBase.vala
@@ -3,7 +3,7 @@ public class Tuba.Views.ContentBase : Views.Base {
 	public GLib.ListStore model;
 	protected Gtk.ListView content;
 	private bool bottom_reached_locked = false;
-	protected signal void reached_close_to_top ();
+	//  protected signal void reached_close_to_top ();
 
 	public bool empty {
 		get { return model.get_n_items () <= 0; }
@@ -40,7 +40,7 @@ public class Tuba.Views.ContentBase : Views.Base {
 		scroll_to_top_rev.reveal_child = !is_close_to_top
 			&& scrolled.vadjustment.value + scrolled.vadjustment.page_size + 100 < scrolled.vadjustment.upper;
 
-		if (is_close_to_top) reached_close_to_top ();
+		//  if (is_close_to_top) reached_close_to_top ();
 	}
 
 	protected virtual void bind_listitem_cb (GLib.Object item) {


### PR DESCRIPTION
Entity queue was introduced on #234 as a workaround for ListBox's constant vadjustment change when new items got added to the list by only appending them when the user was near the top. ListView doesn't have this issue.

ContentBase's reached_close_to_top signal got commented out as it's unused.