### PR TITLE
feat: DEVMODE

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -42,6 +42,11 @@ if devel
   endif
 endif
 
+devmode = false
+if devmode
+  add_project_arguments(['--define=DEV_MODE'], language: 'vala')
+endif
+
 configure_file(output: 'config.h', configuration: config)
 
 add_project_arguments (

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -216,7 +216,9 @@ namespace Tuba {
 			ColorScheme color_scheme = (ColorScheme) settings.get_enum ("color-scheme");
 			style_manager.color_scheme = color_scheme.to_adwaita_scheme ();
 
-			set_accels_for_action ("app.dev-only-window", {"F2"});
+			#if DEV_MODE
+				set_accels_for_action ("app.dev-only-window", {"F2"});
+			#endif
 			set_accels_for_action ("app.about", {"F1"});
 			set_accels_for_action ("app.compose", {"<Ctrl>T", "<Ctrl>N"});
 			set_accels_for_action ("app.back", {"<Alt>BackSpace", "<Alt>Left", "Escape", "<Alt>KP_Left", "Pointer_DfltBtnPrev"});

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -42,6 +42,11 @@ namespace Tuba {
 		public signal void refresh ();
 		public signal void toast (string title);
 
+		#if DEV_MODE
+			public signal void dev_new_post (Json.Node node);
+			public signal void dev_new_notification (Json.Node node);
+		#endif
+
 		//  public CssProvider css_provider = new CssProvider ();
 		//  public CssProvider zoom_css_provider = new CssProvider (); //FIXME: Zoom not working
 
@@ -51,6 +56,11 @@ namespace Tuba {
 		};
 
 		private const GLib.ActionEntry[] APP_ENTRIES = {
+			#if DEV_MODE
+			 	// vala-lint=block-opening-brace-space-before
+				{ "dev-only-window", dev_only_window_activated },
+			#endif
+			 // vala-lint=block-opening-brace-space-before
 			{ "about", about_activated },
 			{ "compose", compose_activated },
 			{ "back", back_activated },
@@ -68,6 +78,12 @@ namespace Tuba {
 			{ "open-preferences", open_preferences },
 			{ "open-current-account-profile", open_current_account_profile }
 		};
+
+		#if DEV_MODE
+			private void dev_only_window_activated () {
+				new Dialogs.Dev ().show ();
+			}
+		#endif
 
 		private void remove_from_followers (GLib.SimpleAction action, GLib.Variant? value) {
 			if (value == null) return;
@@ -200,6 +216,7 @@ namespace Tuba {
 			ColorScheme color_scheme = (ColorScheme) settings.get_enum ("color-scheme");
 			style_manager.color_scheme = color_scheme.to_adwaita_scheme ();
 
+			set_accels_for_action ("app.dev-only-window", {"F2"});
 			set_accels_for_action ("app.about", {"F1"});
 			set_accels_for_action ("app.compose", {"<Ctrl>T", "<Ctrl>N"});
 			set_accels_for_action ("app.back", {"<Alt>BackSpace", "<Alt>Left", "Escape", "<Alt>KP_Left", "Pointer_DfltBtnPrev"});

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -241,7 +241,10 @@ namespace Tuba {
 		}
 
 		protected override void shutdown () {
-			settings.apply ();
+			#if !DEV_MODE
+				settings.apply ();
+			#endif
+
 			base.shutdown ();
 		}
 

--- a/src/Dialogs/DevConsole.vala
+++ b/src/Dialogs/DevConsole.vala
@@ -1,0 +1,127 @@
+// DEV ONLY WINDOW
+// Do not translate
+public class Tuba.Dialogs.Dev : Adw.PreferencesWindow {
+	public class WindowSize : Object {
+		public int w { get; construct set; }
+		public int h { get; construct set; }
+		public string name {
+			owned get {
+				return @"$(w)x$(h)";
+			}
+		}
+
+		public WindowSize (int w, int h) {
+			Object (w: w, h: h);
+		}
+	}
+
+	public GLib.ListStore ws_cr_model;
+
+	WindowSize[] window_sizes = {
+		new WindowSize (624, 351),
+		new WindowSize (800, 450),
+		new WindowSize (1024, 576),
+		new WindowSize (1200, 675),
+		new WindowSize (1600, 900),
+		new WindowSize (360, 654),
+		new WindowSize (720, 360)
+	};
+
+	construct {
+		var general_settings = new Adw.PreferencesPage ();
+		var appearance_group = new Adw.PreferencesGroup () {
+			title = "Appearance"
+		};
+
+		var color_scheme_sr = new Adw.SwitchRow () {
+			title = "Dark Mode",
+			active = Adw.StyleManager.get_default ().dark
+		};
+		color_scheme_sr.notify["active"].connect (() => update_color_scheme (color_scheme_sr.active));
+
+		Gtk.SignalListItemFactory signallistitemfactory = new Gtk.SignalListItemFactory ();
+		signallistitemfactory.bind.connect (ws_cr_bind);
+
+		ws_cr_model = new GLib.ListStore (typeof (WindowSize));
+		ws_cr_model.splice (0, 0, window_sizes);
+
+		var window_size_cr = new Adw.ComboRow () {
+			title = "Window Size",
+			model = ws_cr_model,
+			factory = signallistitemfactory
+		};
+		window_size_cr.notify["selected"].connect (() => update_window_size ((WindowSize) window_size_cr.selected_item));
+
+		appearance_group.add (color_scheme_sr);
+		appearance_group.add (window_size_cr);
+		general_settings.add (appearance_group);
+
+		var notifications_group = new Adw.PreferencesGroup () {
+			title = "Notifications"
+		};
+
+		var notification_badge_row = new Adw.SpinRow.with_range (0, 200, 1.0) {
+			title = "Badge",
+			value = Tuba.Mastodon.Account.PLACE_NOTIFICATIONS.badge,
+
+		};
+		notification_badge_row.notify["value"].connect (() => update_notification_badge (notification_badge_row.value));
+
+		var notification_entry_row = new Adw.EntryRow () {
+			title = "Prepend from JSON",
+			show_apply_button = true
+		};
+		notification_entry_row.apply.connect (() => new_notification (notification_entry_row.text));
+
+		notifications_group.add (notification_badge_row);
+		notifications_group.add (notification_entry_row);
+		general_settings.add (notifications_group);
+
+		var status_group = new Adw.PreferencesGroup () {
+			title = "Status"
+		};
+
+		var status_entry_row = new Adw.EntryRow () {
+			title = "Prepend from JSON",
+			show_apply_button = true
+		};
+		status_entry_row.apply.connect (() => new_post (status_entry_row.text));
+
+		status_group.add (status_entry_row);
+		general_settings.add (status_group);
+
+		this.add (general_settings);
+	}
+
+	private void new_notification (string? json) {
+		if (json == null || json.length == 0) return;
+
+		var parser = new Json.Parser ();
+		parser.load_from_data (json, -1);
+		app.dev_new_notification (parser.steal_root ());
+	}
+
+	private void new_post (string? json) {
+		if (json == null || json.length == 0) return;
+
+		var parser = new Json.Parser ();
+		parser.load_from_data (json, -1);
+		app.dev_new_post (parser.steal_root ());
+	}
+
+	private void ws_cr_bind (GLib.Object item) {
+		((Gtk.ListItem) item).child = new Gtk.Label (((WindowSize)((Gtk.ListItem) item).item).name);
+	}
+
+	private void update_notification_badge (double value) {
+		Tuba.Mastodon.Account.PLACE_NOTIFICATIONS.badge = (int) value;
+	}
+
+	private void update_window_size (WindowSize windowsize) {
+		app.main_window.set_default_size (windowsize.w, windowsize.h);
+	}
+
+	private void update_color_scheme (bool dark_mode) {
+		Adw.StyleManager.get_default ().color_scheme = dark_mode ? Adw.ColorScheme.FORCE_DARK : Adw.ColorScheme.FORCE_LIGHT;
+	}
+}

--- a/src/Dialogs/DevConsole.vala
+++ b/src/Dialogs/DevConsole.vala
@@ -67,30 +67,47 @@ public class Tuba.Dialogs.Dev : Adw.PreferencesWindow {
 		};
 		notification_badge_row.notify["value"].connect (() => update_notification_badge (notification_badge_row.value));
 
-		var notification_entry_row = new Adw.EntryRow () {
-			title = "Prepend from JSON",
-			show_apply_button = true
-		};
-		notification_entry_row.apply.connect (() => new_notification (notification_entry_row.text));
-
 		notifications_group.add (notification_badge_row);
-		notifications_group.add (notification_entry_row);
 		general_settings.add (notifications_group);
 
-		var status_group = new Adw.PreferencesGroup () {
-			title = "Status"
+		var json_group = new Adw.PreferencesGroup () {
+			title = "Entities"
 		};
 
 		var status_entry_row = new Adw.EntryRow () {
-			title = "Prepend from JSON",
+			title = "Prepend Status from JSON",
 			show_apply_button = true
 		};
 		status_entry_row.apply.connect (() => new_post (status_entry_row.text));
 
-		status_group.add (status_entry_row);
-		general_settings.add (status_group);
+		var notification_entry_row = new Adw.EntryRow () {
+			title = "Prepend Notification from JSON",
+			show_apply_button = true
+		};
+		notification_entry_row.apply.connect (() => new_notification (notification_entry_row.text));
+
+		var profile_entry_row = new Adw.EntryRow () {
+			title = "Open Profile from JSON",
+			show_apply_button = true
+		};
+		profile_entry_row.apply.connect (() => open_account (profile_entry_row.text));
+
+		json_group.add (status_entry_row);
+		json_group.add (notification_entry_row);
+		json_group.add (profile_entry_row);
+		general_settings.add (json_group);
 
 		this.add (general_settings);
+	}
+
+	private void open_account (string? json) {
+		if (json == null || json.length == 0) return;
+
+		var parser = new Json.Parser ();
+		parser.load_from_data (json, -1);
+		API.Account acc = (API.Account) Entity.from_json (typeof (API.Account), parser.steal_root ());
+
+		app.main_window.open_view (new Views.Profile (acc));
 	}
 
 	private void new_notification (string? json) {

--- a/src/Dialogs/MainWindow.vala
+++ b/src/Dialogs/MainWindow.vala
@@ -37,9 +37,11 @@ public class Tuba.Dialogs.MainWindow: Adw.ApplicationWindow, Saveable {
 		main_page = new Adw.NavigationPage (new Views.Main (), _("Home"));
 		navigation_view.add (main_page);
 
-		if (Build.PROFILE == "development") {
-			this.add_css_class ("devel");
-		}
+		#if !DEV_MODE
+			if (Build.PROFILE == "development") {
+				this.add_css_class ("devel");
+			}
+		#endif
 	}
 
 	public bool is_media_viewer_visible () {

--- a/src/Dialogs/meson.build
+++ b/src/Dialogs/meson.build
@@ -7,4 +7,8 @@ sources += files(
     'Saveable.vala',
 )
 
+if devmode
+  sources += files ('DevConsole.vala')
+endif
+
 subdir('Composer')

--- a/src/Services/Accounts/InstanceAccount.vala
+++ b/src/Services/Accounts/InstanceAccount.vala
@@ -61,6 +61,24 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 		this.construct_streamable ();
 		this.stream_event[EVENT_NOTIFICATION].connect (on_notification_event);
 		this.register_known_places (this.known_places);
+
+		#if DEV_MODE
+			app.dev_new_notification.connect (node => {
+				try {
+					var entity = create_entity<API.Notification> (node);
+
+					var id = int.parse (entity.id);
+					if (id > last_received_id) {
+						last_received_id = id;
+
+						unread_count++;
+						send_toast (entity);
+					}
+				} catch (Error e) {
+					warning (@"on_notification_event: $(e.message)");
+				}
+			});
+		#endif
 	}
 	~InstanceAccount () {
 		destruct_streamable ();

--- a/src/Services/Network/Streams.vala
+++ b/src/Services/Network/Streams.vala
@@ -7,6 +7,10 @@ public class Tuba.Streams : Object {
 	}
 
 	public void subscribe (string? url, Streamable s) {
+		#if DEV_MODE
+			return;
+		#endif
+
 		if (url == null)
 			return;
 

--- a/src/Services/Settings.vala
+++ b/src/Services/Settings.vala
@@ -65,7 +65,9 @@ public class Tuba.Settings : GLib.Settings {
 	}
 
 	void on_changed (string key) {
-		if (key in apply_instantly_keys) apply ();
+		#if !DEV_MODE
+			if (key in apply_instantly_keys) apply ();
+		#endif
 	}
 }
 

--- a/src/Views/Home.vala
+++ b/src/Views/Home.vala
@@ -27,6 +27,16 @@ public class Tuba.Views.Home : Views.Timeline {
 		});
 
         scrolled_overlay.add_overlay (compose_button_rev);
+
+        #if DEV_MODE
+            app.dev_new_post.connect (node => {
+                try {
+                    model.insert (0, Entity.from_json (accepts, node));
+                } catch (Error e) {
+                    warning (@"Error getting Entity from json: $(e.message)");
+                }
+            });
+        #endif
     }
 
     double last_adjustment = 0;

--- a/src/Views/Notifications.vala
+++ b/src/Views/Notifications.vala
@@ -3,16 +3,25 @@ public class Tuba.Views.Notifications : Views.Timeline, AccountHolder, Streamabl
 	private Binding badge_number_binding;
 
 	construct {
-        url = "/api/v1/notifications";
-        label = _("Notifications");
-        icon = "tuba-bell-outline-symbolic";
-        accepts = typeof (API.Notification);
+		url = "/api/v1/notifications";
+		label = _("Notifications");
+		icon = "tuba-bell-outline-symbolic";
+		accepts = typeof (API.Notification);
 		badge_number = 0;
 		needs_attention = false;
 
 		stream_event[InstanceAccount.EVENT_NOTIFICATION].connect (on_new_post);
-    }
 
+		#if DEV_MODE
+			app.dev_new_notification.connect (node => {
+				try {
+					model.insert (0, Entity.from_json (accepts, node));
+				} catch (Error e) {
+					warning (@"Error getting Entity from json: $(e.message)");
+				}
+			});
+		#endif
+	}
 	~Notifications () {
 		warning ("Destroying Notifications");
 		stream_event[InstanceAccount.EVENT_NOTIFICATION].disconnect (on_new_post);
@@ -63,5 +72,5 @@ public class Tuba.Views.Notifications : Views.Timeline, AccountHolder, Streamabl
 		return account != null
 			? @"$(account.instance)/api/v1/streaming/?stream=user:notification&access_token=$(account.access_token)"
 			: null;
-    }
+	}
 }


### PR DESCRIPTION
Taking screenshots for the stores is awfully tedious, I usually run a Mastodon instance, create accounts, set them up, create the relationships, create the posts and quickly take screenshots. With DEVMODE, there's a special dialog that allows you to set some stuff up and push custom entities

![image](https://github.com/GeopJr/Tuba/assets/18014039/6613027c-8b4f-43de-8a64-a074053de2ad)
