### PR TITLE
fix(composer): set the editor as the focused widget

### DIFF
--- a/src/Dialogs/Composer/Dialog.vala
+++ b/src/Dialogs/Composer/Dialog.vala
@@ -229,7 +229,7 @@ public class Tuba.Dialogs.Compose : Adw.Dialog {
 		);
 		p_edit.bind_property ("can-publish", p_poll, "can-publish", GLib.BindingFlags.SYNC_CREATE);
 
-		p_edit.editor_grab_focus ();
+		this.focus_widget = p_edit.editor;
 	}
 
 	private void setup_pages (ComposerPage[] pages) {

--- a/src/Dialogs/Composer/EditorPage.vala
+++ b/src/Dialogs/Composer/EditorPage.vala
@@ -165,12 +165,8 @@ public class Tuba.EditorPage : ComposerPage {
 		builder.add_string_value (status.sensitive ? status.spoiler_text : "");
 	}
 
-	protected GtkSource.View editor;
+	public GtkSource.View editor;
 	protected Gtk.Label char_counter;
-
-	public void editor_grab_focus () {
-		editor.grab_focus ();
-	}
 
 	#if LIBSPELLING
 		protected Spelling.TextBufferAdapter adapter;


### PR DESCRIPTION
Same thing as the selectable issue, grabbing focus doesn't work anymore but thankfully, AdwDialog offers a focus-widget prop

fix: #857 