### PR TITLE
feat: v0.6.2

### DIFF
--- a/data/dev.geopjr.Tuba.metainfo.xml.in
+++ b/data/dev.geopjr.Tuba.metainfo.xml.in
@@ -54,6 +54,24 @@
     <control>touch</control>
   </recommends>
   <releases>
+    <release version="0.6.2" date="2024-01-15">
+      <description translatable="no">
+        <ul>
+            <li>Fixed incorrect DateTime calculation on very old posts</li>
+            <li>Fixed MediaViewer not handling all instances of some keybinds</li>
+            <li>Fixed sidebar headerbar account switcher button having multiple focus targets</li>
+            <li>Fixed mentions not opening on GoToSocial</li>
+            <li>Fixed some edge cases that would leave the view without a switcher</li>
+            <li>Fixed narrow mode not showing a back button</li>
+            <li>Fixed keyring not being unlocked when looking up secrets</li>
+            <li>Fixed incorrect LabelWithWidgets size calculation</li>
+            <li>Fixed segfault on friendica when handling empty image urls</li>
+            <li>Fixed MediaViewer back button showing incorrect icon on RTL</li>
+            <li>Switched to replacing the whole Navigation stack when selecting a sidebar item</li>
+            <li>Updated translations</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.6.1" date="2023-12-23">
       <description translatable="no">
         <ul>

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'dev.geopjr.Tuba',
     ['c', 'vala'],
-    version: '0.6.1',
+    version: '0.6.2',
     meson_version: '>= 0.56.0',
     default_options: [
         'warning_level=2',


### PR DESCRIPTION
```
# Fixed

- Fixed DateTime months calculation on dates older than 1 year (#732)
- Fixed MediaViewer not handling numpad keybinds (#726, thanks [at]mgorny)
- Fixed double focus target on sidebar's headerbar account switcher button (#730, thanks [at]mgorny)
- Fixed mentions not opening on GoToSocial (and probably others) due to unauthorized requests to their APIs (#733, thanks [at]daenney)
- Fixed main view being left without a switcher when the initial window size is right at the breakpoint (#735, thanks [at]IBBoard)
- Fixed LabelWithWidgets using a makeshift (and incorrect) `extents_to_pixels` implementation (#720)
- Fixed narrow mode not showing a back button (#718)
- Fixed keyring not being unlocked on some setups due to a libsecret issue and instead manually partially validate secrets (#742, #744, thanks [at]stacyharper, [at]LukaszH77)
- Fixed friendica segfaulting due to attempting to handle empty urls (#746)
- Fixed MediaViewer back button not pointing right on RTL
- Switched to replacing the whole Navigation stack when clicking a sidebar item rather than manually handling it (#741, thanks [at]alice-mkh)
- Updated translations (thanks everyone)

**Full Changelog**: https://github.com/GeopJr/Tuba/compare/v0.6.1...v0.6.2
```