### PR TITLE
fix(Main): headerbar conditions

### DIFF
--- a/src/Views/Main.vala
+++ b/src/Views/Main.vala
@@ -38,14 +38,13 @@ public class Tuba.Views.Main : Views.TabbedBase {
 		app.main_window.update_selected_home_item ();
 	}
 
-	protected override Gtk.Widget header_widget {
+	protected override bool title_stack_page_visible {
 		get {
-			return header.title_widget;
+			return title_stack.visible_child_name == "title";
 		}
+
 		set {
-			if (app?.main_window?.is_mobile == true) {
-				header.title_widget = value;
-			}
+			title_stack.visible_child_name = app.main_window.is_mobile && value ? "switcher" : "title";
 		}
 	}
 
@@ -53,6 +52,7 @@ public class Tuba.Views.Main : Views.TabbedBase {
 		app.main_window.bind_property ("is-mobile", search_button, "visible", GLib.BindingFlags.SYNC_CREATE);
 		app.main_window.bind_property ("is-mobile", switcher_bar, "visible", GLib.BindingFlags.SYNC_CREATE);
 		app.main_window.bind_property ("is-mobile", switcher, "visible", GLib.BindingFlags.SYNC_CREATE);
+		app.main_window.bind_property ("is-mobile", this, "title-stack-page-visible", GLib.BindingFlags.SYNC_CREATE);
 
 		app.main_window.notify["is-mobile"].connect (notify_bind);
 		notify_bind ();
@@ -61,7 +61,6 @@ public class Tuba.Views.Main : Views.TabbedBase {
 	private void notify_bind () {
 		update_fake_button (!app.main_window.is_mobile);
 		toolbar_view_mobile_style = app.main_window.is_mobile;
-		if (!app.main_window.is_mobile) header.title_widget = title_header;
 	}
 
 	public override void build_header () {

--- a/src/Views/TabbedBase.vala
+++ b/src/Views/TabbedBase.vala
@@ -5,7 +5,7 @@ public class Tuba.Views.TabbedBase : Views.Base {
 	protected Adw.ViewSwitcher switcher;
 	protected Adw.ViewSwitcherBar switcher_bar;
 	protected Adw.ViewStack stack;
-	protected Adw.WindowTitle title_header;
+	protected Gtk.Stack title_stack;
 
 	public void change_page_to_named (string page_name) {
 		stack.visible_child_name = page_name;
@@ -46,31 +46,36 @@ public class Tuba.Views.TabbedBase : Views.Base {
 		views = {};
 	}
 
-	protected virtual Gtk.Widget header_widget {
+	protected virtual bool title_stack_page_visible {
 		get {
-			return header.title_widget;
+			return title_stack.visible_child_name == "title";
 		}
+
 		set {
-			header.title_widget = value;
+			title_stack.visible_child_name = value ? "title" : "switcher";
 		}
 	}
 
 	public override void build_header () {
+		title_stack = new Gtk.Stack ();
+		header.title_widget = title_stack;
+
 		switcher = new Adw.ViewSwitcher () { policy = Adw.ViewSwitcherPolicy.WIDE };
-		header.title_widget = switcher;
+		title_stack.add_named (switcher, "switcher");
 
 		switcher_bar = new Adw.ViewSwitcherBar ();
 		toolbar_view.add_bottom_bar (switcher_bar);
 
-		title_header = new Adw.WindowTitle (label, "");
+		var title_header = new Adw.WindowTitle (label, "");
 		bind_property ("label", title_header, "title", BindingFlags.SYNC_CREATE);
+		title_stack.add_named (title_header, "title");
 
 		var condition = new Adw.BreakpointCondition.length (
 			Adw.BreakpointConditionLengthType.MAX_WIDTH,
 			550, Adw.LengthUnit.SP
 		);
 		var breakpoint = new Adw.Breakpoint (condition);
-		breakpoint.add_setter (this, "header-widget", title_header);
+		breakpoint.add_setter (title_stack, "visible-child-name", "title");
 		breakpoint.add_setter (switcher_bar, "reveal", true);
 		add_breakpoint (breakpoint);
 	}


### PR DESCRIPTION
fix: #575 

The workflow is unnecessarily complex. On narrow mode, the ViewSwitcher should be the headerbar child and the Base breakpoint should handle its visibility BUT on wide mode, the WindowTitle should be the headerbar child and the Base breakpoint should not touch it at all. Instead of changing the headerbar child, set it to a stack and change the page. On `Main` specifically, the page can be set to switcher ONLY when it's on narrow mode