### PR TITLE
feat(Media): copy to clipboard action

### DIFF
--- a/src/Widgets/Attachment/Image.vala
+++ b/src/Widgets/Attachment/Image.vala
@@ -45,6 +45,7 @@ public class Tuba.Widgets.Attachment.Image : Widgets.Attachment.Item {
 		button.child = media_overlay;
 	}
 
+	const string[] CAN_COPY_KINDS = { "IMAGE" };
 	protected Gtk.Image? media_icon = null;
 	protected override void on_rebind () {
 		base.on_rebind ();
@@ -70,6 +71,28 @@ public class Tuba.Widgets.Attachment.Image : Widgets.Attachment.Item {
 			// Doesn't get applied sometimes when set above
 			media_icon.icon_size = Gtk.IconSize.LARGE;
 		}
+
+		copy_media_simple_action.set_enabled (media_kind in CAN_COPY_KINDS);
+	}
+
+	protected override void copy_media () {
+		debug ("Begin copy-media action");
+		Host.download.begin (entity.url, (obj, res) => {
+			try {
+				string path = Host.download.end (res);
+
+				Gdk.Texture texture = Gdk.Texture.from_filename (path);
+				if (texture == null) return;
+
+				Gdk.Clipboard clipboard = Gdk.Display.get_default ().get_clipboard ();
+				clipboard.set_texture (texture);
+			} catch (Error e) {
+				var dlg = app.inform (_("Error"), e.message);
+				dlg.present ();
+			}
+
+			debug ("End copy-media action");
+		});
 	}
 
 	protected virtual void on_cache_response (bool is_loaded, owned Gdk.Paintable? data) {

--- a/src/Widgets/Attachment/Item.vala
+++ b/src/Widgets/Attachment/Item.vala
@@ -73,11 +73,17 @@ public class Tuba.Widgets.Attachment.Item : Adw.Bin {
 		}
 	}
 
+	protected SimpleAction copy_media_simple_action;
 	construct {
 		height_request = 164;
 
 		actions = new GLib.SimpleActionGroup ();
 		actions.add_action_entries (ACTION_ENTRIES, this);
+
+		copy_media_simple_action = new SimpleAction ("copy-media", null);
+		copy_media_simple_action.activate.connect (copy_media);
+		actions.add_action (copy_media_simple_action);
+
 		this.insert_action_group ("attachment", actions);
 
 		notify["entity"].connect (on_rebind);
@@ -176,9 +182,15 @@ public class Tuba.Widgets.Attachment.Item : Adw.Bin {
 		menu_model.append (_("Copy URL"), "attachment.copy-url");
 		menu_model.append (_("Save Media"), "attachment.save-as");
 
+		var copy_media_menu_item = new MenuItem (_("Copy Media"), "attachment.copy-media");
+		copy_media_menu_item.set_attribute_value ("hidden-when", "action-disabled");
+		menu_model.append_item (copy_media_menu_item);
+
 		context_menu = new Gtk.PopoverMenu.from_model (menu_model);
 		context_menu.set_parent (this);
 	}
+
+	protected virtual void copy_media () {}
 
 	protected virtual void on_rebind () {
 		alt_btn.visible = entity != null && entity.description != null && entity.description != "";


### PR DESCRIPTION
fix: #524

This is a bit messy:

- copying attachments (outside of media viewer) will need to first download the full image
- you can only copy images
- the action will only be visible on image

(Tuba's media viewer can load multiple formats (videos, audio, remote audio) so the above is necessary)