### PR TITLE
feat: treat the handle as private info

### DIFF
--- a/src/Services/Accounts/AccountStore.vala
+++ b/src/Services/Accounts/AccountStore.vala
@@ -8,7 +8,7 @@ public abstract class Tuba.AccountStore : GLib.Object {
 
 	public bool ensure_active_account () {
 		var has_active = false;
-		var account = find_by_handle (settings.active_account);
+		var account = find_by_uuid (settings.active_account);
 
 		if (account == null && !saved.is_empty) {
 			account = saved[0];
@@ -60,9 +60,10 @@ public abstract class Tuba.AccountStore : GLib.Object {
 		ensure_active_account ();
 	}
 
-	public InstanceAccount? find_by_handle (string handle) {
+	public InstanceAccount? find_by_uuid (string uuid) {
+		if (!GLib.Uuid.string_is_valid (uuid)) return null;
 		var iter = saved.filter (acc => {
-			return acc.handle == handle;
+			return acc.uuid == uuid;
 		});
 		iter.next ();
 
@@ -86,7 +87,7 @@ public abstract class Tuba.AccountStore : GLib.Object {
 				try {
 					account.verify_credentials.end (res);
 					account.error = null;
-					settings.active_account = account.handle;
+					settings.active_account = account.uuid;
 					if (account.source != null && account.source.language != null && account.source.language != "")
 						settings.default_language = account.source.language;
 				}
@@ -114,6 +115,7 @@ public abstract class Tuba.AccountStore : GLib.Object {
 		if (account == null)
 			throw new Oopsie.INTERNAL (@"Account $handle has unknown backend: $backend");
 
+		if (account.uuid == null || !GLib.Uuid.string_is_valid (account.uuid)) account.uuid = GLib.Uuid.string_random ();
 		return account;
 	}
 

--- a/src/Services/Accounts/InstanceAccount.vala
+++ b/src/Services/Accounts/InstanceAccount.vala
@@ -15,6 +15,7 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 	public const string KIND_REMOTE_REBLOG = "__remote-reblog";
 	public const string KIND_EDITED = "update";
 
+	public string uuid { get; construct set; }
 	public string? backend { set; get; }
 	public API.Instance? instance_info { get; set; }
 	public Gee.ArrayList<API.Emoji>? instance_emojis { get; set; }

--- a/src/Services/Accounts/SecretAccountStore.vala
+++ b/src/Services/Accounts/SecretAccountStore.vala
@@ -1,6 +1,6 @@
 public class Tuba.SecretAccountStore : AccountStore {
 
-	const string VERSION = "1";
+	const string VERSION = "2";
 
 	Secret.Schema schema;
 	GLib.HashTable<string,Secret.SchemaAttributeType> schema_attributes;
@@ -107,7 +107,7 @@ public class Tuba.SecretAccountStore : AccountStore {
 
 		var attrs = new GLib.HashTable<string,string> (str_hash, str_equal);
 		attrs["version"] = VERSION;
-		attrs["login"] = account.handle;
+		attrs["login"] = account.uuid;
 
 		Secret.password_clearv.begin (
 			schema,
@@ -128,7 +128,7 @@ public class Tuba.SecretAccountStore : AccountStore {
 
 	void account_to_secret (InstanceAccount account) {
 		var attrs = new GLib.HashTable<string,string> (str_hash, str_equal);
-		attrs["login"] = account.handle;
+		attrs["login"] = account.uuid;
 		attrs["version"] = VERSION;
 
 		var generator = new Json.Generator ();
@@ -175,6 +175,9 @@ public class Tuba.SecretAccountStore : AccountStore {
 
 		builder.set_member_name ("backend");
 		builder.add_string_value (account.backend);
+
+		builder.set_member_name ("uuid");
+		builder.add_string_value (account.uuid);
 
 		// If display name has emojis it's
 		// better to save and load them

--- a/src/Services/Settings.vala
+++ b/src/Services/Settings.vala
@@ -1,5 +1,4 @@
 public class Tuba.Settings : GLib.Settings {
-
 	public string active_account { get; set; }
 	public string default_language { get; set; default = "en"; }
 	public ColorScheme color_scheme { get; set; }


### PR DESCRIPTION
:warning: This is a secrets version bump - you'll be asked to re-login. You can safely move back to the main branch and your old logins will work just fine. If anything happens, go to Passwords and Keys and remove all Tuba entries. :warning: 

Mostly an RFC. This PR will treat the instance account handle as private info.

# The good

UUIDs will be used instead to distinguish your account outside of Tuba. That includes both the secrets and gsettings.

## Benefits
- Per account settings (when done), will be under `/dev/geopjr/Tuba/.../e1cb8003-044e-4353-aa72-34aa7f9714fb/` instead of `/dev/geopjr/Tuba/.../mastodon_at_mastodon_dot_social/`
- The last active account will also become `e1cb8003-044e-4353-aa72-34aa7f9714fb` instead of `[at]mastodon[at]mastodon.social`
- Same for the wallet login attribute
- With #616, individual caches will be possible and anonymous `.cache/Tuba/e1cb8003-044e-4353-aa72-34aa7f9714fb/images/`

## Why

An example scenario for this threat model would be: A device belonging to an activist gets compromised, either physically (if the device is unencrypted) or remotely. The attacker can easily associate them with their online accounts from Tuba using gsettings or .cache.

Obviously there will be other ways for that info to be found but since we can prevent Tuba's impact we might as well do it.

# The bad

While I've set it up in a way to generate the UUID's on existing logins without having to re-auth, it might be needed if we want to use UUIDs even on secret attributes. I need to take a deeper look into it - to see if there are any implementations that do not encrypt them.

The change is basically this:
![image](https://github.com/GeopJr/Tuba/assets/18014039/da5b91f9-84e3-4ee0-8197-240ecaff6ccf)

There's an additional downside of not recognizing the keys right away.
Changing the attributes **will** require a re-auth.
