### PR TITLE
fix(Mention): use token when opening accounts

### DIFF
--- a/src/API/Mention.vala
+++ b/src/API/Mention.vala
@@ -21,7 +21,14 @@ public class Tuba.API.Mention : Entity, Widgetizable {
     }
 
 	public override void open () {
-		Views.Profile.open_from_id (id);
+        new Request.GET (@"/api/v1/accounts/$id")
+			.with_account (accounts.active)
+            .then ((in_stream) => {
+                var parser = Network.get_parser_from_inputstream (in_stream);
+                var node = network.parse_node (parser);
+                API.Account.from (node).open ();
+            })
+            .exec ();
 	}
 
 }

--- a/src/Views/Profile.vala
+++ b/src/Views/Profile.vala
@@ -319,17 +319,6 @@ public class Tuba.Views.Profile : Views.Accounts {
 		return base.append_params (req);
 	}
 
-	public static void open_from_id (string id) {
-		var msg = new Soup.Message ("GET", @"$(accounts.active.instance)/api/v1/accounts/$id");
-		network.queue (msg, null, (in_stream) => {
-			var parser = Network.get_parser_from_inputstream (in_stream);
-			var node = network.parse_node (parser);
-			var acc = API.Account.from (node);
-			app.main_window.open_view (new Views.Profile (acc));
-		},
-		network.on_error);
-	}
-
 	public class RowButton : Gtk.Button {
 		public bool remove { get; set; default = false; }
 	}


### PR DESCRIPTION
fix: #731 

Relic of Tootle, it was never converted to use the cacheable internal soup session and never used the token causing GoToSocial to not be able to fetch accounts when mentions got clicked.