### PR TITLE
fix(helpers)[image]: do not handle empty urls

### DIFF
--- a/src/Services/Helpers/Image.vala
+++ b/src/Services/Helpers/Image.vala
@@ -50,7 +50,7 @@ public class Tuba.Helper.Image {
 	}
 
 	public static void request_paintable (string? url, string? blurhash, owned OnItemChangedFn cb) {
-		if (url == null) return;
+		if (url == null || url == "") return;
 		new Helper.Image ();
 		bool has_loaded = false;
 		cb (null);


### PR DESCRIPTION
friendica sometimes returns empty strings for images

fix: #745 