### PR TITLE
fix(streams): retry on connection reset by peer

### DIFF
--- a/src/Services/Network/Streams.vala
+++ b/src/Services/Network/Streams.vala
@@ -76,7 +76,7 @@ public class Tuba.Streams : Object {
 					socket.message.connect (on_message);
 				} catch (Error e) {
 					warning (@"Error opening stream: $(e.message)");
-					if (e.code == 3 || e.code == 44) {
+					if (e.matches (Quark.from_string ("g-tls-error-quark"), 3) || e.matches (Quark.from_string ("g-io-error-quark"), 44)) {
 						on_closed ();
 					}
 				}

--- a/src/Services/Network/Streams.vala
+++ b/src/Services/Network/Streams.vala
@@ -76,6 +76,9 @@ public class Tuba.Streams : Object {
 					socket.message.connect (on_message);
 				} catch (Error e) {
 					warning (@"Error opening stream: $(e.message)");
+					if (e.code == 3 || e.code == 44) {
+						on_closed ();
+					}
 				}
 			});
 			return false;


### PR DESCRIPTION
fix: #750 

Okay so, `NS_ERROR_NET_RESET` errors seem regular on mastosoc

![Screenshot from 2024-01-16 23-20-14](https://github.com/GeopJr/Tuba/assets/18014039/9d9d2800-0ece-4f9e-ade7-1df341fe08f9)

and as expected it doesn't go through the connection error handler so I guess we'll have to do it manually on connection reset by peer. It seems to work!

![image](https://github.com/GeopJr/Tuba/assets/18014039/d0edc747-6bbd-4c10-987c-63c16dc06bde)
