### PR TITLE
feat(ListEdit): hide posts from home

### DIFF
--- a/data/ui/dialogs/list_edit.ui
+++ b/data/ui/dialogs/list_edit.ui
@@ -22,11 +22,15 @@
         <property name="title" translatable="yes">General</property>
         <child>
           <object class="AdwPreferencesGroup">
-            <property name="title" translatable="yes">Info</property>
             <child>
               <object class="AdwEntryRow" id="title_row">
                 <property name="input-purpose">free-form</property>
                 <property name="title" translatable="yes">List Name</property>
+              </object>
+            </child>
+            <child>
+              <object class="AdwSwitchRow" id="hide_from_home_row">
+                <property name="title" translatable="yes">Hide these posts from home</property>
               </object>
             </child>
           </object>

--- a/src/API/List.vala
+++ b/src/API/List.vala
@@ -2,6 +2,7 @@ public class Tuba.API.List : Entity, Widgetizable {
     public string id { get; set; }
     public string title { get; set; }
     public string? replies_policy { get; set; default = null; }
+    public bool exclusive { get; set; default = false; }
 
 	public static List from (Json.Node node) throws Error {
 		return Entity.from_json (typeof (API.List), node) as API.List;


### PR DESCRIPTION
Mastodon 4.2.0 added a setting for lists to hide members' posts from the home timeline.

Needs further testing on non-supported versions (and probably hide it then?)