### PR TITLE
fix(Status): overflow on large names

### DIFF
--- a/data/ui/widgets/status.ui
+++ b/data/ui/widgets/status.ui
@@ -108,9 +108,9 @@
                             <child>
                               <object class="TubaWidgetsRichLabel" id="name_label">
                                 <property name="visible">True</property>
-                                <property name="ellipsize">True</property>
+                                <property name="ellipsize">0</property>
                                 <property name="smaller-emoji-pixel-size">True</property>
-                                <property name="lines">-1</property>
+                                <property name="lines">100</property>
                                 <style>
                                   <class name="font-bold" />
                                 </style>

--- a/src/Widgets/LabelWithWidgets.vala
+++ b/src/Widgets/LabelWithWidgets.vala
@@ -47,6 +47,8 @@ public class Tuba.Widgets.LabelWithWidgets : Gtk.Widget, Gtk.Buildable, Gtk.Acce
             return _ellipsize;
         }
         set {
+            if (_ellipsize == value) return;
+
             _ellipsize = value;
             update_label ();
         }
@@ -58,6 +60,8 @@ public class Tuba.Widgets.LabelWithWidgets : Gtk.Widget, Gtk.Buildable, Gtk.Acce
             return _use_markup;
         }
         set {
+            if (_use_markup == value) return;
+
             _use_markup = value;
             label.use_markup = _use_markup;
         }


### PR DESCRIPTION
During the ListBox -> ListView migration the name label had to no longer wrap. Ellipsizing doesn't exactly work as expected on LWW so it caused overflows. After correctly setting up the AdwClamp with the ListView, it no longer seems to be an issue so we can revert back