### PR TITLE
fix(views): tabbedbase -> view of same label

### DIFF
--- a/src/Dialogs/MainWindow.vala
+++ b/src/Dialogs/MainWindow.vala
@@ -147,6 +147,7 @@ public class Tuba.Dialogs.MainWindow: Adw.ApplicationWindow, Saveable {
 				last_view != null
 				&& last_view.label == view.label
 				&& !view.allow_nesting
+				&& view.uid == last_view.uid
 			)
 		) return view;
 

--- a/src/Views/Base.vala
+++ b/src/Views/Base.vala
@@ -10,6 +10,7 @@ public class Tuba.Views.Base : Adw.BreakpointBin {
 	public bool allow_nesting { get; set; default = false; }
 	public bool is_sidebar_item { get; set; default = false; }
 	public int badge_number { get; set; default = 0; }
+	public int uid { get; set; default = -1; }
 	protected SimpleActionGroup actions { get; set; default = new SimpleActionGroup (); }
 
 	private bool _show_back_button = true;

--- a/src/Views/Explore.vala
+++ b/src/Views/Explore.vala
@@ -1,6 +1,7 @@
 public class Tuba.Views.Explore : Views.TabbedBase {
 	construct {
 		label = _("Explore");
+		uid = 1;
 
 		add_timeline_tab (_("Posts"), "tuba-chat-symbolic", "/api/v1/trends/statuses", typeof (API.Status));
 		add_timeline_tab (_("Hashtags"), "tuba-hashtag-symbolic", "/api/v1/trends/tags", typeof (API.Tag));


### PR DESCRIPTION
TabbedBase inherits its label from its subviews. When a subview has the same label as the new view we are switching to, it will refuse to switch. This PR introduces an id for them. Not ideal but introducing an enum would be annoying. When the ids don't match it will not return the same view.

Repro: Explore -> Switch to its Hashtags sub view -> Click the sidebar hashtag item