### PR TITLE
fix(votebox): ellipsize vote count and expiration label

### DIFF
--- a/data/ui/widgets/votebox.ui
+++ b/data/ui/widgets/votebox.ui
@@ -23,6 +23,7 @@
         <child>
           <object class="GtkButton" id="button_vote">
             <property name="visible">0</property>
+            <property name="valign">center</property>
           </object>
         </child>
         <child>
@@ -31,7 +32,6 @@
             <property name="wrap-mode">word-char</property>
             <property name="xalign">1</property>
             <property name="hexpand">1</property>
-            <property name="valign">center</property>
           </object>
         </child>
       </object>

--- a/data/ui/widgets/votebox.ui
+++ b/data/ui/widgets/votebox.ui
@@ -26,13 +26,9 @@
           </object>
         </child>
         <child>
-          <object class="GtkLabel" id="people_label">
-            <property name="ellipsize">end</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel" id="expires_label">
-            <property name="ellipsize">end</property>
+          <object class="GtkLabel" id="info_label">
+            <property name="wrap">1</property>
+            <property name="wrap-mode">word-char</property>
           </object>
         </child>
       </object>

--- a/data/ui/widgets/votebox.ui
+++ b/data/ui/widgets/votebox.ui
@@ -27,10 +27,12 @@
         </child>
         <child>
           <object class="GtkLabel" id="people_label">
+            <property name="ellipsize">end</property>
           </object>
         </child>
         <child>
           <object class="GtkLabel" id="expires_label">
+            <property name="ellipsize">end</property>
           </object>
         </child>
       </object>

--- a/data/ui/widgets/votebox.ui
+++ b/data/ui/widgets/votebox.ui
@@ -29,6 +29,9 @@
           <object class="GtkLabel" id="info_label">
             <property name="wrap">1</property>
             <property name="wrap-mode">word-char</property>
+            <property name="xalign">1</property>
+            <property name="hexpand">1</property>
+            <property name="valign">center</property>
           </object>
         </child>
       </object>

--- a/src/Widgets/VoteBox.vala
+++ b/src/Widgets/VoteBox.vala
@@ -2,8 +2,7 @@
 public class Tuba.Widgets.VoteBox : Gtk.Box {
 	[GtkChild] protected unowned Gtk.ListBox poll_box;
 	[GtkChild] protected unowned Gtk.Button button_vote;
-    [GtkChild] protected unowned Gtk.Label people_label;
-    [GtkChild] protected unowned Gtk.Label expires_label;
+    [GtkChild] protected unowned Gtk.Label info_label;
 
 	public API.Poll? poll { get; set;}
     protected Gee.ArrayList<string> selected_index = new Gee.ArrayList<string> ();
@@ -144,11 +143,13 @@ public class Tuba.Widgets.VoteBox : Gtk.Box {
             row_number++;
         }
 
-        // translators: the variable is the amount of people that voted
-        people_label.label = _("%lld voted").printf (poll.votes_count);
-        expires_label.label = poll.expired
-            ? DateTime.humanize_ago (poll.expires_at)
-            : DateTime.humanize_left (poll.expires_at);
+        info_label.label = "%s · %s".printf (
+            // translators: the variable is the amount of people that voted
+            _("%lld voted").printf (poll.votes_count),
+            poll.expired
+                ? DateTime.humanize_ago (poll.expires_at)
+                : DateTime.humanize_left (poll.expires_at)
+        );
 	}
 
     private void on_check_option_toggeled (Gtk.CheckButton radio) {


### PR DESCRIPTION
These labels can in theory become arbitrarily long due to translation. Thus, its width should be controlled using ellipses. This is as of now an issue with the German translation.

Fixes: https://github.com/GeopJr/Tuba/issues/665