### PR TITLE
fix(LWW): do not ellipsize when lines && widgets > 100

### DIFF
--- a/src/Widgets/LabelWithWidgets.vala
+++ b/src/Widgets/LabelWithWidgets.vala
@@ -252,8 +252,12 @@ public class Tuba.Widgets.LabelWithWidgets : Gtk.Widget, Gtk.Buildable, Gtk.Acce
                 label.wrap_mode = Pango.WrapMode.WORD_CHAR;
 
                 // The lines check is Tuba specific for statuses that overflow their row
-                if (lines == 100 && widgets.length > 100) lines = widgets.length;
-                label.ellipsize = lines < 100 ? Pango.EllipsizeMode.NONE : Pango.EllipsizeMode.END;
+                if (lines == 100 && widgets.length > 100) {
+                    lines = widgets.length;
+                    label.ellipsize = Pango.EllipsizeMode.NONE;
+                } else {
+                    label.ellipsize = lines < 100 ? Pango.EllipsizeMode.NONE : Pango.EllipsizeMode.END;
+                }
             }
 
             _text = new_label;


### PR DESCRIPTION
Problem: without setting lines to 100 and ellipsizing, LLW would mess up its sizing. I do not think this is a problem anymore, maybe, but without ellipsizing theres a performance impact so it has to stay for now until the switch to ListView or other optimized containers. However, it seems that when a post contains only custom emojis, it needs ellipsizing to be off for the wrapping to be done right (ex. https://eepy.moe/notes/9li57c0uugndgjq2)

Solution: when lines and widgets > 100, set ellipsizing to none :shrug: