### PR TITLE
feat(Search): limit All to 4 per category

### DIFF
--- a/src/Views/Search.vala
+++ b/src/Views/Search.vala
@@ -57,8 +57,12 @@ public class Tuba.Views.Search : Views.TabbedBase {
 
 	void append_results (Gee.ArrayList<Entity> array, Views.ContentBase tab) {
 		if (!array.is_empty) {
+			int all_i = 0;
 			array.@foreach (e => {
-				append_entity (all_tab, e);
+				if (all_i < 4) {
+					append_entity (all_tab, e);
+					all_i++;
+				}
 				append_entity (tab, e);
 
 				return true;
@@ -82,10 +86,9 @@ public class Tuba.Views.Search : Views.TabbedBase {
 				bool hashtag = query.has_prefix ("#");
 
 				if (hashtag) append_results (results.hashtags, hashtags_tab);
-
 				append_results (results.accounts, accounts_tab);
-				append_results (results.statuses, statuses_tab);
 				if (!hashtag) append_results (results.hashtags, hashtags_tab);
+				append_results (results.statuses, statuses_tab);
 
 				base_status = new StatusMessage ();
 


### PR DESCRIPTION
Mastodon's web ui limits the "All" tab to 4 items per category (4 people, 4 hashtags, 4 posts) and shows everything on each category. That sounds good to me

Also it orders them as People > Hashtags > Posts. I changed it so Tuba does the same, that way hashtags separate people and posts since they look similar-ish. (Tuba does however place hashtags at the top if the search query starts with `#`)