### PR TITLE
Fix keyboard shortcuts in editor and media viewer

### DIFF
--- a/src/Dialogs/Composer/EditorPage.vala
+++ b/src/Dialogs/Composer/EditorPage.vala
@@ -160,6 +160,7 @@ public class Tuba.EditorPage : ComposerPage {
 
 		var keypress_controller = new Gtk.EventControllerKey ();
         keypress_controller.key_pressed.connect ((keyval, _, modifier) => {
+            modifier &= Gdk.MODIFIER_MASK;
             if (keyval == Gdk.Key.Return && (modifier == Gdk.ModifierType.CONTROL_MASK || modifier == (Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.LOCK_MASK))) {
 				ctrl_return_pressed ();
 				return true;

--- a/src/Dialogs/Composer/EditorPage.vala
+++ b/src/Dialogs/Composer/EditorPage.vala
@@ -161,7 +161,7 @@ public class Tuba.EditorPage : ComposerPage {
 		var keypress_controller = new Gtk.EventControllerKey ();
         keypress_controller.key_pressed.connect ((keyval, _, modifier) => {
             modifier &= Gdk.MODIFIER_MASK;
-            if (keyval == Gdk.Key.Return && (modifier == Gdk.ModifierType.CONTROL_MASK || modifier == (Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.LOCK_MASK))) {
+            if ((keyval == Gdk.Key.Return || keyval == Gdk.Key.KP_Enter) && (modifier == Gdk.ModifierType.CONTROL_MASK || modifier == (Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.LOCK_MASK))) {
 				ctrl_return_pressed ();
 				return true;
 			}

--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -519,6 +519,7 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 	}
 
 	protected bool on_keypress (uint keyval, uint keycode, Gdk.ModifierType state) {
+		state &= Gdk.MODIFIER_MASK;
 		if (state != 0) {
 			if (state != Gdk.ModifierType.CONTROL_MASK && state != (Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.SHIFT_MASK)) return false;
 

--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -529,10 +529,12 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 			switch (keyval) {
 				case Gdk.Key.plus:
 				case Gdk.Key.equal:
+				case Gdk.Key.KP_Add:
 					page.zoom_in ();
 					break;
 				case Gdk.Key.minus:
 				case Gdk.Key.underscore:
+				case Gdk.Key.KP_Subtract:
 					page.zoom_out ();
 					break;
 				default:


### PR DESCRIPTION
Fixed modifier checks not to be affected by NumLock (and other private GDK constants). Fixed MediaViewer and Composer to accept NumPad keys along with alphanumeric block keys.

Fixes #725 