### PR TITLE
fix(Status): memory leak

### DIFF
--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -419,6 +419,7 @@
 	Widgets.Avatar? actor_avatar = null;
 	ulong header_button_activate;
 	private Binding actor_avatar_binding;
+	string? header_kind_url = null;
 	const string[] SHOULD_SHOW_ACTOR_AVATAR = {
 		InstanceAccount.KIND_REBLOG,
 		InstanceAccount.KIND_REMOTE_REBLOG,
@@ -465,10 +466,16 @@
 		header_icon.icon_name = res_kind.icon;
 		header_label.instance_emojis = this.kind_instigator.emojis_map;
 		header_label.label = res_kind.description;
+		header_kind_url = res_kind.url;
 
 		if (header_button_activate > 0) header_button.disconnect (header_button_activate);
-		if (res_kind.url != null)
-			header_button_activate = header_button.clicked.connect (() => header_label.on_activate_link (res_kind.url));
+		if (header_kind_url != null)
+			header_button_activate = header_button.clicked.connect (on_header_button_clicked);
+	}
+
+	private void on_header_button_clicked () {
+		if (header_kind_url != null)
+			header_label.on_activate_link (header_kind_url);
 	}
 
 	private void open_kind_instigator_account () {


### PR DESCRIPTION
as always, Vala lambda self ref

Statuses with a kind (like boosted) would stay in memory due to a lambda that would self-ref.

fix: #798 (might not fix everything but at least most of it)

Load -> Load another page -> Refresh

[Screencast from 2024-02-22 11-43-35.webm](https://github.com/GeopJr/Tuba/assets/18014039/103057cb-f48a-472c-84b1-769571192624)
