### PR TITLE
feat(ci): re-enable snap

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,6 @@ jobs:
     name: "Snap Builder"
     runs-on: ubuntu-latest
     needs: [ lint ]
-    if: ${{ false }} # disable until GNOME 45 runtimes get added
     strategy:
       matrix:
         arch: [x86_64, aarch64]


### PR DESCRIPTION
gnome-sdk now has libadwaita 1.4