### PR TITLE
fix(status): row + card bg color

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -465,7 +465,7 @@ video > overlay > revealer > controls {
 	padding: 0px;
 }
 
-.ttl-post {
+.card-spacing {
 	background-color: @card_bg_color;
 }
 

--- a/data/style.css
+++ b/data/style.css
@@ -465,6 +465,10 @@ video > overlay > revealer > controls {
 	padding: 0px;
 }
 
+.ttl-post {
+	background-color: @card_bg_color;
+}
+
 /* .ttl-view:not(.no-transition) .large.content,
 .ttl-view:not(.no-transition) .small.content { */
 .ttl-view:not(.no-transition) .large.fake-content,


### PR DESCRIPTION
fix: #581 

Apparently ListRow's activatable hover background-color ends up overriding .card's :shrug:  