### PR TITLE
feat(profile): role badges

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -571,3 +571,14 @@ video > overlay > revealer > controls {
 .ttl-account-switcher row:selected .blue-checkmark {
 	opacity: 1;
 }
+
+.profile-role {
+	background-color: alpha(currentColor, .1);
+	padding: 4px 11px;
+	font-size: 12.2px;
+	font-weight: 500;
+}
+
+.profile-role-border-radius {
+	border-radius: 9999px;
+}

--- a/data/ui/views/profile_header.ui
+++ b/data/ui/views/profile_header.ui
@@ -118,6 +118,17 @@
                     </child>
 
                     <child>
+                      <object class="GtkFlowBox" id="roles">
+                        <property name="visible">0</property>
+                        <property name="selection-mode">none</property>
+                        <property name="column_spacing">6</property>
+                        <property name="row_spacing">6</property>
+                        <!-- Lower values leave space between items -->
+                        <property name="max_children_per_line">100</property>
+                      </object>
+                    </child>
+
+                    <child>
                       <object class="TubaWidgetsMarkupView" id="note">
                         <property name="margin_top">6</property>
                       </object>

--- a/src/API/Account.vala
+++ b/src/API/Account.vala
@@ -28,6 +28,7 @@ public class Tuba.API.Account : Entity, Widgetizable {
 	public int64 followers_count { get; set; }
 	public int64 following_count { get; set; }
 	public int64 statuses_count { get; set; }
+	public Gee.ArrayList<API.AccountRole>? roles { get; set; default = null; }
 	public Gee.ArrayList<API.AccountField>? fields { get; set; default = null; }
 	public AccountSource? source { get; set; default = null; }
 

--- a/src/API/Account/Role.vala
+++ b/src/API/Account/Role.vala
@@ -1,0 +1,14 @@
+public class Tuba.API.AccountRole : Entity {
+	public string id { get; set; default = ""; }
+	public string name { get; set; default = ""; }
+    // Ignore for now
+	//  public string color { get; set; default = ""; }
+
+    public Gtk.Widget to_widget () {
+		return new Gtk.Label (name) {
+            wrap = true,
+            wrap_mode = Pango.WrapMode.WORD_CHAR,
+            css_classes = { "profile-role", "profile-role-border-radius" }
+        };
+	}
+}

--- a/src/API/Account/meson.build
+++ b/src/API/Account/meson.build
@@ -1,3 +1,4 @@
 sources += files(
+    'Role.vala',
     'Source.vala',
 )

--- a/src/API/Entity.vala
+++ b/src/API/Entity.vala
@@ -113,6 +113,9 @@ public class Tuba.Entity : GLib.Object, Widgetizable, Json.Serializable {
 				case "uploads":
 					contains = typeof (API.FunkwhaleTrack);
 					break;
+				case "roles":
+					contains = typeof (API.AccountRole);
+					break;
 				default:
 					contains = typeof (Entity);
 					break;

--- a/src/Widgets/ProfileCover.vala
+++ b/src/Widgets/ProfileCover.vala
@@ -1,6 +1,7 @@
 [GtkTemplate (ui = "/dev/geopjr/Tuba/ui/views/profile_header.ui")]
 protected class Tuba.Widgets.Cover : Gtk.Box {
 
+    [GtkChild] unowned Gtk.FlowBox roles;
     [GtkChild] unowned Widgets.Background background;
     [GtkChild] unowned Gtk.Label cover_badge;
     [GtkChild] unowned Gtk.Image cover_bot_badge;
@@ -83,6 +84,19 @@ protected class Tuba.Widgets.Cover : Gtk.Box {
         note.content = profile.account.note;
         cover_bot_badge.visible = profile.account.bot;
         update_cover_badge ();
+
+        if (profile.account.roles != null && profile.account.roles.size > 0) {
+            roles.visible = true;
+
+            foreach (API.AccountRole role in profile.account.roles) {
+                roles.append (
+                    new Gtk.FlowBoxChild () {
+                        child = role.to_widget (),
+                        css_classes = { "profile-role-border-radius" }
+                    }
+                );
+            }
+        }
 
         if (profile.account.id != accounts.active.id) {
             profile.rs.invalidated.connect (() => {


### PR DESCRIPTION
Mastodon 4.2.0 added profile badges

![Screenshot from 2023-09-26 00-26-15](https://github.com/GeopJr/Tuba/assets/18014039/a40ce50a-07b9-45df-897e-2219e95add73)

(Most instances will have 1-2 badges at most)

The style is mostly from PikaBuckup. The API returns a color for each badge/role but we will ignore it has the same issues as the freedesktop accents - a11y etc. Best we can do is find the closest adwaita color :shrug: Mastodon web also ignores it.

Design wise, mastodon web has an icon next to the labels but it gets repetitive. Mastodon web also moved the automated/bot icon/badge(?) there too, I don't think we should move tubas.
The badge background could change to a transparent accented one.