### PR TITLE
feat: use gl instead of ngl

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -201,6 +201,7 @@ namespace Tuba {
 				if (GLib.Environment.get_variable ("SECRET_BACKEND") == "file")
 					GLib.Environment.set_variable ("SECRET_FILE_TEST_PASSWORD", @"$(GLib.Environment.get_user_name ())$(Build.DOMAIN)", false);
 			#endif
+			GLib.Environment.set_variable ("GSK_RENDERER", "gl", false);
 
 			app = new Application ();
 			return app.run (args);


### PR DESCRIPTION
ngl is becoming the default renderer, and while I wanted Tuba to contribute in testing it, the performance issues are noticeable on less powerful hardware and might be better to wait a bit until everything gets ironed out

Setting `GSK_RENDERER` to `ngl` should work and use the new renderer however.