### PR TITLE
feat: v0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,27 +66,6 @@ $ make install
 - Clone
 - Open in GNOME Builder
 
-# Screenshots
-
-<details>
-<summary>View All</summary>
-
-<table>
-  <tr>
-    <td align="center"><img loading="lazy" draggable="false" alt="Screenshot of the Tuba app in light and mobile view. The current view is the home one. The main window is inactive as there's the compose modal open. The modal's privacy setting dropdown is open. This screenshot showcases: 1. that you can write posts, 2. you can use emojis, 3. it supports character limits of the instance, 4. you can change privacy settings, 5. you can attach media, 5. you can set content warnings" src="https://i.imgur.com/3essApP.png" /></td>
-    <td align="center"><img loading="lazy" draggable="false" alt="Screenshot of the Tuba app in dark and mobile view. The current view is the main one on the 'Home' tab. The 'Notifications' tab has the number 15 in an accent-colored bubble. There are 3 posts visible by BASIL, AUBREY and HERO showcasing some of Tuba's features: 1. Image attachments, 2. custom emojis, 3. content warnings, 4. reboosts, 5. notification badges, 6.post indicators, 7. post actions." src="https://i.imgur.com/Q3lnP51.png" /></td>
-  </tr>
-  <tr>
-    <td colspan="2" align="center"><img loading="lazy" draggable="false" alt="Screenshot of the Tuba app in light and large window size view. The current view is the main one on the 'Home' tab. 2 more posts are visible now by the users HERO and KEL. The screenshot showcases: 1. poll support, 2. user mentions in posts, 3. large window size." src="https://i.imgur.com/XBtQsya.png" /></td>
-  </tr>
-  <tr>
-    <td align="center"><img loading="lazy" draggable="false" alt="Screenshot of the Tuba app in dark and mobile view. The current view is the search one on the 'Hashtags' tab. The search entry has '#linux' as its content. There's a full page of results returned showcasing Tuba's search functionality and ability to return how many times each hashtag was used and by how many people in the past 2 days." src="https://i.imgur.com/VxeOMOg.png" /></td>
-    <td align="center"><img loading="lazy" draggable="false" alt="Screenshot of the Tuba app in light and medium window size view. The current view is the profile one on the user Xenia. This screenshot showcases: 1. verified links, 2. the ability to follow users, 3. posts, following and follower counts, 4. profile headers, 5. the sidebar." src="https://i.imgur.com/jBF85mI.png" /></td>
-  </tr>
-</table>
-
-</details>
-
 # Sponsors
 
 <div align="center">

--- a/data/dev.geopjr.Tuba.metainfo.xml.in
+++ b/data/dev.geopjr.Tuba.metainfo.xml.in
@@ -16,12 +16,15 @@
   <provides>
     <binary>dev.geopjr.Tuba</binary>
   </provides>
+  <launchable type="desktop-id">dev.geopjr.Tuba.desktop</launchable>
   <developer_name translatable="no">Evangelos "GeopJr" Paterakis</developer_name>
   <url type="homepage">https://tuba.geopjr.dev/</url>
   <url type="bugtracker">https://github.com/GeopJr/Tuba/issues</url>
   <url type="translate">https://hosted.weblate.org/engage/tuba/</url>
   <url type="donation">https://geopjr.dev/donate</url>
   <url type="contact">https://matrix.to/#/#tuba:gnome.org</url>
+  <url type="vcs-browser">https://github.com/GeopJr/Tuba/</url>
+  <url type="contribute">https://github.com/GeopJr/Tuba#contributing</url>
   <screenshots>
     <screenshot type="default">
       <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/main/data/screenshots/screenshot-1.png</image>
@@ -42,10 +45,6 @@
     <content_attribute id="social-contacts">intense</content_attribute>
   </content_rating>
   <translation type="gettext">dev.geopjr.Tuba</translation>
-  <custom>
-    <value key="Purism::form_factor">workstation</value>
-    <value key="Purism::form_factor">mobile</value>
-  </custom>
   <requires>
     <display_length compare="ge">360</display_length>
   </requires>
@@ -55,6 +54,51 @@
     <control>touch</control>
   </recommends>
   <releases>
+    <release version="0.6.0" date="2023-12-22">
+      <description translatable="no">
+        <ul>
+            <li>Added MediaViewer enter and leave transitions</li>
+            <li>Added web+ap support</li>
+            <li>Redesigned account widgets</li>
+            <li>Added a button to toggle all spoilers in threads</li>
+            <li>Replaced manually caching with libsoup's built-in caching</li>
+            <li>Added advanced boost dialog to choose boost visibility and quote posts</li>
+            <li>Added keeping track of the spellchecker enabled state</li>
+            <li>Added dismissible warning when replying to posts older than 3 months</li>
+            <li>Added subscribing for notifications on new account posts</li>
+            <li>Added the option to hide accounts in list from the Home timeline</li>
+            <li>Added the ability to open profiles in browser</li>
+            <li>Added profile badges</li>
+            <li>Added keeping track of the window maximized state</li>
+            <li>Removed the preview card warning dialog</li>
+            <li>Redesigned the completion provider popups</li>
+            <li>Added per-account settings</li>
+            <li>Added more shortcuts</li>
+            <li>Fixed floating button reveal animation not playing from the bottom of the window</li>
+            <li>Fixed account switcher selection not being updated when adding a new account</li>
+            <li>Fixed mention resolving based on provided mentions not working</li>
+            <li>Fixed inconsistencies in card and focus styling</li>
+            <li>Fixed conditions that would leave the main window without a view switcher</li>
+            <li>Fixed certain post elements not being rendered</li>
+            <li>Fixed MediaViewer crash when triggering certain shortcuts while the animation is in progress</li>
+            <li>Fixed certain shortcuts not working with caps lock on</li>
+            <li>Fixed occasional duplicate posts at the top of timelines</li>
+            <li>Fixed profile timelines returning less posts on every refresh</li>
+            <li>Fixed entities not being updated in the same session showing outdated info</li>
+            <li>Fixed memory leaks and segfaults found</li>
+            <li>Fixed websockets not recovering after disconnecting</li>
+            <li>Fixed some instances of incorrect label measuring</li>
+            <li>Removed back arrow from sidebar pages</li>
+            <li>Fixed bookwyrm page title not filling all available space</li>
+            <li>Fixed flatpak notifications not including the avatar of the issuer</li>
+            <li>Fixed composer word capturing to match the whole word rather than from the start until the cursor</li>
+            <li>Fixed composer completion provider replacement not replacing the whole word</li>
+            <li>Fixed votebox labels overflowing the window</li>
+            <li>Fixed sidebar main page items not being marked as selected in some cases</li>
+            <li>Read the full changelog on the repo</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.5.0" date="2023-09-22">
       <description translatable="no">
         <ul>

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'dev.geopjr.Tuba',
     ['c', 'vala'],
-    version: '0.5.0',
+    version: '0.6.0',
     meson_version: '>= 0.56.0',
     default_options: [
         'warning_level=2',


### PR DESCRIPTION
release note:

```
# Added

- Keyboard shortcut for preferences (#549, thanks [at]TheEvilSkeleton) 
- Removed `.view` styling from the composer (#551, thanks [at]bragefuglseth)
- Open in Browser for profiles (#563)
- Option to hide accounts in lists from the Home timeline (#557)
- Automatically close the account switcher popover when selecting "Forget" (#562)
- `web+ap` support (#561)
- Subscribing for notifications on new account posts (#568)
- Profile role badges (#555)
- Composer button always visible on wide sizes (#552, thanks [at]bragefuglseth)
- Update the preview card's icons and colors (#584, thanks [at]bertob)
- Keep track of the window's maximized state between restarts (#593, thanks [at]henryrov)
- Transition when entering and leaving the MediaViewer (#602, thanks Fractal Team)
- Different feedback methods for timeline errors than the base (#591)
- A more appropriate icon for copying profile handles (#617, thanks [at]kra-mo)
- Toasts for global feedback (#620)
- Network API cleanup (#616)
- Replace manually caching with libsoup's (#616)
- Advanced Boost Dialog for setting boost visibility and quoting posts (#629)
- Remove MediaViewer carousel dots (#652, thanks [at]bertob)
- Show unshortened units on their tooltips (#653, thanks [at]bertob)
- More MediaViewer shortcuts (#642, thanks [at]nekohayo)
- Remember spellchecker enabled state (#673)
- Redesigned the composer's completion providers to match Fractal's (#664, thanks Fractal Team)
- Removed (forked) gspell-4 support (#677)
- Loop and autoplay gifs in the MediaViewer (#682)
- Button to toggle all spoilers in a thread (#615)
- Warning when replying to a post older than 3 months (#659)
- Use UUIDs for distinguishing accounts instead of handles (#699)
- Per-account settings (#680)
- Avoid reading all secrets based on attributes (#701)
- Separators between profile cover counter-buttons (#702, thanks [at]TheEvilSkeleton) 
- Limit the "All" tab in search to 4 results per category (#709)
- Order the "All" tab's results in search in the Profiles > Hashtags > Posts order (#709)
- Removed the preview card out-of-instance warning dialog (#679)
- New account widgets (#637)
- More MediaViewer shortcuts for zooming (#712, thanks [at]oscfdezdz)
- Set relationship buttons to insensitive while processing (#703, thanks [at]camelCaseNick)

# Fixed

- Animations when revealing the composer button not starting at the bottom (#552)
- Warning on new account dialog about pages needing a title (#556)
- About => About Tuba (#565, thanks [at]bragefuglseth)
- Account switcher selection not getting updated when selecting to a new account (#562)
- Array deserialization logic being prone to conflicts (#566)
- Invalid property named being used on status objects (#571)
- Focus ring on profile cover not following its outline (#585)
- Post cards not following the `.card` colors on hover (#583, thanks [at]bertob)
- Simplified complex main view conditions that could leave the window without a switcher (#580)
- RichLabel using markup by default causing some posts being partially visible (#578)
- MediaViewer out of bounds when changing carousel position while the animation is playing (#579)
- Ctrl+Enter on composer not working with caps lock on (#590)
- Simplified and refactored the MediaViewer API (#602)
- Handle post codeblocks using the blockquote handler (#595)
- Duplicate posts in the timeline cause by a race condition between the timeline and the websocket (#596)
- FAB's focus rings being cut off (#607)
- Profile timeline changes not cleaning the page headers, leading to less posts being returned every time it refreshed (#636, thanks [at]LukaszH77)
- Objects not being updated in the same session, showing older info (#616)
- Cleanup the image helpers (#616)
- Remove unused instances of libsoup messages (#616)
- Memory leak with CustomEmojiChooser (#616)
- Websockets not recovering after disconnecting (#616)
- Remove LabelWithWidgets hack that would interfere with label measuring (#648, thanks [at]bugaevc)
- Remove back arrow from sidebar pages (#648, thanks [at]bertob)
- Remove ToolbarView style toggling on breakpoint (#649, thanks [at]bugaevc)
- Show a plus icon instead of a user one next to the Add Account entry on the MediaViewer (#656, thanks [at]afranke)
- Bookwyrm page title not filling the full available width (#667)
- Notification icons in flatpak (#675)
- Refactor question API (#672)
- Composer's word capturing to match the whole word when providing completions (#661)
- Composer's completion provider replacement not replacing the whole word (#661)
- Votebox labels overflowing (#695, thanks [at]camelCaseNick)
- Handle empty paragraphs is posts (#707)
- Handle paragraphs in list items (#707)
- Sidebar fake pages not being selected when in a nested view (#711)

**Full Changelog**: https://github.com/GeopJr/Tuba/compare/v0.5.0...v0.6.0
```

TODO:

- ~~check all changelogs again~~
- ~~prepare full release note~~
- ~~prepare fedi posts~~
- ~~take fedi screenshots~~