### PR TITLE
fix(LWW): wrap+ellipsize+lines => min_w > nat_w

### DIFF
--- a/src/Widgets/LabelWithWidgets.vala
+++ b/src/Widgets/LabelWithWidgets.vala
@@ -241,6 +241,7 @@ public class Tuba.Widgets.LabelWithWidgets : Gtk.Widget, Gtk.Buildable, Gtk.Acce
         if (_fix_overflow_hack) {
             label.lines = int.max (100, widgets.length);
             label.ellipsize = Pango.EllipsizeMode.END;
+            label.width_chars = 1;
         }
 
         if (old_label != new_label) {


### PR DESCRIPTION
fix: #775 #719 

another banger

![image](https://github.com/GeopJr/Tuba/assets/18014039/bfeefde5-dd38-42ee-8f32-50c4878613d9)

another banger by gtklabel

<hr />

wrap + ellipsize + lines can sometimes cause the minimum width to be > than the natural one causing the effect found in the linked issues. Setting width-chars to anything but < 1 will skip the measuring :shrug: 

> For ellipsizing labels, if either is specified (and less than the actual text size), it is used as the minimum width, and the actual text size is used as the natural width of the label. For wrapping labels, width-chars is used as the minimum width, if specified, and max-width-chars is used as the natural width. Even if max-width-chars specified, wrapping labels will be rewrapped to use all of the available width.
