### PR TITLE
feat: refactor question api

### DIFF
--- a/src/API/Status/PreviewCard.vala
+++ b/src/API/Status/PreviewCard.vala
@@ -157,78 +157,72 @@ public class Tuba.API.PreviewCard : Entity, Widgetizable {
 	}
 
 	public static void open_special_card (CardSpecialType card_special_type, string card_url) {
-		var privacy_dialog = app.question (
-			card_special_type.to_dialog_title (),
-			card_special_type.to_dialog_body (card_url),
+		app.question.begin (
+			{card_special_type.to_dialog_title (), false},
+			{card_special_type.to_dialog_body (card_url), false},
 			app.main_window,
-			_("Proceed"),
-			Adw.ResponseAppearance.DESTRUCTIVE
-		);
-
-		privacy_dialog.response.connect (res => {
-			if (res == "yes") {
-				if (card_special_type.open_special_card (card_url)) {
-					privacy_dialog.destroy ();
-					return;
-				};
-				string special_api_url = "";
-				string special_host = "";
-				try {
-					card_special_type.parse_url (card_url, out special_host, out special_api_url);
-				} catch {
-					Host.open_uri (card_url);
-					privacy_dialog.destroy ();
-					return;
-				}
-
-
-				new Request.GET (special_api_url)
-					.then ((in_stream) => {
-						bool failed = true;
-						var parser = Network.get_parser_from_inputstream (in_stream);
-						var node = network.parse_node (parser);
-						string res_url = "";
-						API.BookWyrm? bookwyrm_obj = null;
-
-						switch (card_special_type) {
-							case API.PreviewCard.CardSpecialType.PEERTUBE:
-								var peertube_obj = API.PeerTube.from (node);
-
-								peertube_obj.get_video (card_url, out res_url, out failed);
-								break;
-							case API.PreviewCard.CardSpecialType.FUNKWHALE:
-								var funkwhale_obj = API.Funkwhale.from (node);
-
-								funkwhale_obj.get_track (special_host, out res_url, out failed);
-								break;
-							case API.PreviewCard.CardSpecialType.BOOKWYRM:
-								bookwyrm_obj = API.BookWyrm.from (node);
-								res_url = bookwyrm_obj.id;
-
-								if (bookwyrm_obj.title != null && bookwyrm_obj.title != "") failed = false;
-								break;
-							default:
-								assert_not_reached ();
-						}
-
-						if (failed || res_url == "") {
-							Host.open_uri (card_url);
-						} else {
-							if (bookwyrm_obj == null) {
-								app.main_window.show_media_viewer (res_url, Tuba.Attachment.MediaType.VIDEO, null, 0, null, false, null, card_url, true);
-							} else {
-								app.main_window.show_book (bookwyrm_obj, card_url);
-							}
-						}
-					})
-					.on_error (() => {
+			{ { _("Proceed"), Adw.ResponseAppearance.DESTRUCTIVE}, { _("Cancel"), Adw.ResponseAppearance.DEFAULT } },
+			false,
+			(obj, res) => {
+				if (app.question.end (res)) {
+					if (card_special_type.open_special_card (card_url)) {
+						return;
+					};
+					string special_api_url = "";
+					string special_host = "";
+					try {
+						card_special_type.parse_url (card_url, out special_host, out special_api_url);
+					} catch {
 						Host.open_uri (card_url);
-					})
-					.exec ();
-			}
-			privacy_dialog.destroy ();
-		});
+						return;
+					}
 
-		privacy_dialog.present ();
+
+					new Request.GET (special_api_url)
+						.then ((in_stream) => {
+							bool failed = true;
+							var parser = Network.get_parser_from_inputstream (in_stream);
+							var node = network.parse_node (parser);
+							string res_url = "";
+							API.BookWyrm? bookwyrm_obj = null;
+
+							switch (card_special_type) {
+								case API.PreviewCard.CardSpecialType.PEERTUBE:
+									var peertube_obj = API.PeerTube.from (node);
+
+									peertube_obj.get_video (card_url, out res_url, out failed);
+									break;
+								case API.PreviewCard.CardSpecialType.FUNKWHALE:
+									var funkwhale_obj = API.Funkwhale.from (node);
+
+									funkwhale_obj.get_track (special_host, out res_url, out failed);
+									break;
+								case API.PreviewCard.CardSpecialType.BOOKWYRM:
+									bookwyrm_obj = API.BookWyrm.from (node);
+									res_url = bookwyrm_obj.id;
+
+									if (bookwyrm_obj.title != null && bookwyrm_obj.title != "") failed = false;
+									break;
+								default:
+									assert_not_reached ();
+							}
+
+							if (failed || res_url == "") {
+								Host.open_uri (card_url);
+							} else {
+								if (bookwyrm_obj == null) {
+									app.main_window.show_media_viewer (res_url, Tuba.Attachment.MediaType.VIDEO, null, 0, null, false, null, card_url, true);
+								} else {
+									app.main_window.show_book (bookwyrm_obj, card_url);
+								}
+							}
+						})
+						.on_error (() => {
+							Host.open_uri (card_url);
+						})
+						.exec ();
+				}
+			}
+		);
 	}
 }

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -479,30 +479,51 @@ namespace Tuba {
 			return dlg;
 		}
 
-		public Adw.MessageDialog question (
-			string text,
-			string? msg = null,
+		public struct QuestionButton {
+			public string label;
+			public Adw.ResponseAppearance appearance;
+		}
+
+		public struct QuestionButtons {
+			public QuestionButton yes;
+			public QuestionButton no;
+		}
+
+		public struct QuestionText {
+			public string text;
+			public bool use_markup;
+		}
+
+		public async bool question (
+			QuestionText title,
+			QuestionText? msg = null,
 			Gtk.Window? win = app.main_window,
-			string yes_label = _("Yes"),
-			Adw.ResponseAppearance yes_appearance = Adw.ResponseAppearance.DEFAULT,
-			string no_label = _("Cancel"),
-			Adw.ResponseAppearance no_appearance = Adw.ResponseAppearance.DEFAULT
+			QuestionButtons buttons = {
+				{ _("Yes"), Adw.ResponseAppearance.DEFAULT },
+				{ _("Cancel"), Adw.ResponseAppearance.DEFAULT }
+			},
+			bool skip = false // skip the dialog, used for preferences to avoid duplicate code
 		) {
+			if (skip) return true;
+
 			var dlg = new Adw.MessageDialog (
 				win,
-				text,
-				msg
+				title.text,
+				msg == null ? null : msg.text
 			);
 
-			dlg.add_response ("no", no_label);
-			dlg.set_response_appearance ("no", no_appearance);
+			dlg.heading_use_markup = title.use_markup;
+			if (msg != null) dlg.body_use_markup = msg.use_markup;
 
-			dlg.add_response ("yes", yes_label);
-			dlg.set_response_appearance ("yes", yes_appearance);
+			dlg.add_response ("no", buttons.no.label);
+			dlg.set_response_appearance ("no", buttons.no.appearance);
+
+			dlg.add_response ("yes", buttons.yes.label);
+			dlg.set_response_appearance ("yes", buttons.yes.appearance);
 
 			if (win != null)
 				dlg.transient_for = win;
-			return dlg;
+			return (yield dlg.choose (null)) == "yes";
 		}
 
 	}

--- a/src/Dialogs/Composer/Dialog.vala
+++ b/src/Dialogs/Composer/Dialog.vala
@@ -195,32 +195,23 @@ public class Tuba.Dialogs.Compose : Adw.Window {
 		on_paste_activated (this.title);
 	}
 
-	Adw.MessageDialog? dlg;
 	void on_exit () {
 		push_all ();
 
 		if (status.equal (original_status)) {
 			on_close ();
 		} else {
-			dlg = app.question (
-				_("Are you sure you want to exit?"),
-				_("Your progress will be lost."),
+			app.question.begin (
+				{_("Are you sure you want to exit?"), false},
+				{_("Your progress will be lost."), false},
 				this,
-				_("Discard"),
-				Adw.ResponseAppearance.DESTRUCTIVE,
-				_("Cancel")
+				{ { _("Discard"), Adw.ResponseAppearance.DESTRUCTIVE }, { _("Cancel"), Adw.ResponseAppearance.DEFAULT } },
+				false,
+				(obj, res) => {
+					if (app.question.end (res)) on_close ();
+				}
 			);
-			dlg.response.connect (on_dlg_response);
-			dlg.present ();
 		}
-	}
-
-	void on_dlg_response (string res) {
-		if (dlg == null) return;
-		dlg.dispose ();
-		dlg = null;
-
-		if (res == "yes") on_close ();
 	}
 
 	private ComposerPage[] t_pages = {};

--- a/src/Services/Accounts/SecretAccountStore.vala
+++ b/src/Services/Accounts/SecretAccountStore.vala
@@ -47,24 +47,17 @@ public class Tuba.SecretAccountStore : AccountStore {
 			warning (@"$help_msg\nread more: $wiki_page");
 
 			new Dialogs.NewAccount ();
-			var dlg = app.question (
-				"Error while searching for user accounts",
-				@"$help_msg.",
+			app.question.begin (
+				{"Error while searching for user accounts", false},
+				{@"$help_msg.", false},
 				app.add_account_window,
-				"Read More",
-				Adw.ResponseAppearance.SUGGESTED,
-				"Close"
-			);
-
-			dlg.response.connect (res => {
-				if (res == "yes") {
-					Host.open_uri (wiki_page);
+				{ {"Read More", Adw.ResponseAppearance.SUGGESTED }, { "Close", Adw.ResponseAppearance.DEFAULT } },
+				false,
+				(obj, res) => {
+					if (app.question.end (res)) Host.open_uri (wiki_page);
+					Process.exit (1);
 				}
-				dlg.destroy ();
-				Process.exit (1);
-			});
-
-			dlg.present ();
+			);
 		}
 
 		secrets.foreach (item => {

--- a/src/Views/Lists.vala
+++ b/src/Views/Lists.vala
@@ -53,28 +53,24 @@ public class Tuba.Views.Lists : Views.Timeline {
 		public virtual signal void remove_from_model (API.List? t_list);
 
 		void on_remove_clicked () {
-			var remove = app.question (
-				_("Delete \"%s\"?").printf (this.list.title),
-				_("This action cannot be reverted."),
+			app.question.begin (
+				{_("Delete \"%s\"?").printf (this.list.title), false},
+				{_("This action cannot be reverted."), false},
 				app.main_window,
-				_("Delete"),
-				Adw.ResponseAppearance.DESTRUCTIVE
-			);
-
-			remove.response.connect (res => {
-				if (res == "yes") {
-					new Request.DELETE (@"/api/v1/lists/$(list.id)")
-						.with_account (accounts.active)
-						.then (() => {
-							remove_from_model (this.list);
-							this.destroy ();
-						})
-						.exec ();
+				{ { _("Delete"), Adw.ResponseAppearance.DESTRUCTIVE }, { _("Cancel"), Adw.ResponseAppearance.DEFAULT } },
+				false,
+				(obj, res) => {
+					if (app.question.end (res)) {
+						new Request.DELETE (@"/api/v1/lists/$(list.id)")
+							.with_account (accounts.active)
+							.then (() => {
+								remove_from_model (this.list);
+								this.destroy ();
+							})
+							.exec ();
+					}
 				}
-				remove.destroy ();
-			});
-
-			remove.present ();
+			);
 		}
 
 		public Adw.PreferencesWindow create_edit_preferences_window (API.List t_list) {

--- a/src/Views/Sidebar.vala
+++ b/src/Views/Sidebar.vala
@@ -212,33 +212,25 @@ public class Tuba.Views.Sidebar : Gtk.Widget, AccountHolder {
 
 		[GtkCallback] void on_forget () {
 			popdown_signal ();
-			// The String#replace below replaces the @ with <zero-width>@
-			// so it wraps cleanly
-
-			var confirmed = app.question (
+			app.question.begin (
 				// translators: the variable is an account handle
-				_("Forget %s?").printf (account.handle.replace ("@", "​@")),
-				_("This account will be removed from the application."),
+				{_("Forget %s?").printf ("<span segment=\"word\">@%s</span><span segment=\"word\">@%s</span>".printf (account.username, account.domain)), true},
+				{_("This account will be removed from the application."), false},
 				app.main_window,
-				_("Forget"),
-				Adw.ResponseAppearance.DESTRUCTIVE
-			);
-
-			confirmed.response.connect (res => {
-				if (res == "yes") {
-					try {
-						accounts.remove (account);
-					}
-					catch (Error e) {
-						warning (e.message);
-						var dlg = app.inform (_("Error"), e.message);
-						dlg.present ();
+				{ { _("Forget"), Adw.ResponseAppearance.DESTRUCTIVE }, { _("Cancel"), Adw.ResponseAppearance.DEFAULT } },
+				false,
+				(obj, res) => {
+					if (app.question.end (res)) {
+						try {
+							accounts.remove (account);
+						} catch (Error e) {
+							warning (e.message);
+							var dlg = app.inform (_("Error"), e.message);
+							dlg.present ();
+						}
 					}
 				}
-				confirmed.destroy ();
-			});
-
-			confirmed.present ();
+			);
 		}
 
 	}

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -324,30 +324,26 @@
 	}
 
 	private void delete_status () {
-		var remove = app.question (
-			_("Are you sure you want to delete this post?"),
+		app.question.begin (
+			{_("Are you sure you want to delete this post?"), false},
 			null,
 			app.main_window,
-			_("Delete"),
-			Adw.ResponseAppearance.DESTRUCTIVE
-		);
-
-		remove.response.connect (res => {
-			if (res == "yes") {
-				this.status.formal.annihilate ()
-					//  .then ((in_stream) => {
-					//  	var parser = Network.get_parser_from_inputstream (in_stream);
-					//  	var root = network.parse (parser);
-					//  	if (root.has_member ("error")) {
-					//  		// TODO: Handle error (probably a toast?)
-					//  	};
-					//  })
-					.exec ();
+			{ { _("Delete"), Adw.ResponseAppearance.DESTRUCTIVE }, { _("Cancel"), Adw.ResponseAppearance.DEFAULT } },
+			false,
+			(obj, res) => {
+				if (app.question.end (res)) {
+					this.status.formal.annihilate ()
+						//  .then ((in_stream) => {
+						//  	var parser = Network.get_parser_from_inputstream (in_stream);
+						//  	var root = network.parse (parser);
+						//  	if (root.has_member ("error")) {
+						//  		// TODO: Handle error (probably a toast?)
+						//  	};
+						//  })
+						.exec ();
+				}
 			}
-			remove.destroy ();
-		});
-
-		remove.present ();
+		);
 	}
 
 	protected string spoiler_text {


### PR DESCRIPTION
feat: use pango markup for the forget dialog

The question API was just a MessageDialog constructor, forcing its users to destroy dialogs manually and handle responses. Since the response will always be yes/no and MessageDialog added a choose method, we should turn it into a proper async helper that returns a bool based on the response and handles everything else.

Other goodies include a skip parameter that can be used with preferences to skip the dialog altogether (the goal is to avoid duplicate code) (that can be used with #666), use_markup on body and heading (can be provided to the struct) and clearer API.

The main downside is that async and structs can't use default parameter values so everything must be provided on every instance (e.g. the skip parameter)

TODO:
- check if composer is leaking, as its callback is now again an anonymous function