### PR TITLE
feat(network): increase soup's max conn props

### DIFF
--- a/src/Services/Helpers/Image.vala
+++ b/src/Services/Helpers/Image.vala
@@ -35,7 +35,7 @@ public class Tuba.Helper.Image {
 		cache.load ();
 		cache.set_max_size (1024 * 1024 * 100);
 
-		session = new Soup.Session () {
+		session = new Soup.Session.with_options ("max-conns", 64, "max-conns-per-host", 64) {
 			user_agent = @"$(Build.NAME)/$(Build.VERSION) libsoup/$(Soup.get_major_version()).$(Soup.get_minor_version()).$(Soup.get_micro_version()) ($(Soup.MAJOR_VERSION).$(Soup.MINOR_VERSION).$(Soup.MICRO_VERSION))" // vala-lint=line-length
 		};
 		session.add_feature (cache);

--- a/src/Services/Network/Network.vala
+++ b/src/Services/Network/Network.vala
@@ -31,7 +31,7 @@ public class Tuba.Network : GLib.Object {
 		cache.load ();
         cache.set_max_size (1024 * 1024 * 100);
 
-		session = new Soup.Session () {
+		session = new Soup.Session.with_options ("max-conns", 64, "max-conns-per-host", 64) {
 			user_agent = @"$(Build.NAME)/$(Build.VERSION) libsoup/$(Soup.get_major_version()).$(Soup.get_minor_version()).$(Soup.get_micro_version()) ($(Soup.MAJOR_VERSION).$(Soup.MINOR_VERSION).$(Soup.MICRO_VERSION))" // vala-lint=line-length
 		};
 		session.add_feature (cache);


### PR DESCRIPTION
I don't know if it changes much but a bit mindblowing that this has to be set at all... The defaults are 10 and 2...
