### PR TITLE
fix(Notifications): icons on flatpak

### DIFF
--- a/src/API/Notification.vala
+++ b/src/API/Notification.vala
@@ -1,32 +1,32 @@
 public class Tuba.API.Notification : Entity, Widgetizable {
 
-    public string id { get; set; }
-    public API.Account account { get; set; }
-    public string? kind { get; set; default = null; }
-    public API.Status? status { get; set; default = null; }
+	public string id { get; set; }
+	public API.Account account { get; set; }
+	public string? kind { get; set; default = null; }
+	public API.Status? status { get; set; default = null; }
 
-    public override void open () {
-        if (status != null) {
-            status.open ();
-        } else {
-            account.open ();
-        }
-    }
+	public override void open () {
+		if (status != null) {
+			status.open ();
+		} else {
+			account.open ();
+		}
+	}
 
-    public override Gtk.Widget to_widget () {
-        return new Widgets.Notification (this);
-    }
+	public override Gtk.Widget to_widget () {
+		return new Widgets.Notification (this);
+	}
 
-	public virtual GLib.Notification to_toast (InstanceAccount issuer, int others = 0) {
-        Tuba.InstanceAccount.Kind res_kind;
-        bool should_show_buttons = issuer == accounts.active;
+	public virtual async GLib.Notification to_toast (InstanceAccount issuer, int others = 0) {
+		Tuba.InstanceAccount.Kind res_kind;
+		bool should_show_buttons = issuer == accounts.active;
 
-        var kind_actor_name = account.display_name;
-        if (others > 0) {
-            //  translators: <user> (& <amount> others) <actions>
-            //               for example: GeopJr (& 10 others) mentioned you
-            kind_actor_name = _("%s (& %d others)").printf (account.display_name, others);
-        }
+		var kind_actor_name = account.display_name;
+		if (others > 0) {
+			//  translators: <user> (& <amount> others) <actions>
+			//               for example: GeopJr (& 10 others) mentioned you
+			kind_actor_name = _("%s (& %d others)").printf (account.display_name, others);
+		}
 
 		issuer.describe_kind (kind, out res_kind, kind_actor_name);
 		var toast = new GLib.Notification (res_kind.description);
@@ -36,56 +36,63 @@ public class Tuba.API.Notification : Entity, Widgetizable {
 			toast.set_body (body);
 		}
 
-        if (should_show_buttons) {
-            toast.set_default_action_and_target_value (
-                "app.open-status-url",
-                new Variant.string (
-                    status?.url ?? account.url
-                )
-            );
+		if (should_show_buttons) {
+			toast.set_default_action_and_target_value (
+				"app.open-status-url",
+				new Variant.string (
+					status?.url ?? account.url
+				)
+			);
 
-            switch (kind) {
-                case InstanceAccount.KIND_MENTION:
-                    if (status != null) {
-                        toast.add_button_with_target_value (
-                            _("Reply…"),
-                            "app.reply-to-status-uri",
-                            new Variant.tuple ({accounts.active.id, status.uri})
-                        );
-                    }
-                    break;
-                case InstanceAccount.KIND_FOLLOW:
-                    toast.add_button_with_target_value (
-                        _("Remove from Followers"),
-                        "app.remove-from-followers",
-                        new Variant.tuple ({accounts.active.id, account.id})
-                    );
-                    toast.add_button_with_target_value (
-                        _("Follow Back"),
-                        "app.follow-back",
-                        new Variant.tuple ({accounts.active.id, account.id})
-                    );
-                    break;
-                case InstanceAccount.KIND_FOLLOW_REQUEST:
-                    toast.add_button_with_target_value (
-                        _("Decline"),
-                        "app.answer-follow-request",
-                        new Variant.tuple ({accounts.active.id, account.id, false})
-                    );
-                    toast.add_button_with_target_value (
-                        _("Accept"),
-                        "app.answer-follow-request",
-                        new Variant.tuple ({accounts.active.id, account.id, true})
-                    );
-                    break;
-            }
-        }
+			switch (kind) {
+				case InstanceAccount.KIND_MENTION:
+					if (status != null) {
+						toast.add_button_with_target_value (
+							_("Reply…"),
+							"app.reply-to-status-uri",
+							new Variant.tuple ({accounts.active.id, status.uri})
+						);
+					}
+					break;
+				case InstanceAccount.KIND_FOLLOW:
+					toast.add_button_with_target_value (
+						_("Remove from Followers"),
+						"app.remove-from-followers",
+						new Variant.tuple ({accounts.active.id, account.id})
+					);
+					toast.add_button_with_target_value (
+						_("Follow Back"),
+						"app.follow-back",
+						new Variant.tuple ({accounts.active.id, account.id})
+					);
+					break;
+				case InstanceAccount.KIND_FOLLOW_REQUEST:
+					toast.add_button_with_target_value (
+						_("Decline"),
+						"app.answer-follow-request",
+						new Variant.tuple ({accounts.active.id, account.id, false})
+					);
+					toast.add_button_with_target_value (
+						_("Accept"),
+						"app.answer-follow-request",
+						new Variant.tuple ({accounts.active.id, account.id, true})
+					);
+					break;
+			}
+		}
 
-        if (!Tuba.is_flatpak) {
-            var icon_file = GLib.File.new_for_uri (account.avatar);
-            var icon = new FileIcon (icon_file);
-            toast.set_icon (icon);
-        }
+		Icon? icon = null;
+		if (Tuba.is_flatpak) {
+			Bytes avatar_bytes = yield Tuba.Helper.Image.request_bytes (account.avatar);
+			if (avatar_bytes != null)
+				icon = new BytesIcon (avatar_bytes);
+		} else {
+			var icon_file = GLib.File.new_for_uri (account.avatar);
+			icon = new FileIcon (icon_file);
+		}
+
+		if (icon != null)
+			toast.set_icon (icon);
 
 		return toast;
 	}

--- a/src/Services/Accounts/InstanceAccount.vala
+++ b/src/Services/Accounts/InstanceAccount.vala
@@ -435,8 +435,9 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 			sent_notifications.set (id, others);
 		}
 
-		var toast = obj.to_toast (this, others);
-		app.send_notification (id, toast);
+		obj.to_toast.begin (this, others, (_obj, res) => {
+			app.send_notification (id, obj.to_toast.end (res));
+		});
 		//  sent_notification_ids.add(id);
 	}
 

--- a/src/Services/Helpers/Image.vala
+++ b/src/Services/Helpers/Image.vala
@@ -20,7 +20,7 @@ public class Tuba.Helper.Image {
 	public static void flush_cache () {
 		new Helper.Image ();
 		cache.flush ();
-        cache.dump ();
+		cache.dump ();
 	}
 
 	static construct {
@@ -29,12 +29,24 @@ public class Tuba.Helper.Image {
 			Soup.CacheType.SINGLE_USER
 		);
 		cache.load ();
-        cache.set_max_size (1024 * 1024 * 100);
+		cache.set_max_size (1024 * 1024 * 100);
 
 		session = new Soup.Session () {
 			user_agent = @"$(Build.NAME)/$(Build.VERSION) libsoup/$(Soup.get_major_version()).$(Soup.get_minor_version()).$(Soup.get_micro_version()) ($(Soup.MAJOR_VERSION).$(Soup.MINOR_VERSION).$(Soup.MICRO_VERSION))" // vala-lint=line-length
 		};
 		session.add_feature (cache);
+	}
+
+	public static async Bytes? request_bytes (string url) {
+		new Helper.Image ();
+
+		var download_msg = new Soup.Message ("GET", url);
+		try {
+			return yield session.send_and_read_async (download_msg, 0, null);
+		} catch (Error e) {
+			warning (@"Failed to download and read image at \"$url\": $(e.message)");
+			return null;
+		}
 	}
 
 	public static void request_paintable (string? url, string? blurhash, owned OnItemChangedFn cb) {
@@ -63,7 +75,7 @@ public class Tuba.Helper.Image {
 					try {
 						paintable = decode.end (async_res);
 					} catch (Error e) {
-						warning (@"Failed to download image at \"$url\". $(e.message).");
+						warning (@"Failed to download image at \"$url\": $(e.message)");
 						cb (null);
 
 						return;


### PR DESCRIPTION
fix: #426

On flatpak, desktop notification would miss the user avatar. This is due to a bug with the way we set it and the sandbox.

Once notifications are sent, they cannot be modified so the icon has to be ready before sending it. As to avoid delaying them due to downloading the icon, we create a FileIcon with a remote file pointing to the avatar. That however doesn't work on flatpak and would result in notifications never being sent #382. As a workaround, I disabled the icons on flatpak.

This has been reported to the portal and the only solution is downloading the icon in advance. This is what this PR does, it utulizes the image helper so there's cache and sends the notification when the image is done. (only on flatpak, the native versions uses the original solution)
