### PR TITLE
fix: use toasts when possible to display errors

### DIFF
--- a/src/Dialogs/Composer/Dialog.vala
+++ b/src/Dialogs/Composer/Dialog.vala
@@ -386,7 +386,7 @@ public class Tuba.Dialogs.Compose : Adw.Window {
 				transaction.end (res);
 			} catch (Error e) {
 				warning (e.message);
-				var dlg = app.inform (_("Error"), e.message);
+				var dlg = app.inform (_("Error"), e.message, this);
 				dlg.present ();
 			} finally {
 				this.sensitive = true;

--- a/src/Dialogs/ProfileEdit.vala
+++ b/src/Dialogs/ProfileEdit.vala
@@ -129,7 +129,7 @@ public class Tuba.Dialogs.ProfileEdit : Adw.Window {
 				on_close ();
 			} catch (GLib.Error e) {
 				critical (e.message);
-				var dlg = app.inform (_("Error"), e.message);
+				var dlg = app.inform (_("Error"), e.message, this);
 				dlg.present ();
 			} finally {
 				this.sensitive = true;

--- a/src/Views/Sidebar.vala
+++ b/src/Views/Sidebar.vala
@@ -225,8 +225,7 @@ public class Tuba.Views.Sidebar : Gtk.Widget, AccountHolder {
 							accounts.remove (account);
 						} catch (Error e) {
 							warning (e.message);
-							var dlg = app.inform (_("Error"), e.message);
-							dlg.present ();
+							app.toast ("%s: %s".printf (_("Error"), e.message));
 						}
 					}
 				}

--- a/src/Views/Timeline.vala
+++ b/src/Views/Timeline.vala
@@ -218,8 +218,7 @@ public class Tuba.Views.Timeline : AccountHolder, Streamable, Views.ContentBase 
 		if (base_status == null) {
 			warning (@"Error while refreshing $label: $code $reason");
 
-			var dlg = app.inform (_("Network Error"), reason);
-			dlg.present ();
+			app.toast ("%s: %s".printf (_("Network Error"), reason));
 		} else {
 			base.on_error (code, reason);
 		}

--- a/src/Widgets/Announcement.vala
+++ b/src/Widgets/Announcement.vala
@@ -177,8 +177,7 @@ public class Tuba.Widgets.Announcement : Gtk.ListBoxRow {
 				warning (@"Error while reacting to announcement: $code $message");
 				btn.sensitive = true;
 
-				var dlg = app.inform (_("Error"), message);
-				dlg.present ();
+				app.toast ("%s: %s".printf (_("Error"), message));
 			})
 			.exec ();
 	}

--- a/src/Widgets/Attachment/Image.vala
+++ b/src/Widgets/Attachment/Image.vala
@@ -84,8 +84,7 @@ public class Tuba.Widgets.Attachment.Image : Widgets.Attachment.Item {
 				clipboard.set_texture (texture);
 				app.toast (_("Copied image to clipboard"));
 			} catch (Error e) {
-				var dlg = app.inform (_("Error"), e.message);
-				dlg.present ();
+				app.toast ("%s: %s".printf (_("Error"), e.message));
 			}
 
 			debug ("End copy-media action");

--- a/src/Widgets/Attachment/Item.vala
+++ b/src/Widgets/Attachment/Item.vala
@@ -210,8 +210,7 @@ public class Tuba.Widgets.Attachment.Item : Adw.Bin {
 				open.end (res);
 			}
 			catch (Error e) {
-				var dlg = app.inform (_("Error"), e.message);
-				dlg.present ();
+				app.toast ("%s: %s".printf (_("Error"), e.message));
 			}
 		});
 	}

--- a/src/Widgets/Status/ActionsRow.vala
+++ b/src/Widgets/Status/ActionsRow.vala
@@ -339,9 +339,7 @@ public class Tuba.Widgets.ActionsRow : Gtk.Box {
 			} catch (Error e) {
 				warning (@"Couldn't perform action \"$action\" on a Status:");
 				warning (e.message);
-
-				var dlg = app.inform (_("Network Error"), e.message);
-				dlg.present ();
+				app.toast ("%s: %s".printf (_("Network Error"), e.message));
 
 				if (count_property != null)
 					status_btn.amount += status_btn.active ? -1 : 1;

--- a/src/Widgets/VoteBox.vala
+++ b/src/Widgets/VoteBox.vala
@@ -24,8 +24,7 @@ public class Tuba.Widgets.VoteBox : Gtk.Box {
                 button.sensitive = true;
             })
             .on_error ((code, reason) => {
-                var dlg = app.inform (_("Error"), reason);
-                dlg.present ();
+                app.toast ("%s: %s".printf (_("Error"), reason));
                 button.sensitive = true;
             })
             .exec ();


### PR DESCRIPTION
multiple modals on the mainwindow can lock focus. Additionally, set the inform modal's window to the current one on non-mainwindow cases.

fix: #754 