### PR TITLE
feat(composer): remove gspell-4 support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -71,7 +71,6 @@ libgtk_dep = dependency('gtk4', version: '>=4.11.3', required: true)
 libadwaita_dep = dependency('libadwaita-1', version: '>=1.4', required: true)
 gtksourceview_dep = dependency('gtksourceview-5', required: true, version: '>=5.6.0')
 libwebp_dep = dependency('libwebp', required: false)
-gspell = dependency('gspell-4', required: false)
 libspelling = dependency('libspelling-1', required: false)
 
 if not libwebp_dep.found ()
@@ -90,10 +89,6 @@ if libspelling.found ()
   add_project_arguments(['--define=LIBSPELLING'], language: 'vala')
 endif
 
-if gspell.found ()
-  add_project_arguments(['--define=GSPELL'], language: 'vala')
-endif
-
 if gtksourceview_dep.version().version_compare('>=5.7.1')
   add_project_arguments(['--define=GTKSOURCEVIEW_5_7_1'], language: 'vala')
 endif
@@ -110,7 +105,6 @@ final_deps = [
   dependency('json-glib-1.0', version: '>=1.4.4'),
   dependency('libxml-2.0'),
   dependency('libsecret-1', required: true),
-  gspell,
   libspelling,
   gtksourceview_dep,
   libgtk_dep,

--- a/src/Dialogs/Composer/AttachmentsPageAttachment.vala
+++ b/src/Dialogs/Composer/AttachmentsPageAttachment.vala
@@ -129,11 +129,6 @@ public class Tuba.AttachmentsPageAttachment : Widgets.Attachment.Item {
 			adapter.enabled = true;
 		#endif
 
-		#if GSPELL && !LIBSPELLING
-			var gspell_view = Gspell.TextView.get_from_gtk_text_view (alt_editor);
-			gspell_view.basic_setup ();
-		#endif
-
 		var scroller = new Gtk.ScrolledWindow () {
 			hexpand = true,
 			vexpand = true

--- a/src/Dialogs/Composer/EditorPage.vala
+++ b/src/Dialogs/Composer/EditorPage.vala
@@ -158,11 +158,6 @@ public class Tuba.EditorPage : ComposerPage {
 			adapter.notify["enabled"].connect (update_spelling_settings);
 		#endif
 
-		#if GSPELL && !LIBSPELLING
-			var gspell_view = Gspell.TextView.get_from_gtk_text_view (editor);
-			gspell_view.basic_setup ();
-		#endif
-
 		var keypress_controller = new Gtk.EventControllerKey ();
         keypress_controller.key_pressed.connect ((keyval, _, modifier) => {
             if (keyval == Gdk.Key.Return && (modifier == Gdk.ModifierType.CONTROL_MASK || modifier == (Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.LOCK_MASK))) {

--- a/src/Dialogs/ProfileEdit.vala
+++ b/src/Dialogs/ProfileEdit.vala
@@ -100,11 +100,6 @@ public class Tuba.Dialogs.ProfileEdit : Adw.Window {
 			adapter.enabled = true;
 		#endif
 
-		#if GSPELL && !LIBSPELLING
-			var gspell_view = Gspell.TextView.get_from_gtk_text_view (bio_text_view);
-			gspell_view.basic_setup ();
-		#endif
-
 		if (accounts.active.instance_emojis?.size > 0) {
 			cepbtn.visible = true;
 		}


### PR DESCRIPTION
gspell 4 support requires a beta version of gspell with some additional patches of mine which can be found here https://github.com/geopjr-forks/gspell-4

I don't think anyone is using it. libspelling is maintained, shipped in distros and doesn't require additional patches, so I think it's ok to remove gspell-4 support.