### PR TITLE
feat(Question): handle close responses

### DIFF
--- a/src/API/Status/PreviewCard.vala
+++ b/src/API/Status/PreviewCard.vala
@@ -164,7 +164,7 @@ public class Tuba.API.PreviewCard : Entity, Widgetizable {
 			{ { _("Proceed"), Adw.ResponseAppearance.DESTRUCTIVE}, { _("Cancel"), Adw.ResponseAppearance.DEFAULT } },
 			false,
 			(obj, res) => {
-				if (app.question.end (res)) {
+				if (app.question.end (res).truthy ()) {
 					if (card_special_type.open_special_card (card_url)) {
 						return;
 					};

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -494,7 +494,32 @@ namespace Tuba {
 			public bool use_markup;
 		}
 
-		public async bool question (
+		public enum QuestionAnswer {
+			YES,
+			NO,
+			CLOSE;
+
+			public static QuestionAnswer from_string (string answer) {
+				switch (answer.down ()) {
+					case "yes":
+						return YES;
+					case "no":
+						return NO;
+					default:
+						return CLOSE;
+				}
+			}
+
+			public bool truthy () {
+				return this == YES;
+			}
+
+			public bool falsy () {
+				return this != YES;
+			}
+		}
+
+		public async QuestionAnswer question (
 			QuestionText title,
 			QuestionText? msg = null,
 			Gtk.Window? win = app.main_window,
@@ -504,7 +529,7 @@ namespace Tuba {
 			},
 			bool skip = false // skip the dialog, used for preferences to avoid duplicate code
 		) {
-			if (skip) return true;
+			if (skip) return QuestionAnswer.YES;
 
 			var dlg = new Adw.MessageDialog (
 				win,
@@ -523,7 +548,7 @@ namespace Tuba {
 
 			if (win != null)
 				dlg.transient_for = win;
-			return (yield dlg.choose (null)) == "yes";
+			return QuestionAnswer.from_string (yield dlg.choose (null));
 		}
 
 	}

--- a/src/Dialogs/Composer/Dialog.vala
+++ b/src/Dialogs/Composer/Dialog.vala
@@ -208,7 +208,7 @@ public class Tuba.Dialogs.Compose : Adw.Window {
 				{ { _("Discard"), Adw.ResponseAppearance.DESTRUCTIVE }, { _("Cancel"), Adw.ResponseAppearance.DEFAULT } },
 				false,
 				(obj, res) => {
-					if (app.question.end (res)) on_close ();
+					if (app.question.end (res).truthy ()) on_close ();
 				}
 			);
 		}

--- a/src/Services/Accounts/SecretAccountStore.vala
+++ b/src/Services/Accounts/SecretAccountStore.vala
@@ -54,7 +54,7 @@ public class Tuba.SecretAccountStore : AccountStore {
 				{ {"Read More", Adw.ResponseAppearance.SUGGESTED }, { "Close", Adw.ResponseAppearance.DEFAULT } },
 				false,
 				(obj, res) => {
-					if (app.question.end (res)) Host.open_uri (wiki_page);
+					if (app.question.end (res).truthy ()) Host.open_uri (wiki_page);
 					Process.exit (1);
 				}
 			);

--- a/src/Views/Lists.vala
+++ b/src/Views/Lists.vala
@@ -60,7 +60,7 @@ public class Tuba.Views.Lists : Views.Timeline {
 				{ { _("Delete"), Adw.ResponseAppearance.DESTRUCTIVE }, { _("Cancel"), Adw.ResponseAppearance.DEFAULT } },
 				false,
 				(obj, res) => {
-					if (app.question.end (res)) {
+					if (app.question.end (res).truthy ()) {
 						new Request.DELETE (@"/api/v1/lists/$(list.id)")
 							.with_account (accounts.active)
 							.then (() => {

--- a/src/Views/Profile.vala
+++ b/src/Views/Profile.vala
@@ -262,7 +262,7 @@ public class Tuba.Views.Profile : Views.Timeline {
 				{ { block ? _("Block") : _("Unblock"), Adw.ResponseAppearance.DESTRUCTIVE }, { _("Cancel"), Adw.ResponseAppearance.DEFAULT } },
 				false,
 				(obj, res) => {
-					if (app.question.end (res)) profile.rs.modify (block ? "block" : "unblock");
+					if (app.question.end (res).truthy ()) profile.rs.modify (block ? "block" : "unblock");
 				}
 			);
 		});
@@ -281,7 +281,7 @@ public class Tuba.Views.Profile : Views.Timeline {
 				{ { block ? _("Block") : _("Unblock"), Adw.ResponseAppearance.DESTRUCTIVE }, { _("Cancel"), Adw.ResponseAppearance.DEFAULT } },
 				false,
 				(obj, res) => {
-					if (app.question.end (res)) {
+					if (app.question.end (res).truthy ()) {
 						var req = new Request.POST ("/api/v1/domain_blocks")
 							.with_account (accounts.active)
 							.with_param ("domain", profile.account.domain)

--- a/src/Views/Sidebar.vala
+++ b/src/Views/Sidebar.vala
@@ -220,7 +220,7 @@ public class Tuba.Views.Sidebar : Gtk.Widget, AccountHolder {
 				{ { _("Forget"), Adw.ResponseAppearance.DESTRUCTIVE }, { _("Cancel"), Adw.ResponseAppearance.DEFAULT } },
 				false,
 				(obj, res) => {
-					if (app.question.end (res)) {
+					if (app.question.end (res).truthy ()) {
 						try {
 							accounts.remove (account);
 						} catch (Error e) {

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -331,7 +331,7 @@
 			{ { _("Delete"), Adw.ResponseAppearance.DESTRUCTIVE }, { _("Cancel"), Adw.ResponseAppearance.DEFAULT } },
 			false,
 			(obj, res) => {
-				if (app.question.end (res)) {
+				if (app.question.end (res).truthy ()) {
 					this.status.formal.annihilate ()
 						//  .then ((in_stream) => {
 						//  	var parser = Network.get_parser_from_inputstream (in_stream);

--- a/src/Widgets/Status/ActionsRow.vala
+++ b/src/Widgets/Status/ActionsRow.vala
@@ -128,7 +128,7 @@ public class Tuba.Widgets.ActionsRow : Gtk.Box {
 				{ { _("Reply"), Adw.ResponseAppearance.SUGGESTED }, { _("Don't remind me again"), Adw.ResponseAppearance.DEFAULT } },
 				false,
 				(obj, res) => {
-					if (!app.question.end (res)) {
+					if (app.question.end (res) == Tuba.Application.QuestionAnswer.NO) {
 						settings.reply_to_old_post_reminder = false;
 					}
 					reply (btn);


### PR DESCRIPTION
In #672 the question API changed to return a bool, true for yes, false for no. However I completely missed the close response, sent when the user closes the dialog without choosing one of the responses. It would be treated as choosing the "No" one, but that shouldn't always be the case. This PR changes the question API to return an enum value of YES, NO, CLOSE with the helper instance methods truthy (YES) and falsy (NO, CLOSE)

fix: #689 