### PR TITLE
feat(Composer): syntax highlighting

### DIFF
--- a/data/langs/fedi-basic.lang
+++ b/data/langs/fedi-basic.lang
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<language id="fedi-basic" _name="Fedi Basic Highlighting" version="2.0" _section="Markup">
+	<styles>
+		<style id="hashtag" name="Hashtag" map-to="rust:attribute" />
+		<style id="mention" name="Mention" map-to="rust:lifetime" />
+		<style id="emoji" name="Emoji" map-to="rust:macro" />
+	</styles>
+	<definitions>
+		<context id="hashtag" style-ref="hashtag">
+			<match>#([^\s]+)</match>
+		</context>
+		<context id="mention" style-ref="mention">
+			<match>@[a-zA-Z0-9_]+(@[a-zA-Z0-9_\.]+)?</match>
+		</context>
+		<context id="emoji" style-ref="emoji">
+			<match>:[a-zA-Z0-9_]{2,}:</match>
+		</context>
+		<context id="fedi-syntax">
+			<include>
+				<context ref="hashtag"/>
+				<context ref="mention"/>
+				<context ref="emoji"/>
+			</include>
+		</context>
+		<context id="fedi-basic">
+			<include>
+				<context ref="fedi-syntax"/>
+			</include>
+		</context>
+	</definitions>
+</language>

--- a/data/langs/fedi-dark.xml
+++ b/data/langs/fedi-dark.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<style-scheme id="Fedi-dark" _name="Fedi-dark" version="1.0" parent-scheme="Adwaita-dark">
+  <author>GeopJr</author>
+  <_description>Syntax highlighting for Tuba</_description>
+
+  <metadata>
+    <property name="variant">dark</property>
+    <property name="light-variant">Fedi</property>
+  </metadata>
+
+  <!-- "style '<name>' not defined" so just override unused ones -->
+  <style name="rust:attribute"         foreground="blue_2" bold="true"/>
+  <style name="rust:lifetime"          foreground="blue_2" bold="true"/>
+  <style name="rust:macro"             foreground="blue_2" bold="true"/>
+</style-scheme>

--- a/data/langs/fedi-html.lang
+++ b/data/langs/fedi-html.lang
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<language id="fedi-html" _name="Fedi Flavoured HTML" version="2.0" _section="Markup">
+	<definitions>
+		<context id="fedi-html">
+			<include>
+				<context ref="fedi-basic:fedi-basic"/>
+				<context ref="html:html"/>
+			</include>
+		</context>
+	</definitions>
+</language>

--- a/data/langs/fedi-markdown.lang
+++ b/data/langs/fedi-markdown.lang
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<language id="fedi-markdown" _name="Fedi Flavoured Markdown" version="2.0" _section="Markup">
+	<definitions>
+		<context id="fedi-markdown">
+			<include>
+				<context ref="fedi-basic:fedi-basic"/>
+				<context ref="markdown:markdown"/>
+			</include>
+		</context>
+	</definitions>
+</language>

--- a/data/langs/fedi.xml
+++ b/data/langs/fedi.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<style-scheme id="Fedi" _name="Fedi" version="1.0" parent-scheme="Adwaita">
+  <author>GeopJr</author>
+  <_description>Syntax highlighting for Tuba</_description>
+
+  <metadata>
+    <property name="variant">light</property>
+    <property name="dark-variant">Fedi-dark</property>
+  </metadata>
+
+  <!-- "style '<name>' not defined" so just override unused ones -->
+  <style name="rust:attribute"         foreground="blue_3" bold="true"/>
+  <style name="rust:lifetime"          foreground="blue_3" bold="true"/>
+  <style name="rust:macro"             foreground="blue_3" bold="true"/>
+</style-scheme>

--- a/data/meson.build
+++ b/data/meson.build
@@ -28,6 +28,56 @@ install_data(
     ),
 )
 
+install_data(
+    join_paths('langs', 'fedi.xml'),
+    install_dir: join_paths(
+        get_option('prefix'),
+        get_option('datadir'),
+        'gtksourceview-5',
+        'styles',
+    ),
+)
+
+install_data(
+    join_paths('langs', 'fedi-dark.xml'),
+    install_dir: join_paths(
+        get_option('prefix'),
+        get_option('datadir'),
+        'gtksourceview-5',
+        'styles',
+    ),
+)
+
+install_data(
+    join_paths('langs', 'fedi-basic.lang'),
+    install_dir: join_paths(
+        get_option('prefix'),
+        get_option('datadir'),
+        'gtksourceview-5',
+        'language-specs',
+    ),
+)
+
+install_data(
+    join_paths('langs', 'fedi-html.lang'),
+    install_dir: join_paths(
+        get_option('prefix'),
+        get_option('datadir'),
+        'gtksourceview-5',
+        'language-specs',
+    ),
+)
+
+install_data(
+    join_paths('langs', 'fedi-markdown.lang'),
+    install_dir: join_paths(
+        get_option('prefix'),
+        get_option('datadir'),
+        'gtksourceview-5',
+        'language-specs',
+    ),
+)
+
 desktop_file = i18n.merge_file(
     input: meson.project_name() + '.desktop.in',
     output: meson.project_name() + '.desktop',

--- a/data/style.css
+++ b/data/style.css
@@ -662,3 +662,8 @@ GtkSourceAssistant row:last-child {
 	margin: -2px;
 	border-radius: 0;
 }
+
+.sourceview.reset {
+	background: transparent;
+	color: currentColor;
+}

--- a/src/Services/Accounts/InstanceAccount.vala
+++ b/src/Services/Accounts/InstanceAccount.vala
@@ -254,6 +254,7 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 		public string mime { get; construct set; }
 		public string icon_name { get; construct set; }
 		public string title { get; construct set; }
+		public string syntax { get; construct set; }
 
 		public StatusContentType (string content_type) {
 			mime = content_type;
@@ -263,25 +264,31 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 					icon_name = "tuba-paper-symbolic";
 					// translators: this is a content type
 					title = _("Plain Text");
+					syntax = "fedi-basic";
 					break;
 				case "text/html":
 					icon_name = "tuba-code-symbolic";
 					title = "HTML";
+					syntax = "fedi-html";
 					break;
 				case "text/markdown":
 					icon_name = "tuba-markdown-symbolic";
 					title = "Markdown";
+					syntax = "fedi-markdown";
 					break;
 				case "text/bbcode":
 					icon_name = "tuba-rich-text-symbolic";
 					title = "BBCode";
+					syntax = "fedi-basic";
 					break;
 				case "text/x.misskeymarkdown":
 					icon_name = "tuba-rich-text-symbolic";
 					title = "MFM";
+					syntax = "fedi-basic";
 					break;
 				default:
 					icon_name = "tuba-rich-text-symbolic";
+					syntax = "fedi-basic";
 
 					int slash = content_type.index_of_char ('/');
 					int ct_l = content_type.length;


### PR DESCRIPTION
fix: #153 

Last piece of the composer puzzle, syntax highlighting

Took longer than expected, but it's here:

| Plain | Markdown | HTML |
| :---: | :---: | :---: |
| ![Screenshot from 2024-03-07 04-12-41](https://github.com/GeopJr/Tuba/assets/18014039/08f0b648-b9c6-46ca-9cfc-3336fd3fd32f) | ![Screenshot from 2024-03-07 04-12-53](https://github.com/GeopJr/Tuba/assets/18014039/e62714e2-db18-42e4-bbe5-6b4df07f6e6d) | ![Screenshot from 2024-03-07 04-13-04](https://github.com/GeopJr/Tuba/assets/18014039/68cabe5c-9960-4ca0-9d48-862d542d310d) |



