### PR TITLE
feat(Composer): adw 1.4 + hide arrows when overflowing

### DIFF
--- a/data/ui/dialogs/compose.ui
+++ b/data/ui/dialogs/compose.ui
@@ -1,60 +1,66 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <requires lib="gtk" version="4.0"/>
-  <requires lib="libadwaita" version="1.0"/>
-  <template class="TubaDialogsCompose" parent="AdwWindow">
-    <property name="modal">1</property>
-    <property name="default_width">500</property>
-    <property name="default_height">400</property>
+	<requires lib="gtk" version="4.0" />
+	<requires lib="libadwaita" version="1.0" />
+	<template class="TubaDialogsCompose" parent="AdwWindow">
+		<property name="modal">1</property>
+		<property name="default_width">500</property>
+		<property name="default_height">400</property>
+		<property name="width_request">360</property>
+		<property name="height_request">200</property>
+		<child>
+			<object class="AdwBreakpoint">
+				<condition>max-width: 450sp</condition>
+				<setter object="header" property="title-widget" />
+				<setter object="switcher_bar" property="reveal">True</setter>
+			</object>
+		</child>
 
-    <child>
-      <object class="GtkBox">
-        <property name="orientation">vertical</property>
+		<child>
+			<object class="AdwToolbarView" id="toolbar_view">
+				<child type="top">
+					<object class="AdwHeaderBar" id="header">
+						<property name="hexpand">1</property>
+						<property name="show_end_title_buttons">0</property>
+						<property name="show_start_title_buttons">0</property>
+						<property name="centering-policy">strict</property>
 
-        <child>
-          <object class="AdwHeaderBar" id="header">
-            <property name="hexpand">1</property>
-            <property name="show_end_title_buttons">0</property>
-            <property name="show_start_title_buttons">0</property>
-            <property name="centering-policy">strict</property>
+						<property name="title-widget">
+							<object class="AdwViewSwitcher" id="title_switcher">
+								<property name="policy">wide</property>
+								<property name="stack">stack</property>
+							</object>
+						</property>
+						<child type="start">
+							<object class="GtkButton" id="close_button">
+								<property name="label" translatable="yes">Cancel</property>
+								<!-- <signal name="clicked" handler="on_close" swapped="no"/> -->
+								<property name="action-name">composer.exit</property>
+							</object>
+						</child>
+						<child type="end">
+							<object class="GtkButton" id="commit_button">
+								<property name="label" translatable="yes">_Publish</property>
+								<property name="use-underline">1</property>
+								<signal name="clicked" handler="on_commit" swapped="no" />
+							</object>
+						</child>
+					</object>
+				</child>
 
-            <child type="title">
-              <object class="AdwViewSwitcher" id="title_switcher">
-                <!-- <property name="title" translatable="yes">Title</property> -->
-                <!-- <property name="subtitle" translatable="yes">Subtitle</property> -->
-              </object>
-            </child>
-            <child type="start">
-              <object class="GtkButton" id="close_button">
-                <property name="label" translatable="yes">Cancel</property>
-                <!-- <signal name="clicked" handler="on_close" swapped="no"/> -->
-                <property name="action-name">composer.exit</property>
-              </object>
-            </child>
-            <child type="end">
-              <object class="GtkButton" id="commit_button">
-                <property name="label" translatable="yes">_Publish</property>
-                <property name="use-underline">1</property>
-                <signal name="clicked" handler="on_commit" swapped="no"/>
-              </object>
-            </child>
+				<property name="content">
+					<object class="AdwViewStack" id="stack">
+						<property name="hexpand">1</property>
+						<property name="vexpand">1</property>
+					</object>
+				</property>
 
-          </object>
-        </child>
-
-        <child>
-          <object class="AdwViewStack" id="stack">
-            <property name="hexpand">1</property>
-            <property name="vexpand">1</property>
-          </object>
-        </child>
-        <child>
-          <object class="AdwViewSwitcherBar" id="switcher_bar">
-            <property name="stack">stack</property>
-          </object>
-        </child>
-      </object>
-    </child>
-
-  </template>
+				<child type="bottom">
+					<object class="AdwViewSwitcherBar" id="switcher_bar">
+						<property name="stack">stack</property>
+					</object>
+				</child>
+			</object>
+		</child>
+	</template>
 </interface>

--- a/src/Dialogs/Composer/Dialog.vala
+++ b/src/Dialogs/Composer/Dialog.vala
@@ -167,6 +167,8 @@ public class Tuba.Dialogs.Compose : Adw.Window {
 
 			disconnect (build_sigid);
 		});
+
+		stack.notify["visible-child"].connect (on_view_switched);
 	}
 	~Compose () {
 		debug ("Destroying composer");
@@ -174,6 +176,13 @@ public class Tuba.Dialogs.Compose : Adw.Window {
 			page.dispose ();
 		}
 		t_pages = {};
+	}
+
+	void on_view_switched () {
+		var child = stack.visible_child as ComposerPage;
+		if (child != null) {
+			this.title = child.title;
+		}
 	}
 
 	Adw.MessageDialog? dlg;

--- a/src/Dialogs/Composer/EditorPage.vala
+++ b/src/Dialogs/Composer/EditorPage.vala
@@ -4,6 +4,15 @@ public class Tuba.EditorPage : ComposerPage {
 	protected int64 remaining_chars { get; set; default = 0; }
 	public signal void ctrl_return_pressed ();
 
+	private bool hide_dropdown_arrows {
+		set {
+			Gtk.DropDown?[] dropdown_widgets = {visibility_button, language_button, content_type_button};
+			foreach (Gtk.DropDown? dropdown in dropdown_widgets) {
+				if (dropdown != null) dropdown.show_arrow = !value;
+			}
+		}
+	}
+
 	construct {
 		//  translators: "Text" as in text-based input
 		title = _("Text");
@@ -17,13 +26,14 @@ public class Tuba.EditorPage : ComposerPage {
 
 	public override void on_build () {
 		base.on_build ();
+		bool supports_mime_types = accounts.active.supported_mime_types.n_items > 1;
 
 		install_editor ();
 		install_overlay (status.status);
 		install_visibility (status.visibility);
 		install_languages (status.language);
 
-		if (accounts.active.supported_mime_types.n_items > 1)
+		if (supports_mime_types)
 			install_content_type_button (settings.default_content_type);
 		add_button (new Gtk.Separator (Gtk.Orientation.VERTICAL));
 		install_cw (status.spoiler_text);
@@ -31,6 +41,8 @@ public class Tuba.EditorPage : ComposerPage {
 		install_emoji_picker ();
 
 		validate ();
+
+		if (supports_mime_types) hide_dropdown_arrows = true;
 	}
 
 	protected virtual signal void recount_chars () {}


### PR DESCRIPTION
- Uses the adw 1.4 widgets + breakpoints
- Sets the title
- fixes the composer overflowing when content types are available by hiding the dropdown arrows