### PR TITLE
fix(Main): switcher state and breakpoints between is_mobile

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -30,6 +30,7 @@ namespace Tuba {
 
 		public Dialogs.MainWindow? main_window { get; set; }
 		public Dialogs.NewAccount? add_account_window { get; set; }
+		public bool is_mobile { get; set; default=false; }
 
 		public Locales app_locales { get; construct set; }
 

--- a/src/Dialogs/MainWindow.vala
+++ b/src/Dialogs/MainWindow.vala
@@ -12,16 +12,14 @@ public class Tuba.Dialogs.MainWindow: Adw.ApplicationWindow, Saveable {
 		sidebar.set_sidebar_selected_item (pos);
 	}
 
-	public bool is_mobile { get; set; default = false; }
-
 	Views.Base? last_view = null;
 
 	construct {
 		construct_saveable (settings);
 
 		var gtk_settings = Gtk.Settings.get_default ();
-		breakpoint.add_setter (this, "is-mobile", true);
-		notify["is-mobile"].connect (update_selected_home_item);
+		breakpoint.add_setter (app, "is-mobile", true);
+		app.notify["is-mobile"].connect (update_selected_home_item);
 		media_viewer.bind_property ("visible", split_view, "can-focus", GLib.BindingFlags.SYNC_CREATE | GLib.BindingFlags.INVERT_BOOLEAN);
 		media_viewer.notify["visible"].connect (on_media_viewer_toggle);
 
@@ -194,7 +192,7 @@ public class Tuba.Dialogs.MainWindow: Adw.ApplicationWindow, Saveable {
 
 	public void update_selected_home_item () {
 		if (is_home) {
-			if (is_mobile) {
+			if (app.is_mobile) {
 				set_sidebar_selected_item (0);
 			} else {
 				var main_view = main_page.child as Views.Main;

--- a/src/Services/Accounts/Mastodon/Account.vala
+++ b/src/Services/Accounts/Mastodon/Account.vala
@@ -157,13 +157,9 @@ public class Tuba.Mastodon.Account : InstanceAccount {
 	};
 
 	public override void register_known_places (GLib.ListStore places) {
-		ulong main_window_notify = 0;
-		main_window_notify = app.notify["main-window"].connect (() => {
-			app.main_window.bind_property ("is-mobile", PLACE_NOTIFICATIONS, "visible", GLib.BindingFlags.SYNC_CREATE | GLib.BindingFlags.INVERT_BOOLEAN);
-			app.main_window.bind_property ("is-mobile", PLACE_CONVERSATIONS, "visible", GLib.BindingFlags.SYNC_CREATE | GLib.BindingFlags.INVERT_BOOLEAN);
-			app.main_window.bind_property ("is-mobile", PLACE_SEARCH, "visible", GLib.BindingFlags.SYNC_CREATE | GLib.BindingFlags.INVERT_BOOLEAN);
-			app.disconnect (main_window_notify);
-		});
+		app.bind_property ("is-mobile", PLACE_NOTIFICATIONS, "visible", GLib.BindingFlags.SYNC_CREATE | GLib.BindingFlags.INVERT_BOOLEAN);
+		app.bind_property ("is-mobile", PLACE_CONVERSATIONS, "visible", GLib.BindingFlags.SYNC_CREATE | GLib.BindingFlags.INVERT_BOOLEAN);
+		app.bind_property ("is-mobile", PLACE_SEARCH, "visible", GLib.BindingFlags.SYNC_CREATE | GLib.BindingFlags.INVERT_BOOLEAN);
 
 		places.append (PLACE_HOME);
 		places.append (PLACE_NOTIFICATIONS);

--- a/src/Views/Home.vala
+++ b/src/Views/Home.vala
@@ -38,15 +38,10 @@ public class Tuba.Views.Home : Views.Timeline {
             });
         #endif
 
-        ulong main_window_notify = 0;
-        main_window_notify = app.notify["main-window"].connect (() => {
-			app.disconnect (main_window_notify);
-
-			app.main_window.notify["is-mobile"].connect (() => {
-                if (!app.main_window.is_mobile)
-                        compose_button_rev.reveal_child = true;
-            });
-		});
+        app.notify["is-mobile"].connect (() => {
+            if (!app.is_mobile)
+                    compose_button_rev.reveal_child = true;
+        });
     }
 
     void toggle_scroll_to_top_margin () {
@@ -58,7 +53,7 @@ public class Tuba.Views.Home : Views.Timeline {
     bool last_direction_down = false;
     protected override void on_scrolled_vadjustment_value_change () {
         base.on_scrolled_vadjustment_value_change ();
-        if (app.main_window?.is_mobile != true) return;
+        if (app.is_mobile != true) return;
 
         double trunced = Math.trunc (scrolled.vadjustment.value);
         bool direction_down = trunced == last_adjustment ? last_direction_down : trunced > last_adjustment;

--- a/src/Views/Main.vala
+++ b/src/Views/Main.vala
@@ -24,14 +24,32 @@ public class Tuba.Views.Main : Views.TabbedBase {
 	//  	app.main_window.update_selected_home_item ();
 	//  }
 
+	private Gtk.Stack title_wrapper_stack;
+	public bool title_wrapper_stack_visible {
+		get {
+			return title_wrapper_stack.visible_child_name == "title";
+		}
+		set {
+			title_wrapper_stack.visible_child_name = (value ? "stack" : "title");
+		}
+	}
+
 	private void bind () {
-		app.main_window.bind_property ("is-mobile", search_button, "visible", GLib.BindingFlags.SYNC_CREATE);
-		app.main_window.bind_property ("is-mobile", switcher_bar, "visible", GLib.BindingFlags.SYNC_CREATE);
-		app.main_window.bind_property ("is-mobile", switcher, "visible", GLib.BindingFlags.SYNC_CREATE);
+		app.bind_property ("is-mobile", search_button, "visible", GLib.BindingFlags.SYNC_CREATE);
+		app.bind_property ("is-mobile", switcher_bar, "visible", GLib.BindingFlags.SYNC_CREATE);
+		app.bind_property ("is-mobile", this, "title-wrapper-stack-visible", GLib.BindingFlags.SYNC_CREATE);
 	}
 
 	public override void build_header () {
 		base.build_header ();
+		header.title_widget = null;
+
+		title_wrapper_stack = new Gtk.Stack ();
+		title_wrapper_stack.add_named (title_stack, "stack");
+		var title_header = new Adw.WindowTitle (label, "");
+		bind_property ("label", title_header, "title", BindingFlags.SYNC_CREATE);
+		title_wrapper_stack.add_named (title_header, "title");
+		header.title_widget = title_wrapper_stack;
 
 		search_button = new Gtk.Button () {
 			icon_name = "tuba-loupe-large-symbolic",
@@ -44,6 +62,7 @@ public class Tuba.Views.Main : Views.TabbedBase {
 		header.pack_start (sidebar_button);
 		sidebar_button.icon_name = "tuba-dock-left-symbolic";
 
+		bind ();
 		ulong main_window_notify = 0;
 		main_window_notify = app.notify["main-window"].connect (() => {
 			if (app.main_window == null) {
@@ -51,7 +70,6 @@ public class Tuba.Views.Main : Views.TabbedBase {
 				return;
 			}
 
-			bind ();
 			app.main_window.split_view.bind_property (
 				"collapsed",
 				sidebar_button,

--- a/src/Views/TabbedBase.vala
+++ b/src/Views/TabbedBase.vala
@@ -52,7 +52,7 @@ public class Tuba.Views.TabbedBase : Views.Base {
 		}
 
 		set {
-			title_stack.visible_child_name = value ? "title" : "switcher";
+			title_stack.visible_child_name = (value ? "title" : "switcher");
 		}
 	}
 
@@ -70,6 +70,7 @@ public class Tuba.Views.TabbedBase : Views.Base {
 		bind_property ("label", title_header, "title", BindingFlags.SYNC_CREATE);
 		title_stack.add_named (title_header, "title");
 
+		title_stack_page_visible = false;
 		var condition = new Adw.BreakpointCondition.length (
 			Adw.BreakpointConditionLengthType.MAX_WIDTH,
 			550, Adw.LengthUnit.SP


### PR DESCRIPTION
fix: #734 

To avoid a breakpoint condition hell, let's just wrap it in another stack.

The problem:
We want the main window to show the main view switcher and switcher bar ONLY in narrow mode (`is-mobile`). To achieve the bottom bar one, is-mobile is bound to its visibility and the main view breakpoint is bound to its reveal property. That way, there are two visibility states. That is not the case for the switcher however, if the switcher is not visible, the headerbar stack cannot set it as the visible child, so both the breakpoint condition and the `is-mobile` one need to be in sync. That led to the previous *very* complicated solution.

This time let's just have 2 visibility states for it, like the switcher bar, using two stacks, one for `is-mobile` and one for the breakpoint.