### PR TITLE
fix(Profile): timeline api not being reset

### DIFF
--- a/src/Views/ContentBase.vala
+++ b/src/Views/ContentBase.vala
@@ -92,7 +92,7 @@ public class Tuba.Views.ContentBase : Views.Base {
 		model.remove_all ();
 	}
 
-	protected void clear_all_but_first () {
+	protected virtual void clear_all_but_first () {
 		base.clear ();
 
 		if (model.n_items > 1)

--- a/src/Views/Profile.vala
+++ b/src/Views/Profile.vala
@@ -337,9 +337,8 @@ public class Tuba.Views.Profile : Views.Timeline {
 		if (page_next == null && source == "statuses") {
 			req.with_param ("exclude_replies", (!include_replies).to_string ());
 			req.with_param ("only_media", only_media.to_string ());
-			return base.append_params (req);
 		}
-		else return req;
+		return base.append_params (req);
 	}
 
 	public static void open_from_id (string id) {

--- a/src/Views/Timeline.vala
+++ b/src/Views/Timeline.vala
@@ -128,13 +128,22 @@ public class Tuba.Views.Timeline : AccountHolder, Streamable, Views.ContentBase 
 		base.dispose ();
 	}
 
-	public override void clear () {
+	private void cleanup_timeline_api () {
 		this.page_prev = null;
 		this.page_next = null;
 		this.is_last_page = false;
 		this.needs_attention = false;
 		this.badge_number = 0;
+	}
+
+	public override void clear () {
+		cleanup_timeline_api ();
 		base.clear ();
+	}
+
+	protected override void clear_all_but_first () {
+		cleanup_timeline_api ();
+		base.clear_all_but_first ();
 	}
 
 	public void get_pages (string? header) {


### PR DESCRIPTION
fix: #635 

On profiles we need to keep the first item when refreshing (req for ListView), but we didn't clean up the API after before refreshing as clean () was no longer Timeline's