### PR TITLE
fix(SecretAccountStore): rethink validation

### DIFF
--- a/src/Services/Accounts/SecretAccountStore.vala
+++ b/src/Services/Accounts/SecretAccountStore.vala
@@ -135,9 +135,6 @@ public class Tuba.SecretAccountStore : AccountStore {
 		var builder = new Json.Builder ();
 		builder.begin_object ();
 
-		builder.set_member_name ("tuba-id");
-		builder.add_string_value (Build.DOMAIN);
-
 		builder.set_member_name ("id");
 		builder.add_string_value (account.id);
 
@@ -245,15 +242,12 @@ public class Tuba.SecretAccountStore : AccountStore {
 			// HACK: Partial makeshift secret validation
 			// see #742 #701 #114
 			if (
-				(!root_obj.has_member ("tuba-id") || root_obj.get_string_member ("tuba-id") != Build.DOMAIN)
-				&& (
-					!root_obj.has_member ("backend")
-					|| !root_obj.has_member ("acct")
-					|| !root_obj.has_member ("id")
-					|| !root_obj.has_member ("client-secret")
-					|| !root_obj.has_member ("client-id")
-					|| !root_obj.has_member ("access-token")
-				)
+				!root_obj.has_member ("backend")
+				|| !root_obj.has_member ("acct")
+				|| !root_obj.has_member ("id")
+				|| !root_obj.has_member ("client-secret")
+				|| !root_obj.has_member ("client-id")
+				|| !root_obj.has_member ("access-token")
 			) return null;
 
 			// TODO: remove uuid fallback


### PR DESCRIPTION
Enough fighting libsecret. Just do partial content validation until the schema bump.

I added `tuba-id` to the secret as a way to avoid validating the whole object but honestly it should probably be removed. Between the uuid migration and this, a force save might render some secrets unusable (null uuid) and I'm not willing to break the secrets in a patch release

fix: https://github.com/GeopJr/Tuba/pull/742#issuecomment-1886516271