### PR TITLE
feat(MarkupView): hide quote url

### DIFF
--- a/src/Widgets/MarkupView.vala
+++ b/src/Widgets/MarkupView.vala
@@ -184,8 +184,12 @@ public class Tuba.Widgets.MarkupView : Gtk.Box {
 
 	public static void default_handler (MarkupView v, Xml.Node* root) {
 		switch (root->name) {
-			case "html":
 			case "span":
+				string? classes = root->get_prop ("class");
+				if (classes == null || !classes.contains ("quote-inline"))
+					traverse_and_handle (v, root, default_handler);
+				break;
+			case "html":
 			case "markup":
 				traverse_and_handle (v, root, default_handler);
 				break;


### PR DESCRIPTION
Akkoma & other backends that support quotes wrap the "RE: <quote url>" footer in a span with the class `quote-inline` so clients that support quotes remove it:

Before:
![Screenshot from 2023-09-18 12-08-19](https://github.com/GeopJr/Tuba/assets/18014039/f31da84f-d2a4-4c34-99bf-3431a06d63b8)

After:
![Screenshot from 2023-09-18 12-07-46](https://github.com/GeopJr/Tuba/assets/18014039/329ab78d-bdc6-47a1-9b78-fbd7827b2e03)
