### PR TITLE
fix(SecretAccountStore): workaround DONT_MATCH_NAME

### DIFF
--- a/src/Services/Accounts/SecretAccountStore.vala
+++ b/src/Services/Accounts/SecretAccountStore.vala
@@ -13,7 +13,7 @@ public class Tuba.SecretAccountStore : AccountStore {
 		schema_attributes["version"] = Secret.SchemaAttributeType.STRING;
 		schema = new Secret.Schema.newv (
 			Build.DOMAIN,
-			Secret.SchemaFlags.NONE,
+			Secret.SchemaFlags.DONT_MATCH_NAME,
 			schema_attributes
 		);
 
@@ -61,6 +61,19 @@ public class Tuba.SecretAccountStore : AccountStore {
 		}
 
 		secrets.foreach (item => {
+			// HACK for DONT_MATCH_NAME
+			// https://github.com/GeopJr/Tuba/pull/701
+			// "Mastodon Account" is not meant to be static
+			// and might be affected by translations, so
+			// just keep it as a fallback if xdg:schema
+			// is not available
+
+			bool skip_secret = item.label != _("Mastodon Account");
+			if (item.attributes.contains ("xdg:schema")) {
+				skip_secret = item.attributes.get ("xdg:schema") != Build.DOMAIN;
+			}
+			if (skip_secret) return;
+
 			// TODO: remove uuid fallback
 			bool force_save = false;
 			var account = secret_to_account (item, out force_save);


### PR DESCRIPTION
fix: #701 #114 again 

# What's did #701 do?

When searching for secrets (saved accounts) in the keyring, we encountered issues with the keyring not unlocking in some setups. The solution was to retrieve ALL secrets that match the schema and not just Tuba's (#134, #114). However when working on another app that used the same schema as Tuba's I noticed that the two were reading each other's secrets and failing to load them (as expected) so I reverted the change on #701. Now there are two problems, both #114 and the one just described.

# What does this PR do?

It reverts #701 but to prevent the new problem, it checks if the label is "Mastodon Account" (not so reliable) and if `xdg:schema` matches the app id (`dev.geopjr.Tuba`) and skips the secret if it doesn't.