### PR TITLE
fix(meson): log domain

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -63,6 +63,7 @@ endif
 add_project_arguments(['--vapidir=' + meson.project_source_root() / 'vapi'], language: 'vala')
 add_project_arguments (
   '-DGETTEXT_PACKAGE="@0@"'.format(meson.project_name()),
+  '-DG_LOG_DOMAIN="Tuba"',
   language: 'c'
 )
 


### PR DESCRIPTION
During the vapi removal, it wasn't re-implemented, better use an arg instead 