### PR TITLE
feat(Host): use proper pathing and caching

### DIFF
--- a/src/Services/Network/Request.vala
+++ b/src/Services/Network/Request.vala
@@ -152,6 +152,12 @@ public class Tuba.Request : GLib.Object {
 		return body ("application/json", new Bytes.take (generator.to_data (null).data));
 	}
 
+	private bool cache = true;
+	public Request disable_cache () {
+		cache = false;
+		return this;
+	}
+
 	public Request exec () {
 		var parameters = "";
 		if (pars != null) {
@@ -200,6 +206,7 @@ public class Tuba.Request : GLib.Object {
 			msg.request_headers.append ("Authorization", @"Bearer $(account.access_token)");
 		}
 
+		if (!cache) msg.disable_feature (typeof (Soup.Cache));
 		msg.priority = priority;
 
 		if (content_type != null && body_bytes != null)

--- a/src/Utils/Host.vala
+++ b/src/Utils/Host.vala
@@ -34,14 +34,6 @@ public class Tuba.Host {
 		display.get_clipboard ().set_text (str);
 	}
 
-	public static string get_uri_host (string uri) {
-		var p1 = uri;
-		if ("//" in uri)
-			p1 = uri.split ("//")[1];
-
-		return p1.split ("/")[0];
-	}
-
 	public async static string download (string url) throws Error {
 		debug (@"Downloading file: $url…");
 

--- a/src/Utils/Host.vala
+++ b/src/Utils/Host.vala
@@ -48,12 +48,7 @@ public class Tuba.Host {
 		var file_name = Path.get_basename (url);
 		var dir_name = Path.get_dirname (url);
 
-		var dir_path = Path.build_path (
-			Path.DIR_SEPARATOR_S,
-			Environment.get_user_cache_dir (), // Environment.get_user_special_dir (UserDirectory.DOWNLOAD),
-			Build.DOMAIN,
-			get_uri_host (dir_name));
-
+		var dir_path = GLib.Path.build_path (GLib.Path.DIR_SEPARATOR_S, Tuba.cache_path, "manual", "media");
 		var file_path = Path.build_path (
 			Path.DIR_SEPARATOR_S,
 			dir_path,
@@ -66,7 +61,9 @@ public class Tuba.Host {
 		var file = File.new_for_path (file_path);
 
 		if (!file.query_exists ()) {
-			var msg = yield new Request.GET (url)
+			// Disable libsoup's cache on these
+			// it's better if we handle it so it doesn't affect its limits and loading
+			var msg = yield new Request.GET (url).disable_cache ()
 				.await ();
 
 			var data = msg.response_body;


### PR DESCRIPTION
it should now cache videos under tuba/manual/media/ only.

The previous behavior was caching it under tuba/<url>/ *and* tuba/soup/misc/ (soup's cache)