### PR TITLE
fix: Make Tuba.Widgets.Avatar non-focusable (#729)

### DIFF
--- a/data/ui/views/sidebar/view.ui
+++ b/data/ui/views/sidebar/view.ui
@@ -39,6 +39,7 @@
 								<property name="popover">account_switcher_popover_menu</property>
 								<child>
 									<object class="TubaWidgetsAvatar" id="accounts_button_avi">
+										<property name="can_focus">false</property>
 										<property name="size">26</property>
 									</object>
 								</child>


### PR DESCRIPTION
Make Tuba.Widgets.Avatar non-focusable to prevent the child button of accounts selector from being selected during tab-cycling.  It is duplicate to the accounts selector itself.

Closes #729