### PR TITLE
feat: add shortcut for Preferences

### DIFF
--- a/data/gtk/help-overlay.ui
+++ b/data/gtk/help-overlay.ui
@@ -11,7 +11,7 @@
             <property name="title" translatable="yes">General</property>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" translatable="yes">Show preferences</property>
+                <property name="title" translatable="yes">Show Preferences</property>
                 <property name="action-name">app.open-preferences</property>
               </object>
             </child>

--- a/data/gtk/help-overlay.ui
+++ b/data/gtk/help-overlay.ui
@@ -11,6 +11,12 @@
             <property name="title" translatable="yes">General</property>
             <child>
               <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes">Show preferences</property>
+                <property name="action-name">app.open-preferences</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Compose a new post</property>
                 <property name="action-name">app.compose</property>
               </object>

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -220,6 +220,7 @@ namespace Tuba {
 				set_accels_for_action ("app.dev-only-window", {"F2"});
 			#endif
 			set_accels_for_action ("app.about", {"F1"});
+			set_accels_for_action ("app.open-preferences", {"<Ctrl>comma"});
 			set_accels_for_action ("app.compose", {"<Ctrl>T", "<Ctrl>N"});
 			set_accels_for_action ("app.back", {"<Alt>BackSpace", "<Alt>Left", "Escape", "<Alt>KP_Left", "Pointer_DfltBtnPrev"});
 			set_accels_for_action ("app.refresh", {"<Ctrl>R", "F5"});


### PR DESCRIPTION
Per the [HIG](https://developer.gnome.org/hig/reference/keyboard.html), Ctrl+comma should open the Preferences.