### PR TITLE
feat(composer): strip tracking ids

### DIFF
--- a/src/Dialogs/Composer/EditorPage.vala
+++ b/src/Dialogs/Composer/EditorPage.vala
@@ -58,7 +58,16 @@ public class Tuba.EditorPage : ComposerPage {
 	}
 
 	public override void on_push () {
-		status.status = editor.buffer.text;
+		if (settings.strip_tracking) {
+			status.status = Tracking.cleanup_content_with_uris (
+				editor.buffer.text,
+				Tracking.extract_uris (editor.buffer.text),
+				Tracking.CleanupType.STRIP_TRACKING
+			);
+		} else {
+			status.status = editor.buffer.text;
+		}
+
 		status.sensitive = cw_button.active;
 		if (status.sensitive) {
 			status.spoiler_text = cw_entry.text;

--- a/tests/Tracking.test.vala
+++ b/tests/Tracking.test.vala
@@ -3,6 +3,14 @@ struct TestUrl {
     public string result;
 }
 
+struct TestUrlCleanup {
+    public string content;
+    public GLib.Uri[] uris;
+    public string stripped_content;
+    public int characters_reserved_per_url;
+    public string replaced_content;
+}
+
 const TestUrl[] URLS = {
     { "https://www.gnome.org/", "https://www.gnome.org/" },
     { "https://www.gnome.org/test", "https://www.gnome.org/test" },
@@ -15,6 +23,44 @@ const TestUrl[] URLS = {
     { "https://www.gnome.org/test?utm_source=tuba&foo=bar", "https://www.gnome.org/test?foo=bar" },
     { "https://www.gnome.org/test?utm_source=tuba&foo=bar&oft_id=1312#main", "https://www.gnome.org/test?foo=bar#main" }
 };
+
+TestUrlCleanup[] get_cleanup_urls () {
+    TestUrlCleanup[] res = {};
+
+    res += TestUrlCleanup () {
+        content = "https :/ /www .gnome .org/",
+        uris = {},
+        stripped_content = "https :/ /www .gnome .org/",
+        characters_reserved_per_url = 1,
+        replaced_content = "https :/ /www .gnome .org/"
+    };
+
+    res += TestUrlCleanup () {
+        content = "https://www.gnome.org/",
+        uris = {GLib.Uri.build (GLib.UriFlags.ENCODED, "https", null, "www.gnome.org/", -1, "", null, null)},
+        stripped_content = "https://www.gnome.org/",
+        characters_reserved_per_url = 15,
+        replaced_content = "XXXXXXXXXXXXXXX"
+    };
+
+    res += TestUrlCleanup () {
+        content = "Albums:\nDorian Electra - Fanfare https://dorianelectramusic.bandcamp.com/album/fanfare-explicit?foo=bar&fizz=buzz#main\n[bo en - pale machine 2](https://boen.bandcamp.com/album/pale-machine-2?utm_source=tuba&foo=bar&oft_id=1312#main)\n<a href=\"https://osno1.bandcamp.com/album/i-just-dont-wanna-name-it-anything-with-beach-in-the-title?tag=soft_clothes\">laura les - i just dont wanna name it anything with \"beach\" in the title</a>",
+        uris = {GLib.Uri.build (GLib.UriFlags.ENCODED, "https", null, "dorianelectramusic.bandcamp.com", -1, "/album/fanfare-explicit", "foo=bar&fizz=buzz", "main"), GLib.Uri.build (GLib.UriFlags.ENCODED, "https", null, "boen.bandcamp.com", -1, "/album/pale-machine-2", "utm_source=tuba&foo=bar&oft_id=1312", "main"), GLib.Uri.build (GLib.UriFlags.ENCODED, "https", null, "osno1.bandcamp.com", -1, "/album/i-just-dont-wanna-name-it-anything-with-beach-in-the-title", "tag=soft_clothes", null)},
+        stripped_content = "Albums:\nDorian Electra - Fanfare https://dorianelectramusic.bandcamp.com/album/fanfare-explicit?foo=bar&fizz=buzz#main\n[bo en - pale machine 2](https://boen.bandcamp.com/album/pale-machine-2?foo=bar#main)\n<a href=\"https://osno1.bandcamp.com/album/i-just-dont-wanna-name-it-anything-with-beach-in-the-title?tag=soft_clothes\">laura les - i just dont wanna name it anything with \"beach\" in the title</a>",
+        characters_reserved_per_url = 6,
+        replaced_content = "Albums:\nDorian Electra - Fanfare XXXXXX\n[bo en - pale machine 2](XXXXXX)\n<a href=\"XXXXXX\">laura les - i just dont wanna name it anything with \"beach\" in the title</a>"
+    };
+
+    res += TestUrlCleanup () {
+        content = "https://www.gnome.org/",
+        uris = {GLib.Uri.build (GLib.UriFlags.ENCODED, "https", null, "www.gnome.org/", -1, "", null, null)},
+        stripped_content = "https://www.gnome.org/",
+        characters_reserved_per_url = -5,
+        replaced_content = "https://www.gnome.org/"
+    };
+
+    return res;
+}
 
 public void test_strip_utm () {
     foreach (var test_url in URLS) {
@@ -32,10 +78,43 @@ public void test_strip_utm_fallback () {
     }
 }
 
+public void test_cleanup () {
+    foreach (var test_url in get_cleanup_urls ()) {
+        GLib.Uri[] extracted_uris = Tuba.Tracking.extract_uris (test_url.content);
+        assert_cmpint (extracted_uris.length, CompareOperator.EQ, test_url.uris.length);
+
+        for (var i=0; i < test_url.uris.length; i++) {
+            assert_cmpstr (extracted_uris[i].to_string (), CompareOperator.EQ, test_url.uris[i].to_string ());
+        }
+
+        assert_cmpstr (
+            Tuba.Tracking.cleanup_content_with_uris (
+                test_url.content,
+                test_url.uris,
+                Tuba.Tracking.CleanupType.STRIP_TRACKING
+            ),
+            CompareOperator.EQ,
+            test_url.stripped_content
+        );
+
+        assert_cmpstr (
+            Tuba.Tracking.cleanup_content_with_uris (
+                test_url.content,
+                test_url.uris,
+                Tuba.Tracking.CleanupType.SPECIFIC_LENGTH,
+                test_url.characters_reserved_per_url
+            ),
+            CompareOperator.EQ,
+            test_url.replaced_content
+        );
+    }
+}
+
 public int main (string[] args) {
     Test.init (ref args);
 
     Test.add_func ("/test_strip_utm", test_strip_utm);
     Test.add_func ("/test_strip_utm_fallback", test_strip_utm_fallback);
+    Test.add_func ("/test_cleanup", test_cleanup);
     return Test.run ();
 }


### PR DESCRIPTION
idea from: https://gitlab.gnome.org/World/Chatty/-/merge_requests/1313

It does not share code with that MR however since we can use the url extraction for other stuff like #484

Mastodon uses a huge regex that gets computed on runtime for detecting urls. It contains every single TLD. Obviously this is not maintainable on its own so it's out of the question. Instead use GLib's Uri to parse words individually as uris and return everything found. That will also promote writing urls in full (aka with the scheme).

This PR includes both stripping the tracking params but also replacing the urls with "X" * static amount of chars that a url should count as.

Should it be as a different setting? Probably. The current "strip tracking" setting is less destructive as this PR. At worst your browser will open a somewhat broken link. This PR however will replace your link and might send it broken.

On Chatty#1313, Guido raises a fair suggestion, replacing the link on paste. That sounds good to me too (but will require splitting this PR in a different one)