### PR TITLE
feat: v0.7.0

### DIFF
--- a/data/dev.geopjr.Tuba.metainfo.xml.in
+++ b/data/dev.geopjr.Tuba.metainfo.xml.in
@@ -62,7 +62,7 @@
     <control>touch</control>
   </recommends>
   <releases>
-    <release version="0.7.0" date="2024-03-16">
+    <release version="0.7.0" date="2024-03-20">
       <description translatable="no">
         <ul>
             <li>Visual refinements to match the state of the art of GNOME apps</li>

--- a/data/dev.geopjr.Tuba.metainfo.xml.in
+++ b/data/dev.geopjr.Tuba.metainfo.xml.in
@@ -62,6 +62,39 @@
     <control>touch</control>
   </recommends>
   <releases>
+    <release version="0.7.0" date="2024-03-16">
+      <description translatable="no">
+        <ul>
+            <li>Visual refinements to match the state of the art of GNOME apps</li>
+            <li>Added filter handling and editing support</li>
+            <li>Added post and user reporting</li>
+            <li>Added Mutes and Blocks pages</li>
+            <li>Added banners for unread Announcements and Follow Requests</li>
+            <li>Added syntax highlighting in the Composer</li>
+            <li>Added badge on 'Home' for new posts</li>
+            <li>Added recent emojis in the Custom Emoji Chooser</li>
+            <li>Added stripping tracking parameters from URLs on paste</li>
+            <li>Added notification badges on Account Switcher entries</li>
+            <li>Added the option to darken images on dark mode</li>
+            <li>Redesigned the timeline status pages</li>
+            <li>Added support for all special character counting cases</li>
+            <li>Added 'New Post' to the main menu</li>
+            <li>Added the ability to zoom using ctrl and the mouse wheel on the Media Viewer</li>
+            <li>Added manpage</li>
+            <li>Added Windows builds</li>
+            <li>Added more tracking IDs to the stripping list</li>
+            <li>Added posting visibility syncing with the instance</li>
+            <li>Fixed Media Viewer not opening the correct attachment right away and instead scrolling to it</li>
+            <li>Fixed bugs involving multiple attachments and animations in the Media Viewer</li>
+            <li>Fixed navigation not working between nested pages and non-nested pages of the same name</li>
+            <li>Fixed issues preventing Windows and macOS builds</li>
+            <li>Fixed replacing files when saving attachments</li>
+            <li>Fixed media sensitivity not being kept when editing posts</li>
+            <li>Fixed other minor bugs and memory leaks</li>
+            <li>Updated translations</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.6.3" date="2024-02-02">
       <description translatable="no">
         <ul>

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'dev.geopjr.Tuba',
     ['c', 'vala'],
-    version: '0.6.3',
+    version: '0.7.0',
     meson_version: '>= 0.56.0',
     default_options: [
         'warning_level=2',


### PR DESCRIPTION
```md
# Added

- Option to darken images on dark mode (#610)
- Notification badges on Account Switcher entries (#767)
- Manpage (#771, thanks [at]danialbehzadi)
- Windows builds (#776)
- More tracking IDs to be stripped (#781, #795, thanks [at]kop316)
- Tracking parameter stripping on paste (#782, thanks [at]kop316)
- 1:1 character counting with Mastodon (including links, graphemes and mentions) (#599, #818)
- Ability to zoom using <kbd>Ctrl</kbd>+ Mouse Wheel on the Media Viewer (#727, thanks [at]mgorny)
- Update the 'verified' icon to one that matches the context better (#740)
- New posts badge on 'Home' (#773)
- Post and User reporting dialog (#787)
- Error toasts when saving attachments (#793)
- Filter handling and editing (#800)
- Unread Announcements banner (#766)
- Hide preview cards from own posts on notifications (#815)
- Recent emojis in the Custom Emoji Chooser (#819)
- More links in the About dialog (#820)
- Syntax highlighting (both for mentions, emojis, hashtags and HTML & Markdown) (#823)
- Do not show an icon when timelines are loading (#825)
- Do not use a generic title when the timeline is empty (#825)
- Syncing posting visibility with the instance (#827)
- 'New Post' to the main menu (#828)
- Mutes & Blocks page (#831)
- Unreviewed Follow Requests banner (#832)
- Use libadwaita 1.5 AdwDialog when possible (#804, thanks [at]oscfdezdz)
- Use gl instead of ngl for now (#847)
- Show an icon on empty and error states of timelines (#848)
- Appstream brand colors (#853, thanks [at]bragefuglseth, [at]LukaszH77)

# Fixed

- Incorrect use of title case where necessary (#737, thanks [at]MonsterObserver)
- Replaced `config.h` with `Build.vala`, fixing Windows and macOS builds
- Incorrect measurement of LabelWithWidgets when wrap, ellipsize and lines are set
- libsecret backend for Windows and macOS (#776, #785)
- Replacing attachments when saving (#793)
- Strings missing ellipsis (#802, thanks [at]bragefuglseth)
- Media sensitivity not being kept when editing posts (#811)
- Media Viewer using keypress instead of shortcuts for actions (#812, thanks [at]alice-mkh)
- Increased libsoup's max connections limits (#822)
- Navigation not working between nested pages and non-nested pages of the same name (#826)
- Media Viewer not opening the correct attachment right away and instead scrolling to it (#829)
- Bugs involving multiple attachments and animations in the Media Viewer (#829)
- libxml2 empty document warning (#830)
- Other memory leaks and bugs (#799)

# Package maintainers

- Syntax highlighting requires installing some gtksourceview themes and languages. Meson takes care of it but it might require additional changes on some distros.
```