### PR TITLE
Compose button in direct messages

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -346,7 +346,7 @@ namespace Tuba {
 			new Dialogs.Compose ();
 		}
 
-		void compose_direct_activated() {
+		void compose_direct_activated () {
 			if (accounts.active.instance_info == null) return;
 
 			new Dialogs.Compose.direct ();

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -63,6 +63,7 @@ namespace Tuba {
 			 // vala-lint=block-opening-brace-space-before
 			{ "about", about_activated },
 			{ "compose", compose_activated },
+			{ "compose_direct", compose_direct_activated },
 			{ "back", back_activated },
 			{ "refresh", refresh_activated },
 			{ "search", search_activated },
@@ -343,6 +344,12 @@ namespace Tuba {
 			if (accounts.active.instance_info == null) return;
 
 			new Dialogs.Compose ();
+		}
+
+		void compose_direct_activated() {
+			if (accounts.active.instance_info == null) return;
+
+			new Dialogs.Compose.direct ();
 		}
 
 		void back_activated () {

--- a/src/Dialogs/Composer/Dialog.vala
+++ b/src/Dialogs/Composer/Dialog.vala
@@ -286,6 +286,19 @@ public class Tuba.Dialogs.Compose : Adw.Window {
 		);
 	}
 
+	public Compose.direct (API.Status template = new API.Status.empty ()) {
+		Object (
+			status: new BasicStatus.from_status (template) {
+				visibility = "direct",
+			},
+			original_status: new BasicStatus.from_status (template) {
+				visibility = "direct",
+			},
+			button_label: _("_Publish"),
+			button_class: "suggested-action"
+		);
+	}
+
 	public Compose.redraft (API.Status status) {
 		Object (
 			status: new BasicStatus.from_status (status),

--- a/src/Views/Conversations.vala
+++ b/src/Views/Conversations.vala
@@ -7,9 +7,9 @@ public class Tuba.Views.Conversations : Views.Timeline {
         accepts = typeof (API.Conversation);
         stream_event[InstanceAccount.EVENT_CONVERSATION].connect (on_new_post);
 
- 		compose_button = new Gtk.Button.from_icon_name ("document-edit-symbolic") {
+ 		compose_button = new Gtk.Button.from_icon_name ("mail-unread-symbolic") {
                 action_name = "app.compose_direct",
-                tooltip_text = _("Compose"),
+                tooltip_text = _("Compose message"),
                 css_classes = { "circular", "compose-button", "suggested-action" },
                 margin_bottom = 24,
                 margin_end = 24,

--- a/src/Views/Conversations.vala
+++ b/src/Views/Conversations.vala
@@ -1,10 +1,21 @@
 public class Tuba.Views.Conversations : Views.Timeline {
+	Gtk.Button compose_button;
     construct {
         url = "/api/v1/conversations";
         label = _("Conversations");
         icon = "mail-unread-symbolic";
         accepts = typeof (API.Conversation);
         stream_event[InstanceAccount.EVENT_CONVERSATION].connect (on_new_post);
+
+ 		compose_button = new Gtk.Button.from_icon_name ("document-edit-symbolic") {
+                action_name = "app.compose_direct",
+                tooltip_text = _("Compose"),
+                css_classes = { "circular", "compose-button", "suggested-action" },
+                margin_bottom = 24,
+                margin_end = 24,
+                valign = halign = Gtk.Align.END,
+        };
+ 		scrolled_overlay.add_overlay(compose_button);
     }
 
     public override string? get_stream_url () {

--- a/src/Views/Conversations.vala
+++ b/src/Views/Conversations.vala
@@ -15,7 +15,7 @@ public class Tuba.Views.Conversations : Views.Timeline {
                 margin_end = 24,
                 valign = halign = Gtk.Align.END,
         };
- 		scrolled_overlay.add_overlay(compose_button);
+ 		scrolled_overlay.add_overlay (compose_button);
     }
 
     public override string? get_stream_url () {


### PR DESCRIPTION
This is a draft implementation of the feature requested by #612. Some considerations:
- I'm not sure if adding another action is the most desirable way to achieve this, but it plays nicely with the existing codebase
- What button icon to use
- Not specifically related to this issue, but maybe add a scroll-to-top button to the messages tab in the future
Of course, if this feature isn't thought to be necessary or make sense within Tuba at the moment, feel free to close this.