### PR TITLE
feat(Entity): OOP-ify the array deserialization mess

### DIFF
--- a/src/API/Account.vala
+++ b/src/API/Account.vala
@@ -31,6 +31,17 @@ public class Tuba.API.Account : Entity, Widgetizable {
 	public Gee.ArrayList<API.AccountField>? fields { get; set; default = null; }
 	public AccountSource? source { get; set; default = null; }
 
+	public override Type deserialize_array_type (string prop) {
+		switch (prop) {
+			case "emojis":
+				return typeof (API.Emoji);
+			case "fields":
+				return typeof (API.AccountField);
+		}
+
+		return base.deserialize_array_type (prop);
+	}
+
 	public string handle {
 		owned get {
 			return "@" + acct;

--- a/src/API/Account/Source.vala
+++ b/src/API/Account/Source.vala
@@ -4,8 +4,9 @@ public class Tuba.API.AccountSource : Entity {
 	public Gee.ArrayList<API.AccountField>? fields { get; set; default=null; }
 
 	public override Type deserialize_array_type (string prop) {
-		if (prop == "fields") {
-			return typeof (API.AccountField);
+		switch (prop) {
+			case "fields":
+				return typeof (API.AccountField);
 		}
 
 		return base.deserialize_array_type (prop);

--- a/src/API/Account/Source.vala
+++ b/src/API/Account/Source.vala
@@ -2,4 +2,12 @@ public class Tuba.API.AccountSource : Entity {
 	public string language { get; set; default = ""; }
 	public string note { get; set; default = ""; }
 	public Gee.ArrayList<API.AccountField>? fields { get; set; default=null; }
+
+	public override Type deserialize_array_type (string prop) {
+		if (prop == "fields") {
+			return typeof (API.AccountField);
+		}
+
+		return base.deserialize_array_type (prop);
+	}
 }

--- a/src/API/Announcement.vala
+++ b/src/API/Announcement.vala
@@ -8,6 +8,17 @@ public class Tuba.API.Announcement : Entity, Widgetizable {
 	public Gee.ArrayList<API.Emoji>? emojis { get; set; }
 	public Gee.ArrayList<API.EmojiReaction>? reactions { get; set; default = null; }
 
+	public override Type deserialize_array_type (string prop) {
+		switch (prop) {
+			case "reactions":
+				return typeof (API.EmojiReaction);
+			case "emojis":
+				return typeof (API.Emoji);
+		}
+
+		return base.deserialize_array_type (prop);
+	}
+
 	public Gee.HashMap<string, string>? emojis_map {
 		owned get {
 			return gen_emojis_map ();

--- a/src/API/BookWyrm.vala
+++ b/src/API/BookWyrm.vala
@@ -9,8 +9,9 @@ public class Tuba.API.BookWyrm : Entity, Widgetizable {
 	public Gee.ArrayList<string>? authors { get; set; default=null; }
 
 	public override Type deserialize_array_type (string prop) {
-		if (prop == "authors") {
-			return Type.STRING;
+		switch (prop) {
+			case "authors":
+				return Type.STRING;
 		}
 
 		return base.deserialize_array_type (prop);

--- a/src/API/BookWyrm.vala
+++ b/src/API/BookWyrm.vala
@@ -8,6 +8,14 @@ public class Tuba.API.BookWyrm : Entity, Widgetizable {
 	public API.BookWyrmCover? cover { get; set; default=null; }
 	public Gee.ArrayList<string>? authors { get; set; default=null; }
 
+	public override Type deserialize_array_type (string prop) {
+		if (prop == "authors") {
+			return Type.STRING;
+		}
+
+		return base.deserialize_array_type (prop);
+	}
+
 	public static BookWyrm from (Json.Node node) throws Error {
 		return Entity.from_json (typeof (API.BookWyrm), node) as API.BookWyrm;
 	}

--- a/src/API/Conversation.vala
+++ b/src/API/Conversation.vala
@@ -5,6 +5,14 @@ public class Tuba.API.Conversation : Entity, Widgetizable {
 	public bool unread { get; set; default = false; }
 	public API.Status? last_status { get; set; default = null; }
 
+	public override Type deserialize_array_type (string prop) {
+		if (prop == "accounts") {
+			return typeof (API.Account);
+		}
+
+		return base.deserialize_array_type (prop);
+	}
+
     public override Gtk.Widget to_widget () {
 		if (last_status == null) {
 			var account_list = "";

--- a/src/API/Conversation.vala
+++ b/src/API/Conversation.vala
@@ -6,8 +6,9 @@ public class Tuba.API.Conversation : Entity, Widgetizable {
 	public API.Status? last_status { get; set; default = null; }
 
 	public override Type deserialize_array_type (string prop) {
-		if (prop == "accounts") {
-			return typeof (API.Account);
+		switch (prop) {
+			case "accounts":
+				return typeof (API.Account);
 		}
 
 		return base.deserialize_array_type (prop);

--- a/src/API/Entity.vala
+++ b/src/API/Entity.vala
@@ -77,6 +77,8 @@ public class Tuba.Entity : GLib.Object, Widgetizable, Json.Serializable {
 			switch (contains) {
 				case Type.STRING:
 					return des_list_string (out val, node);
+				case Type.INT:
+					return des_list_int (out val, node);
 			}
 
 			return des_list (out val, node, contains);
@@ -105,8 +107,18 @@ public class Tuba.Entity : GLib.Object, Widgetizable, Json.Serializable {
 		var arr = new Gee.ArrayList<string> ();
 		if (!node.is_null ()) {
 			node.get_array ().foreach_element ((array, i, elem) => {
-				var obj = (string) elem.get_string ();
-				arr.add (obj);
+				arr.add ((string) elem.get_string ());
+			});
+		}
+		val = arr;
+		return true;
+	}
+
+	public static bool des_list_int (out Value val, Json.Node node) {
+		var arr = new Gee.ArrayList<int> ();
+		if (!node.is_null ()) {
+			node.get_array ().foreach_element ((array, i, elem) => {
+				arr.add ((int) elem.get_int ());
 			});
 		}
 		val = arr;

--- a/src/API/Entity.vala
+++ b/src/API/Entity.vala
@@ -56,6 +56,10 @@ public class Tuba.Entity : GLib.Object, Widgetizable, Json.Serializable {
 		return Json.gobject_to_data (this, out len);
 	}
 
+	public virtual Type deserialize_array_type (string prop) {
+		return typeof (Entity);
+	}
+
 	public override bool deserialize_property (string prop, out Value val, ParamSpec spec, Json.Node node) {
 		// debug (@"deserializing $prop of type $(val.type_name ())");
 		var success = default_deserialize_property (prop, out val, spec, node);
@@ -68,55 +72,13 @@ public class Tuba.Entity : GLib.Object, Widgetizable, Json.Serializable {
 		}
 
 		if (type.is_a (typeof (Gee.ArrayList))) {
-			Type contains;
+			Type contains = deserialize_array_type (prop);
 
-			//There has to be a better way
-			switch (prop) {
-				case "supported-mime-types":
-				case "languages":
-				case "authors":
+			switch (contains) {
+				case Type.STRING:
 					return des_list_string (out val, node);
-				case "media-attachments":
-					contains = typeof (API.Attachment);
-					break;
-				case "mentions":
-					contains = typeof (API.Mention);
-					break;
-				case "emojis":
-					contains = typeof (API.Emoji);
-					break;
-				case "emoji-reactions":
-				case "reactions":
-					contains = typeof (API.EmojiReaction);
-					break;
-				case "fields":
-					contains = typeof (API.AccountField);
-					break;
-				case "accounts":
-					contains = typeof (API.Account);
-					break;
-				case "statuses":
-					contains = typeof (API.Status);
-					break;
-				case "hashtags":
-					contains = typeof (API.Tag);
-					break;
-				case "history":
-					contains = typeof (API.TagHistory);
-					break;
-				case "streamingPlaylists":
-					contains = typeof (API.PeerTubeStreamingPlaylist);
-					break;
-				case "files":
-					contains = typeof (API.PeerTubeFile);
-					break;
-				case "uploads":
-					contains = typeof (API.FunkwhaleTrack);
-					break;
-				default:
-					contains = typeof (Entity);
-					break;
 			}
+
 			return des_list (out val, node, contains);
 		}
 

--- a/src/API/Funkwhale.vala
+++ b/src/API/Funkwhale.vala
@@ -14,6 +14,14 @@ public class Tuba.API.Funkwhale : Entity {
 		}
 	}
 
+	public override Type deserialize_array_type (string prop) {
+		if (prop == "uploads") {
+			return typeof (API.FunkwhaleTrack);
+		}
+
+		return base.deserialize_array_type (prop);
+	}
+
 	public static Funkwhale from (Json.Node node) throws Error {
 		return Entity.from_json (typeof (API.Funkwhale), node) as API.Funkwhale;
 	}

--- a/src/API/Funkwhale.vala
+++ b/src/API/Funkwhale.vala
@@ -15,8 +15,9 @@ public class Tuba.API.Funkwhale : Entity {
 	}
 
 	public override Type deserialize_array_type (string prop) {
-		if (prop == "uploads") {
-			return typeof (API.FunkwhaleTrack);
+		switch (prop) {
+			case "uploads":
+				return typeof (API.FunkwhaleTrack);
 		}
 
 		return base.deserialize_array_type (prop);

--- a/src/API/Instance.vala
+++ b/src/API/Instance.vala
@@ -10,6 +10,14 @@ public class Tuba.API.Instance : Entity {
 	public int64 upload_limit { get; set; default = 0; }
     public API.Pleroma.Instance? pleroma { get; set; default = null; }
 
+    public override Type deserialize_array_type (string prop) {
+		if (prop == "languages") {
+			return Type.STRING;
+		}
+
+		return base.deserialize_array_type (prop);
+	}
+
     public string[]? compat_supported_mime_types {
         get {
             if (pleroma != null && pleroma.metadata != null) {

--- a/src/API/Instance.vala
+++ b/src/API/Instance.vala
@@ -11,8 +11,9 @@ public class Tuba.API.Instance : Entity {
     public API.Pleroma.Instance? pleroma { get; set; default = null; }
 
     public override Type deserialize_array_type (string prop) {
-		if (prop == "languages") {
-			return Type.STRING;
+        switch (prop) {
+			case "languages":
+				return Type.STRING;
 		}
 
 		return base.deserialize_array_type (prop);

--- a/src/API/Instance/Mastodon/Configuration/MediaAttachments.vala
+++ b/src/API/Instance/Mastodon/Configuration/MediaAttachments.vala
@@ -7,8 +7,9 @@ public class Tuba.API.Mastodon.Configuration.MediaAttachments : Entity {
 	public int64 video_matrix_limit { get; set; }
 
 	public override Type deserialize_array_type (string prop) {
-		if (prop == "supported-mime-types") {
-			return Type.STRING;
+		switch (prop) {
+			case "supported-mime-types":
+				return Type.STRING;
 		}
 
 		return base.deserialize_array_type (prop);

--- a/src/API/Instance/Mastodon/Configuration/MediaAttachments.vala
+++ b/src/API/Instance/Mastodon/Configuration/MediaAttachments.vala
@@ -5,4 +5,12 @@ public class Tuba.API.Mastodon.Configuration.MediaAttachments : Entity {
 	public int64 video_size_limit { get; set; }
 	public int64 video_frame_rate_limit { get; set; }
 	public int64 video_matrix_limit { get; set; }
+
+	public override Type deserialize_array_type (string prop) {
+		if (prop == "supported-mime-types") {
+			return Type.STRING;
+		}
+
+		return base.deserialize_array_type (prop);
+	}
 }

--- a/src/API/PeerTube.vala
+++ b/src/API/PeerTube.vala
@@ -31,8 +31,9 @@ public class Tuba.API.PeerTube : Entity {
 	}
 
 	public override Type deserialize_array_type (string prop) {
-		if (prop == "streamingPlaylists") {
-			return typeof (API.PeerTubeStreamingPlaylist);
+		switch (prop) {
+			case "streamingPlaylists":
+				return typeof (API.PeerTubeStreamingPlaylist);
 		}
 
 		return base.deserialize_array_type (prop);

--- a/src/API/PeerTube.vala
+++ b/src/API/PeerTube.vala
@@ -29,4 +29,12 @@ public class Tuba.API.PeerTube : Entity {
 	public static PeerTube from (Json.Node node) throws Error {
 		return Entity.from_json (typeof (API.PeerTube), node) as API.PeerTube;
 	}
+
+	public override Type deserialize_array_type (string prop) {
+		if (prop == "streamingPlaylists") {
+			return typeof (API.PeerTubeStreamingPlaylist);
+		}
+
+		return base.deserialize_array_type (prop);
+	}
 }

--- a/src/API/PeerTube/StreamingPlaylist.vala
+++ b/src/API/PeerTube/StreamingPlaylist.vala
@@ -2,8 +2,9 @@ public class Tuba.API.PeerTubeStreamingPlaylist : Entity {
 	public Gee.ArrayList<API.PeerTubeFile>? files { get; set; default=null; }
 
 	public override Type deserialize_array_type (string prop) {
-		if (prop == "files") {
-			return typeof (API.PeerTubeFile);
+		switch (prop) {
+			case "files":
+				return typeof (API.PeerTubeFile);
 		}
 
 		return base.deserialize_array_type (prop);

--- a/src/API/PeerTube/StreamingPlaylist.vala
+++ b/src/API/PeerTube/StreamingPlaylist.vala
@@ -1,3 +1,11 @@
 public class Tuba.API.PeerTubeStreamingPlaylist : Entity {
 	public Gee.ArrayList<API.PeerTubeFile>? files { get; set; default=null; }
+
+	public override Type deserialize_array_type (string prop) {
+		if (prop == "files") {
+			return typeof (API.PeerTubeFile);
+		}
+
+		return base.deserialize_array_type (prop);
+	}
 }

--- a/src/API/Pleroma/Status.vala
+++ b/src/API/Pleroma/Status.vala
@@ -1,3 +1,11 @@
 public class Tuba.API.Pleroma.Status : Entity {
 	public Gee.ArrayList<API.EmojiReaction>? emoji_reactions { get; set; default = null; }
+
+	public override Type deserialize_array_type (string prop) {
+		if (prop == "emoji-reactions") {
+			return typeof (API.EmojiReaction);
+		}
+
+		return base.deserialize_array_type (prop);
+	}
 }

--- a/src/API/Pleroma/Status.vala
+++ b/src/API/Pleroma/Status.vala
@@ -2,8 +2,9 @@ public class Tuba.API.Pleroma.Status : Entity {
 	public Gee.ArrayList<API.EmojiReaction>? emoji_reactions { get; set; default = null; }
 
 	public override Type deserialize_array_type (string prop) {
-		if (prop == "emoji-reactions") {
-			return typeof (API.EmojiReaction);
+		switch (prop) {
+			case "emoji-reactions":
+				return typeof (API.EmojiReaction);
 		}
 
 		return base.deserialize_array_type (prop);

--- a/src/API/SearchResults.vala
+++ b/src/API/SearchResults.vala
@@ -4,6 +4,19 @@ public class Tuba.API.SearchResults : Entity {
 	public Gee.ArrayList<API.Status> statuses { get; set; }
 	public Gee.ArrayList<API.Tag> hashtags { get; set; }
 
+	public override Type deserialize_array_type (string prop) {
+		switch (prop) {
+			case "accounts":
+				return typeof (API.Account);
+			case "statuses":
+				return typeof (API.Status);
+			case "hashtags":
+				return typeof (API.Tag);
+		}
+
+		return base.deserialize_array_type (prop);
+	}
+
 	public static SearchResults from (Json.Node node) throws Error {
 		return Entity.from_json (typeof (SearchResults), node) as SearchResults;
 	}

--- a/src/API/Status.vala
+++ b/src/API/Status.vala
@@ -36,6 +36,22 @@ public class Tuba.API.Status : Entity, Widgetizable {
     public Gee.ArrayList<API.Emoji>? emojis { get; set; }
     public API.PreviewCard? card { get; set; default = null; }
 
+    public override Type deserialize_array_type (string prop) {
+		switch (prop) {
+			case "reactions":
+			case "emoji-reactions":
+				return typeof (API.EmojiReaction);
+			case "mention":
+				return typeof (API.Mention);
+            case "media-attachments":
+				return typeof (API.Attachment);
+            case "emojis":
+				return typeof (API.Emoji);
+		}
+
+		return base.deserialize_array_type (prop);
+	}
+
 	public Tuba.Views.Thread.ThreadRole tuba_thread_role { get; set; default = Tuba.Views.Thread.ThreadRole.NONE; }
 
     //  public string clean_content {

--- a/src/API/Status/PreviewCard.vala
+++ b/src/API/Status/PreviewCard.vala
@@ -114,6 +114,14 @@ public class Tuba.API.PreviewCard : Entity, Widgetizable {
 		}
 	}
 
+	public override Type deserialize_array_type (string prop) {
+		if (prop == "history") {
+			return typeof (API.TagHistory);
+		}
+
+		return base.deserialize_array_type (prop);
+	}
+
     public bool is_peertube {
         get {
 			// Disable PeerTube support for now

--- a/src/API/Status/PreviewCard.vala
+++ b/src/API/Status/PreviewCard.vala
@@ -115,8 +115,9 @@ public class Tuba.API.PreviewCard : Entity, Widgetizable {
 	}
 
 	public override Type deserialize_array_type (string prop) {
-		if (prop == "history") {
-			return typeof (API.TagHistory);
+		switch (prop) {
+			case "history":
+				return typeof (API.TagHistory);
 		}
 
 		return base.deserialize_array_type (prop);

--- a/src/API/Tag.vala
+++ b/src/API/Tag.vala
@@ -5,6 +5,14 @@ public class Tuba.API.Tag : Entity, Widgetizable {
 	public Gee.ArrayList<API.TagHistory>? history { get; set; default = null; }
 	public bool following { get; set; default = false; }
 
+	public override Type deserialize_array_type (string prop) {
+		if (prop == "history") {
+			return typeof (API.TagHistory);
+		}
+
+		return base.deserialize_array_type (prop);
+	}
+
 	public static Tag from (Json.Node node) throws Error {
 		return Entity.from_json (typeof (API.Tag), node) as API.Tag;
 	}

--- a/src/API/Tag.vala
+++ b/src/API/Tag.vala
@@ -6,8 +6,9 @@ public class Tuba.API.Tag : Entity, Widgetizable {
 	public bool following { get; set; default = false; }
 
 	public override Type deserialize_array_type (string prop) {
-		if (prop == "history") {
-			return typeof (API.TagHistory);
+		switch (prop) {
+			case "history":
+				return typeof (API.TagHistory);
 		}
 
 		return base.deserialize_array_type (prop);

--- a/src/Widgets/VoteBox.vala
+++ b/src/Widgets/VoteBox.vala
@@ -20,7 +20,7 @@ public class Tuba.Widgets.VoteBox : Gtk.Box {
         API.Poll.vote (accounts.active, poll.options, selected_index, poll.id)
             .then ((sess, mess, in_stream) => {
                 var parser = Network.get_parser_from_inputstream (in_stream);
-                poll = API.Poll.from_json (typeof (API.Poll), network.parse_node (parser));
+                poll = API.Poll.from (network.parse_node (parser));
 
                 button.sensitive = true;
             })


### PR DESCRIPTION
ArrayList deserialization from JSON has been very messy. There's a huge switch statement that goes through each possible property name to find the type. Not only is that unmaintainable but also leads to property conflicts:

For example an entity that has an `uploads` property of string and an entity that also has an `uploads` property but of API.Attachment **cannot** co-exist. We've been lucky so far that there haven't been any conflicts.

This PR creates a virtual function that returns a `Type` for a property name, allowing descendants to override it for their needs.