### PR TITLE
feat: drop GTK_THEME

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -192,6 +192,8 @@ namespace Tuba {
 			Intl.bindtextdomain (Build.GETTEXT_PACKAGE, Build.LOCALEDIR);
 			Intl.textdomain (Build.GETTEXT_PACKAGE);
 
+			GLib.Environment.unset_variable ("GTK_THEME");
+
 			app = new Application ();
 			return app.run (args);
 		}


### PR DESCRIPTION
GTK_THEME is not the proper way to theme your desktop. It breaks many of Tuba's widgets.

If you want to theme your desktop use themes that use `~/.config/gtk-4.0` or [Gradience](https://gradienceteam.github.io/).