### PR TITLE
feat(RelationshipButton): add feedback to transitional loading state

### DIFF
--- a/src/Widgets/RelationshipButton.vala
+++ b/src/Widgets/RelationshipButton.vala
@@ -19,6 +19,9 @@ public class Tuba.Widgets.RelationshipButton : Gtk.Button {
 	public void on_clicked () {
 		if (fn != null) {
 			fn ();
+
+			sensitive = false;
+
 			fn = null;
 		}
 	}

--- a/src/Widgets/RelationshipButton.vala
+++ b/src/Widgets/RelationshipButton.vala
@@ -18,9 +18,8 @@ public class Tuba.Widgets.RelationshipButton : Gtk.Button {
 
 	public void on_clicked () {
 		if (fn != null) {
-			fn ();
-
 			sensitive = false;
+			fn ();
 
 			fn = null;
 		}


### PR DESCRIPTION
The intermediate state that a RelationshipButton implicitly has is not displayed to the user. As the button can be in this state for up to the timeout of the corresponding network request, it can lead to a perceived unresponsiveness of the app.

I also tried a Gtk.Spinner, but to me, it looks like a label fits better the button that also has a label otherwise.