### PR TITLE
chore(metadata): bump

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -23,7 +23,7 @@ body:
 - type: textarea
   attributes:
     label: Logs and/or Screenshots
-    description: Terminal logs are often invaluable. If you can, launch the app from terminal and paste the output here. Please remove instance domains and post ids before creating this issue for privacy reasons.
+    description: Terminal logs are often invaluable. If you can, launch the app from terminal and paste the output here. Please remove instance domains and post ids before creating this issue for privacy reasons. If there are no useful logs available, run `G_MESSAGES_DEBUG=Tuba flatpak run dev.geopjr.Tuba` for a verbose output.
     value: |
       ```
       <paste your logs here>
@@ -70,7 +70,7 @@ body:
     label: Troubleshooting information
     description: You can find this info under About > Troubleshooting > Debugging Information.
   validations:
-    required: true
+    required: false
 - type: textarea
   attributes:
     label: Additional Context

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -14,8 +14,5 @@ body:
     label: Implementation Details
     description: How should this feature be implemented?
     options:
-      - label: This should be an option in settings.
-      - label: This should be only available to some fediverse backends. (Include which ones on the above field).
-      - label: This is client-only (and shouldn't sync with the instance).
       - label: This follows the [GNOME HIG](https://developer.gnome.org/hig/).
         required: true

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,132 +1,136 @@
-# Contributor Covenant Code of Conduct
+# Code of Conduct
 
-## Our Pledge
-
-We as members, contributors, and leaders pledge to make participation in our
-community a harassment-free experience for everyone, regardless of age, body
-size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, caste, color, religion, or sexual identity
-and orientation.
-
-We pledge to act and interact in ways that contribute to an open, welcoming,
-diverse, inclusive, and healthy community.
-
-## Our Standards
-
-Examples of behavior that contributes to a positive environment for our
-community include:
-
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
-  and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
-  overall community
-
-Examples of unacceptable behavior include:
-
-* The use of sexualized language or imagery, and sexual attention or
-  advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
-  address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
-
-## Enforcement Responsibilities
-
-Community leaders are responsible for clarifying and enforcing our standards of
-acceptable behavior and will take appropriate and fair corrective action in
-response to any behavior that they deem inappropriate, threatening, offensive,
-or harmful.
-
-Community leaders have the right and responsibility to remove, edit, or reject
-comments, commits, code, wiki edits, issues, and other contributions that are
-not aligned to this Code of Conduct, and will communicate reasons for moderation
-decisions when appropriate.
+Thank you for being a part of the GNOME project. We value your participation and want everyone to have an enjoyable and fulfilling experience. Accordingly, all participants are expected to follow this Code of Conduct, and to show respect, understanding, and consideration to one another. Thank you for helping make this a welcoming, friendly community for everyone.
 
 ## Scope
 
-This Code of Conduct applies within all community spaces, and also applies when
-an individual is officially representing the community in public spaces.
-Examples of representing our community include using an official e-mail address,
-posting via an official social media account, or acting as an appointed
-representative at an online or offline event.
+This Code of Conduct applies to all GNOME community spaces, including, but not limited to:
 
-## Enforcement
+ * Issue tracking systems - bugzilla.gnome.org
+ * Documentation and tutorials - developer.gnome.org
+ * Code repositories - git.gnome.org and gitlab.gnome.org
+ * Mailing lists - mail.gnome.org
+ * Wikis - wiki.gnome.org
+ * Chat and forums - irc.gnome.org, discourse.gnome.org, GNOME Telegram channels, and GNOME groups and channels on Matrix.org (including bridges to GNOME IRC channels)
+ * Community spaces hosted on gnome.org infrastructure
+ * Any other channels or groups which exist in order to discuss GNOME project activities
+ * All event venues and associated spaces, including conferences, hackfests, release parties, workshops and other small events
+ * All areas related to event venues: vendor exhibit halls, staff and meal areas, connecting infrastructure like walkways, hallways, elevators, and stairs
+ * Sponsor events, either on-site or off-site
+ * Private events off-site that involve one or more attendees
+ * Social events around the main event
+ * Private conversations taking place in official conference hotels
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-coc@geopjr.dev.
-All complaints will be reviewed and investigated promptly and fairly.
+Communication channels and private conversations that are normally out of scope may be considered in scope if a GNOME participant is being stalked or harassed. Social media conversations may be considered in-scope if the incident occurred under a GNOME event hashtag, or when an official GNOME account on social media is tagged, or within any other discussion about GNOME. The GNOME Foundation reserves the right to take actions against behaviors that happen in any context, if they are deemed to be relevant to the GNOME project and its participants.
 
-All community leaders are obligated to respect the privacy and security of the
-reporter of any incident.
+All participants in GNOME community spaces are subject to the Code of Conduct. This includes GNOME Foundation board members, corporate sponsors, and paid employees. This also includes volunteers, maintainers, leaders, contributors, contribution reviewers, issue reporters, GNOME users, and anyone participating in discussion in GNOME community spaces. For in-person events, this also includes all attendees, exhibitors, vendors, speakers, panelists, organizers, staff, and volunteers.
 
-## Enforcement Guidelines
+## Reporting an Incident
 
-Community leaders will follow these Community Impact Guidelines in determining
-the consequences for any action they deem in violation of this Code of Conduct:
+If you believe that someone is violating the Code of Conduct, or have any other concerns, please [contact the Code of Conduct committee](gnome-code-of-conduct-reporter-guide.md).
 
-### 1. Correction
+## Our Standards
 
-**Community Impact**: Use of inappropriate language or other behavior deemed
-unprofessional or unwelcome in the community.
+The GNOME community is dedicated to providing a positive experience for everyone, regardless of:
 
-**Consequence**: A private, written warning from community leaders, providing
-clarity around the nature of the violation and an explanation of why the
-behavior was inappropriate. A public apology may be requested.
+ * age
+ * body size
+ * caste
+ * citizenship
+ * disability
+ * education
+ * ethnicity
+ * familial status
+ * gender expression
+ * gender identity
+ * genetic information
+ * immigration status
+ * level of experience
+ * nationality
+ * personal appearance
+ * pregnancy
+ * race
+ * religion
+ * sex characteristics
+ * sexual orientation
+ * sexual identity
+ * socio-economic status
+ * tribe
+ * veteran status
 
-### 2. Warning
+### Community Guidelines
 
-**Community Impact**: A violation through a single incident or series
-of actions.
+Examples of behavior that contributes to creating a positive environment include:
 
-**Consequence**: A warning with consequences for continued behavior. No
-interaction with the people involved, including unsolicited interaction with
-those enforcing the Code of Conduct, for a specified period of time. This
-includes avoiding interactions in community spaces as well as external channels
-like social media. Violating these terms may lead to a temporary or
-permanent ban.
+ * **Be friendly.** Use welcoming and inclusive language.
+ * **Be empathetic.** Be respectful of differing viewpoints and experiences.
+ * **Be respectful.** When we disagree, we do so in a polite and constructive manner.
+ * **Be considerate.** Remember that decisions are often a difficult choice between competing priorities. Focus on what is best for the community. Keep discussions around technology choices constructive and respectful.
+ * **Be patient and generous.** If someone asks for help it is because they need it. When documentation is available that answers the question, politely point them to it. If the question is off-topic, suggest a more appropriate online space to seek help.
+ * **Try to be concise.** Read the discussion before commenting in order to not repeat a point that has been made.
 
-### 3. Temporary Ban
+### Inappropriate Behavior
 
-**Community Impact**: A serious violation of community standards, including
-sustained inappropriate behavior.
+Community members asked to stop any inappropriate behavior are expected to comply immediately.
 
-**Consequence**: A temporary ban from any sort of interaction or public
-communication with the community for a specified period of time. No public or
-private interaction with the people involved, including unsolicited interaction
-with those enforcing the Code of Conduct, is allowed during this period.
-Violating these terms may lead to a permanent ban.
+We want all participants in the GNOME community have the best possible experience they can. In order to be clear what that means, we've provided a list of examples of behaviors that are inappropriate for GNOME community spaces:
 
-### 4. Permanent Ban
+ * **Deliberate intimidation, stalking, or following.**
+ * **Sustained disruption of online discussion, talks, or other events.** Sustained disruption of events, online discussions, or meetings, including talks and presentations, will not be tolerated. This includes 'Talking over' or 'heckling' event speakers or influencing crowd actions that cause hostility in event sessions. Sustained disruption also includes drinking alcohol to excess or using recreational drugs to excess, or pushing others to do so.
+ * **Harassment of people who don't drink alcohol or other legal substances.** We do not tolerate derogatory comments about those who abstain from alcohol or other legal substances. We do not tolerate pushing people to drink, talking about their abstinence or preferences to others, or pressuring them to drink - physically or through jeering.
+ * **Sexist, racist, homophobic, transphobic, ableist language or otherwise exclusionary language.** This includes deliberately referring to someone by a gender that they do not identify with, and/or questioning the legitimacy of an individual's gender identity. If you're unsure if a word is derogatory, don't use it. This also includes repeated subtle and/or indirect discrimination.
+ * **Unwelcome sexual attention or behavior that contributes to a sexualized environment.** This includes sexualized comments, jokes or imagery in interactions, communications or presentation materials, as well as inappropriate touching, groping, or sexual advances. Sponsors should not use sexualized images, activities, or other material. Meetup organizing staff and other volunteer organizers should not use sexualized clothing/uniforms/costumes, or otherwise create a sexualized environment.
+ * **Unwelcome physical contact.** This includes touching a person without permission, including sensitive areas such as their hair, pregnant stomach, mobility device (wheelchair, scooter, etc) or tattoos. This also includes physically blocking or intimidating another person. Physical contact or simulated physical contact (such as emojis like "kiss") without affirmative consent is not acceptable. This includes sharing or distribution of sexualized images or text.
+ * **Violence or threats of violence.** Violence and threats of violence are not acceptable - online or offline. This includes incitement of violence toward any individual, including encouraging a person to commit self-harm. This also includes posting or threatening to post other people's personally identifying information ("doxxing") online.
+ * **Influencing or encouraging inappropriate behavior.** If you influence or encourage another person to violate the Code of Conduct, you may face the same consequences as if you had violated the Code of Conduct.
+ * **Possession of an offensive weapon at a GNOME event.** This includes anything deemed to be a weapon by the event organizers.
 
-**Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior, harassment of an
-individual, or aggression toward or disparagement of classes of individuals.
+### Safety versus Comfort
 
-**Consequence**: A permanent ban from any sort of public interaction within
-the community.
+The GNOME community prioritizes marginalized people's safety over privileged people's comfort, for example in situations involving:
+
+ * "Reverse"-isms, including "reverse racism," "reverse sexism," and "cisphobia"
+ * Reasonable communication of boundaries, such as "leave me alone," "go away," or "I'm not discussing this with you."
+ * Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or assumptions
+ * Communicating boundaries or criticizing oppressive behavior in a "tone" you don't find congenial
+
+The examples listed above are not against the Code of Conduct. If you have questions about the above statements, please [read our document on Supporting Diversity](supporting-diversity.md).
+
+Outreach and diversity efforts directed at under-represented groups are permitted under the code of conduct. For example, a social event for women would not be classified as being outside the Code of Conduct under this provision.
+
+Basic expectations for conduct are not covered by the "reverse-ism clause" and would be enforced irrespective of the demographics of those involved. For example, racial discrimination will not be tolerated, irrespective of the race of those involved. Nor would unwanted sexual attention be tolerated, whatever someone's gender or sexual orientation. Members of our community have the right to expect that participants in the project will uphold these standards.
+
+If a participant engages in behavior that violates this code of conduct, the GNOME Code of Conduct committee may take any action they deem appropriate. Examples of consequences are outlined in the [Committee Procedures Guide](gnome-code-of-conduct-committee-procedures.md).
+
+## Procedure for Handling Incidents
+
+ * [Reporter Guide](gnome-code-of-conduct-reporter-guide.md)
+
+ * [Moderator Procedures](gnome-code-of-conduct-moderator-procedures.md)
+
+ * [Committee Procedures Guide](gnome-code-of-conduct-committee-procedures.md)
+
+## License
+
+The GNOME Code of Conduct is licensed under a [Creative Commons Attribution Share-Alike 3.0 Unported License](http://creativecommons.org/licenses/by-sa/3.0/)
+
+[![Creative Commons License](http://i.creativecommons.org/l/by-sa/3.0/88x31.png)](http://creativecommons.org/licenses/by-sa/3.0/)
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 2.1, available at
-[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+The GNOME Code of Conduct was forked from the example policy from the [Geek Feminism wiki, created by the Ada Initiative and other volunteers](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy), which is under a Creative Commons Zero license.
 
-Community Impact Guidelines were inspired by
-[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+Additional language was incorporated and modified from the following Codes of Conduct:
 
-For answers to common questions about this code of conduct, see the FAQ at
-[https://www.contributor-covenant.org/faq][FAQ]. Translations are available
-at [https://www.contributor-covenant.org/translations][translations].
-
-[homepage]: https://www.contributor-covenant.org
-[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
-[Mozilla CoC]: https://github.com/mozilla/diversity
-[FAQ]: https://www.contributor-covenant.org/faq
-[translations]: https://www.contributor-covenant.org/translations
+ * [Citizen Code of Conduct](http://citizencodeofconduct.org/) is licensed [Creative Commons Attribution-ShareAlike 3.0 Unported License](https://creativecommons.org/licenses/by-sa/3.0/).
+ * [Code of Conduct template](https://github.com/sagesharp/code-of-conduct-template/) is licensed [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/) by [Otter Tech](https://otter.technology/code-of-conduct-training)
+ * [Contributor Covenant version 1.4](https://www.contributor-covenant.org/version/1/4/code-of-conduct) (licensed [CC BY 4.0](https://github.com/ContributorCovenant/contributor_covenant/blob/master/LICENSE.md))
+ * [Data Carpentry Code of Conduct](https://docs.carpentries.org/topic_folders/policies/index_coc.html) is licensed [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/)
+ * [Django Project Code of Conduct](https://www.djangoproject.com/conduct/) is licensed under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/)
+ * [Fedora Code of Conduct](http://fedoraproject.org/code-of-conduct)
+ * [Geek Feminism Anti-harassment Policy](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy) which is under a [Creative Commons Zero license](https://creativecommons.org/publicdomain/zero/1.0/)
+ * [GNOME Foundation Code of Conduct](https://wiki.gnome.org/action/recall/Foundation/CodeOfConduct?action=recall&rev=48)
+ * [LGBTQ in Technology Slack Code of Conduct](https://lgbtq.technology/coc.html) licensed [Creative Commons Zero](https://creativecommons.org/publicdomain/zero/1.0/)
+ * [Mozilla Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/) is licensed [Creative Commons Attribution-ShareAlike 3.0 Unported License](https://creativecommons.org/licenses/by-sa/3.0/).
+ * [Python Mentors Code of Conduct](http://pythonmentors.com/)
+ * [Speak Up! Community Code of Conduct](http://web.archive.org/web/20141109123859/http://speakup.io/coc.html), licensed under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -27,7 +27,7 @@ All participants in GNOME community spaces are subject to the Code of Conduct. T
 
 ## Reporting an Incident
 
-If you believe that someone is violating the Code of Conduct, or have any other concerns, please [contact the Code of Conduct committee](gnome-code-of-conduct-reporter-guide.md).
+If you believe that someone is violating the Code of Conduct, or have any other concerns, please [contact the Code of Conduct committee](https://wiki.gnome.org/Foundation/CodeOfConduct/ReporterGuide).
 
 ## Our Standards
 
@@ -94,21 +94,21 @@ The GNOME community prioritizes marginalized people's safety over privileged peo
  * Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or assumptions
  * Communicating boundaries or criticizing oppressive behavior in a "tone" you don't find congenial
 
-The examples listed above are not against the Code of Conduct. If you have questions about the above statements, please [read our document on Supporting Diversity](supporting-diversity.md).
+The examples listed above are not against the Code of Conduct. If you have questions about the above statements, please [read our document on Supporting Diversity](https://wiki.gnome.org/Foundation/CodeOfConduct/SupportingDiversity).
 
 Outreach and diversity efforts directed at under-represented groups are permitted under the code of conduct. For example, a social event for women would not be classified as being outside the Code of Conduct under this provision.
 
 Basic expectations for conduct are not covered by the "reverse-ism clause" and would be enforced irrespective of the demographics of those involved. For example, racial discrimination will not be tolerated, irrespective of the race of those involved. Nor would unwanted sexual attention be tolerated, whatever someone's gender or sexual orientation. Members of our community have the right to expect that participants in the project will uphold these standards.
 
-If a participant engages in behavior that violates this code of conduct, the GNOME Code of Conduct committee may take any action they deem appropriate. Examples of consequences are outlined in the [Committee Procedures Guide](gnome-code-of-conduct-committee-procedures.md).
+If a participant engages in behavior that violates this code of conduct, the GNOME Code of Conduct committee may take any action they deem appropriate. Examples of consequences are outlined in the [Committee Procedures Guide](https://wiki.gnome.org/Foundation/CodeOfConduct/CommitteeProcedures).
 
 ## Procedure for Handling Incidents
 
- * [Reporter Guide](gnome-code-of-conduct-reporter-guide.md)
+ * [Reporter Guide](https://wiki.gnome.org/Foundation/CodeOfConduct/ReporterGuide)
 
- * [Moderator Procedures](gnome-code-of-conduct-moderator-procedures.md)
+ * [Moderator Procedures](https://wiki.gnome.org/Foundation/CodeOfConduct/ModeratorProcedures)
 
- * [Committee Procedures Guide](gnome-code-of-conduct-committee-procedures.md)
+ * [Committee Procedures Guide](https://wiki.gnome.org/Foundation/CodeOfConduct/CommitteeProcedures)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ Package Name | Required Version
 :--- |---:|
 meson | 0.56
 valac | 0.48
-libglib-2.0-dev | 2.71.2
+libglib-2.0-dev | 2.76.0
 libjson-glib-dev | 1.4.4
 libxml2-dev | 2.9.10
 libgee-0.8-dev | 0.8.5
 libsoup3.0-dev | 3.0.0
-libgtk-4-dev | 4.3.0
-libadwaita-1.0-dev | 1.2.0
+libgtk-4-dev | 4.11.3
+libadwaita-1.0-dev | 1.4
 libsecret-1-dev | 0.20
 
 </details>

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 <h3 align="center">Browse the Fediverse</h3>
 <p align="center">
   <br />
-    <a href="./CODE_OF_CONDUCT.md"><img src="https://img.shields.io/badge/Contributor%20Covenant-v2.1-1970e3.svg?style=for-the-badge&labelColor=A2C4FA" alt="Contributor Covenant v2.1" /></a>
-    <a href="./LICENSE"><img src="https://img.shields.io/badge/LICENSE-GPL--3.0-1970e3.svg?style=for-the-badge&labelColor=A2C4FA" alt="License GPL-3.0" /></a>
-    <a href="https://github.com/GeopJr/Tuba/actions/workflows/build.yml"><img alt="GitHub CI Status" src="https://img.shields.io/github/actions/workflow/status/GeopJr/Tuba/build.yml?branch=main&style=for-the-badge&labelColor=A2C4FA"></a>
+    <a href="./CODE_OF_CONDUCT.md"><img src="https://img.shields.io/badge/Code%20of%20Conduct-GNOME-f5c211.svg?style=for-the-badge&labelColor=f9f06b" alt="Contributor Covenant v2.1" /></a>
+    <a href="./LICENSE"><img src="https://img.shields.io/badge/LICENSE-GPL--3.0-f5c211.svg?style=for-the-badge&labelColor=f9f06b" alt="License GPL-3.0" /></a>
+    <a href="https://github.com/GeopJr/Tuba/actions/workflows/build.yml"><img alt="GitHub CI Status" src="https://img.shields.io/github/actions/workflow/status/GeopJr/Tuba/build.yml?branch=main&style=for-the-badge&labelColor=f9f06b"></a>
     <a href='https://stopthemingmy.app'><img width='193.455' alt='Please do not theme this app' src='https://stopthemingmy.app/badge.svg'/></a>
 </p>
 

--- a/Tuba.doap
+++ b/Tuba.doap
@@ -10,6 +10,8 @@
 	<homepage rdf:resource="https://github.com/GeopJr/Tuba" />
 	<bug-database rdf:resource="https://github.com/GeopJr/Tuba/issues" />
 	<programming-language>Vala</programming-language>
+	<platform>GTK 4</platform>
+	<platform>Libadwaita</platform>  
 	<maintainer>
 		<foaf:Person>
 			<foaf:name>Evangelos "GeopJr" Paterakis</foaf:name>

--- a/data/dev.geopjr.Tuba.metainfo.xml.in
+++ b/data/dev.geopjr.Tuba.metainfo.xml.in
@@ -21,6 +21,7 @@
   <url type="bugtracker">https://github.com/GeopJr/Tuba/issues</url>
   <url type="translate">https://hosted.weblate.org/engage/tuba/</url>
   <url type="donation">https://geopjr.dev/donate</url>
+  <url type="contact">https://matrix.to/#/#tuba:gnome.org</url>
   <screenshots>
     <screenshot type="default">
       <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/main/data/screenshots/screenshot-1.png</image>

--- a/meson.build
+++ b/meson.build
@@ -67,7 +67,7 @@ asresources = gnome.compile_resources(
     c_name: 'as',
 )
 
-libgtk_dep = dependency('gtk4', version: '>=4.10.0', required: true)
+libgtk_dep = dependency('gtk4', version: '>=4.11.3', required: true)
 libadwaita_dep = dependency('libadwaita-1', version: '>=1.4', required: true)
 gtksourceview_dep = dependency('gtksourceview-5', required: true, version: '>=5.6.0')
 libwebp_dep = dependency('libwebp', required: false)
@@ -104,7 +104,7 @@ sources = files(
 subdir('src')
 
 final_deps = [
-  dependency('glib-2.0', version: '>=2.70'),
+  dependency('glib-2.0', version: '>=2.76.0'),
   dependency('gee-0.8', version: '>=0.8.5'),
   dependency('libsoup-3.0'),
   dependency('json-glib-1.0', version: '>=1.4.4'),

--- a/vala-lint.conf
+++ b/vala-lint.conf
@@ -1,2 +1,3 @@
 [Checks]
 use-of-tabs=off
+line-length=off


### PR DESCRIPTION
- Simplify issue templates: no need for all the checkboxes in feature requests, bug trubleshooting info is not longer required as some bugs are about the app not starting or really unneeded, bug logs section clarification on how to get logs now that message logs became debug
- Move to GNOME's CoC in preparation for Circle
- README badges colors changed to the non-blue icon
- doap platform clarification
- metainfo contact link
- lint ignore line length