### PR TITLE
feat(ScaleRevealer): multiple widgets

### DIFF
--- a/src/Dialogs/MainWindow.vala
+++ b/src/Dialogs/MainWindow.vala
@@ -79,7 +79,7 @@ public class Tuba.Dialogs.MainWindow: Adw.ApplicationWindow, Saveable {
 	) {
 		if (as_is && preview == null) return;
 
-		media_viewer.add_media (url, media_type, preview, pos, as_is, alt_text, user_friendly_url, stream);
+		media_viewer.add_media (url, media_type, preview, pos, as_is, alt_text, user_friendly_url, stream, source_widget);
 
 		if (!is_media_viewer_visible) {
 			media_viewer.reveal (source_widget);

--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -373,8 +373,13 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 			enabled = true,
 			allow_mouse_drag = true
 		};
+		swipe_tracker.prepare.connect (on_swipe_tracker_prepare);
 		swipe_tracker.update_swipe.connect (on_update_swipe);
 		swipe_tracker.end_swipe.connect (on_end_swipe);
+	}
+
+	private void on_swipe_tracker_prepare (Adw.NavigationDirection direction) {
+		update_revealer_widget ();
 	}
 
 	private void on_update_swipe (double progress) {
@@ -673,6 +678,7 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 	}
 
 	private void reset_media_viewer () {
+		revealer_widgets.clear ();
 		this.fullscreen = false;
 		todo_items.clear ();
 
@@ -684,6 +690,11 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 
 		items.clear ();
 		revealed = false;
+	}
+
+	private void update_revealer_widget () {
+		if (revealed && revealer_widgets.has_key ((int) carousel.position))
+			scale_revealer.source_widget = revealer_widgets.get ((int) carousel.position);
 	}
 
 	private async string download_video (string url) throws Error {
@@ -702,6 +713,7 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 		do_todo_items ();
 	}
 
+	public Gee.HashMap<int, Gtk.Widget> revealer_widgets = new Gee.HashMap<int, Gtk.Widget> ();
 	public void add_media (
 		string url,
 		Tuba.Attachment.MediaType media_type,
@@ -710,11 +722,14 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 		bool as_is = false,
 		string? alt_text = null,
 		string? user_friendly_url = null,
-		bool stream = false
+		bool stream = false,
+		Gtk.Widget? revealer_widget = null
 	) {
 		Item item;
 		string final_friendly_url = user_friendly_url == null ? url : user_friendly_url;
 		Gdk.Paintable? final_preview = as_is ? null : preview;
+		if (revealer_widget != null)
+			revealer_widgets.set (pos == null ? items.size : pos, revealer_widget);
 
 		if (media_type.is_video ()) {
 			var video = new Gtk.Video ();

--- a/src/Widgets/ScaleRevealer.vala
+++ b/src/Widgets/ScaleRevealer.vala
@@ -6,8 +6,28 @@ public class Tuba.Widgets.ScaleRevealer : Adw.Bin {
 
 	public signal void transition_done ();
 	public Adw.TimedAnimation animation { get; construct set; }
-	public Gtk.Widget? source_widget { get; set; }
+	private Gtk.Widget? _source_widget = null;
+	public Gtk.Widget? source_widget {
+		get {
+			return _source_widget;
+		}
+		set {
+			if (_source_widget != null)
+				_source_widget.opacity = 1.0;
+			_source_widget = value;
+			update_source_widget ();
+		}
+	}
 	public Gdk.Texture? source_widget_texture { get; set; }
+
+	private void update_source_widget () {
+		if (this.source_widget == null) {
+			source_widget_texture = null;
+		} else {
+			source_widget_texture = render_widget_to_texture (this.source_widget);
+			this.source_widget.opacity = 0.0;
+		}
+	}
 
 	private bool _reveal_child = false;
 	public bool reveal_child {
@@ -22,13 +42,7 @@ public class Tuba.Widgets.ScaleRevealer : Adw.Bin {
 			if (value) {
 				animation.value_to = 1.0;
 				this.visible = true;
-
-				if (source_widget == null) {
-					source_widget_texture = null;
-				} else {
-					source_widget_texture = render_widget_to_texture (this.source_widget);
-					source_widget.opacity = 0.0;
-				}
+				update_source_widget ();
 			} else {
 				animation.value_to = 0.0;
 			}
@@ -119,7 +133,7 @@ public class Tuba.Widgets.ScaleRevealer : Adw.Bin {
 
 		if (source_widget == null) return;
 		if (source_widget_texture == null) {
-			warning ("The source widget texture is None, using child snapshot as fallback");
+			// The source widget texture is None, using child snapshot as fallback
 			this.snapshot_child (this.child, snapshot);
 		} else {
 			if (progress > 0.0) {

--- a/src/Widgets/ScaleRevealer.vala
+++ b/src/Widgets/ScaleRevealer.vala
@@ -24,7 +24,9 @@ public class Tuba.Widgets.ScaleRevealer : Adw.Bin {
 		if (this.source_widget == null) {
 			source_widget_texture = null;
 		} else {
-			source_widget_texture = render_widget_to_texture (this.source_widget);
+			var t_source_widget_texture = render_widget_to_texture (this.source_widget);
+			if (t_source_widget_texture != null)
+				source_widget_texture = t_source_widget_texture;
 			this.source_widget.opacity = 0.0;
 		}
 	}
@@ -133,7 +135,7 @@ public class Tuba.Widgets.ScaleRevealer : Adw.Bin {
 
 		if (source_widget == null) return;
 		if (source_widget_texture == null) {
-			// The source widget texture is None, using child snapshot as fallback
+			warning ("The source widget texture is None, using child snapshot as fallback");
 			this.snapshot_child (this.child, snapshot);
 		} else {
 			if (progress > 0.0) {


### PR DESCRIPTION
MediaViewer animation should play based on the current carousel position aka if you open the first image and scroll to the 3rd, dismissing the media viewer should play the animation for the third image

https://github.com/GeopJr/Tuba/assets/18014039/6760dc9e-246c-4d00-965f-240fb21202d3

TODO:
- ~~fix some snapshot issues~~ fixed, a wrong texture is better than the child's texture
