### PR TITLE
Use copy icon for copying handle

### DIFF
--- a/data/ui/menus.ui
+++ b/data/ui/menus.ui
@@ -21,7 +21,7 @@
       <item>
         <attribute name="label" translatable="yes">Copy Handle</attribute>
         <attribute name="action">view.copy_handle</attribute>
-        <attribute name="verb-icon">emblem-shared-symbolic</attribute>
+        <attribute name="verb-icon">edit-copy-symbolic</attribute>
       </item>
     </section>
 


### PR DESCRIPTION
The share icon is more commonly associated with opening a share sheet and with no visual feedback of a successful copy, it can look like the button did nothing.

Ideally, the copy action would display a toast too.