### PR TITLE
fix(MediaViewer): bugs with carousel + multiple items + scalerevealer

### DIFF
--- a/src/API/Status/PreviewCard.vala
+++ b/src/API/Status/PreviewCard.vala
@@ -203,7 +203,7 @@ public class Tuba.API.PreviewCard : Entity, Widgetizable {
 					Host.open_uri (card_url);
 				} else {
 					if (bookwyrm_obj == null) {
-						app.main_window.show_media_viewer (res_url, Tuba.Attachment.MediaType.VIDEO, null, 0, null, false, null, card_url, true);
+						app.main_window.show_media_viewer (res_url, Tuba.Attachment.MediaType.VIDEO, null, null, false, null, card_url, true);
 					} else {
 						app.main_window.show_book (bookwyrm_obj, card_url);
 					}

--- a/src/Dialogs/MainWindow.vala
+++ b/src/Dialogs/MainWindow.vala
@@ -79,28 +79,36 @@ public class Tuba.Dialogs.MainWindow: Adw.ApplicationWindow, Saveable {
 	public void scroll_media_viewer (int pos) {
 		if (!is_media_viewer_visible) return;
 
-		media_viewer.scroll_to (pos);
+		media_viewer.scroll_to (pos, false);
 	}
 
 	public void show_media_viewer (
 		string url,
 		Tuba.Attachment.MediaType media_type,
 		Gdk.Paintable? preview,
-		int? pos = null,
 		Gtk.Widget? source_widget = null,
 		bool as_is = false,
 		string? alt_text = null,
 		string? user_friendly_url = null,
-		bool stream = false
+		bool stream = false,
+		bool? load_and_scroll = null,
+		bool reveal_media_viewer = true
 	) {
 		if (as_is && preview == null) return;
 
-		media_viewer.add_media (url, media_type, preview, pos, as_is, alt_text, user_friendly_url, stream, source_widget);
+		media_viewer.add_media (url, media_type, preview, as_is, alt_text, user_friendly_url, stream, source_widget, load_and_scroll);
 
-		if (!is_media_viewer_visible) {
+		if (reveal_media_viewer) {
 			media_viewer.reveal (source_widget);
 			media_viewer_source_widget = source_widget;
 		}
+	}
+
+	public void reveal_media_viewer_manually (Gtk.Widget? source_widget = null) {
+		if (is_media_viewer_visible) return;
+
+		media_viewer.reveal (source_widget);
+		media_viewer_source_widget = source_widget;
 	}
 
 	public void show_book (API.BookWyrm book, string? fallback = null) {

--- a/src/Widgets/Attachment/Box.vala
+++ b/src/Widgets/Attachment/Box.vala
@@ -146,19 +146,28 @@ public class Tuba.Widgets.Attachment.Box : Adw.Bin {
 	}
 
 	private void open_all_attachments (string url) {
-		var i = 0;
-		var main = 0;
-		foreach (var at_widget in attachment_widgets) {
-			if (at_widget.entity.url != url) {
-				at_widget.load_image_in_media_viewer (i);
-			} else {
-				main = i;
-			};
-			i += 1;
-		}
+		int attachment_length = attachment_widgets.length;
+		for (int i = 0; i < attachment_length; i++) {
+			bool? is_main = null;
+			if (attachment_length > 1)
+				is_main = attachment_widgets[i].entity.url == url;
 
-		if (i > 0) {
-			app.main_window.scroll_media_viewer (main);
+			app.main_window.show_media_viewer (
+				attachment_widgets[i].entity.url,
+				attachment_widgets[i].media_kind,
+				attachment_widgets[i].pic.paintable,
+				attachment_widgets[i],
+				false,
+				attachment_widgets[i].pic.alternative_text,
+				null,
+				false,
+				is_main,
+				is_main == null
+			);
+
+			if (is_main == true) {
+				app.main_window.reveal_media_viewer_manually (attachment_widgets[i]);
+			}
 		}
 	}
 }

--- a/src/Widgets/Attachment/Image.vala
+++ b/src/Widgets/Attachment/Image.vala
@@ -1,5 +1,5 @@
 public class Tuba.Widgets.Attachment.Image : Widgets.Attachment.Item {
-	protected Gtk.Picture pic;
+	public Gtk.Picture pic { get; private set; }
 	protected Gtk.Overlay media_overlay;
 
 	private bool _spoiler = false;
@@ -103,15 +103,10 @@ public class Tuba.Widgets.Attachment.Image : Widgets.Attachment.Item {
 		}
 
 		if (media_kind != Tuba.Attachment.MediaType.UNKNOWN) {
-			load_image_in_media_viewer (null);
 			on_any_attachment_click (entity.url);
 		} else { // Fallback
 			base.on_click ();
 		}
-	}
-
-	public void load_image_in_media_viewer (int? pos) {
-		app.main_window.show_media_viewer (entity.url, media_kind, pic.paintable, pos, this, false, pic.alternative_text);
 	}
 
 	public signal void on_any_attachment_click (string url) {}

--- a/src/Widgets/Attachment/Item.vala
+++ b/src/Widgets/Attachment/Item.vala
@@ -15,7 +15,7 @@ public class Tuba.Widgets.Attachment.Item : Adw.Bin {
 	protected Gtk.Button alt_btn;
 	protected Gtk.Box badge_box;
 	protected ulong alt_btn_clicked_id;
-	protected Tuba.Attachment.MediaType media_kind;
+	public Tuba.Attachment.MediaType media_kind { get; protected set; }
 
 	private void copy_url () {
 		Host.copy (entity.url);

--- a/src/Widgets/ProfileCover.vala
+++ b/src/Widgets/ProfileCover.vala
@@ -64,11 +64,11 @@ protected class Tuba.Widgets.Cover : Gtk.Box {
     private string avi_url { get; set; default=""; }
     private string header_url { get; set; default=""; }
     void open_header_in_media_viewer () {
-        app.main_window.show_media_viewer (header_url, Tuba.Attachment.MediaType.IMAGE, background.paintable, null, background, true);
+        app.main_window.show_media_viewer (header_url, Tuba.Attachment.MediaType.IMAGE, background.paintable, background, true);
     }
 
     void open_pfp_in_media_viewer () {
-        app.main_window.show_media_viewer (avi_url, Tuba.Attachment.MediaType.IMAGE, avatar.custom_image, null, avatar, true);
+        app.main_window.show_media_viewer (avi_url, Tuba.Attachment.MediaType.IMAGE, avatar.custom_image, avatar, true);
     }
 
     public Cover (Views.Profile.ProfileAccount profile) {

--- a/src/Widgets/ScaleRevealer.vala
+++ b/src/Widgets/ScaleRevealer.vala
@@ -2,7 +2,7 @@
 // https://gitlab.gnome.org/GNOME/fractal/-/blob/e1976cd4e182cc8513d52c1a985a4fce9a056ad2/src/components/scale_revealer.rs
 
 public class Tuba.Widgets.ScaleRevealer : Adw.Bin {
-	const uint ANIMATION_DURATION = 250;
+	const uint ANIMATION_DURATION = 300;
 
 	public signal void transition_done ();
 	public Adw.TimedAnimation animation { get; construct set; }


### PR DESCRIPTION
Wow, the media viewer api is getting even more bloated, but hey, at least the pesky carousel animation is gone!

fix: #206 plus Circle review

Okay so:

1. Increased scale revealer animation to 300ms from 200ms. Not really noticeable but having a bit more time is helpful for the fix (else some artifacts are visible for a split second)
2. Removed the position api from the media viewer
3. Added the ability to reveal the media viewer manually - needed to properly do the scale revealer transition from the selected attachment to its image else it will always be from the first one
4. The bug was fixed upstream by scrolling when allocating is done, however due to the scale revealer it doesn't have enough time to, so you see the first image for a split second after the revealer before you see the correct one. That's not nice. To fix it, I hacked around it by setting all attachments until the selected one to invisible and when the revealer finishes, it goes through all of them until the selected one, making them visible and scrolling to the next image, providing a seamless transition AND keeping the attachment order

oof 