### PR TITLE
feat(main_window): keep track of last focused item between navigation changes

### DIFF
--- a/src/Dialogs/MainWindow.vala
+++ b/src/Dialogs/MainWindow.vala
@@ -64,6 +64,7 @@ public class Tuba.Dialogs.MainWindow: Adw.ApplicationWindow, Saveable {
 			resizable: true
 		);
 		set_sidebar_selected_item (0);
+		navigation_view.popped.connect (on_popped);
 		main_page = new Adw.NavigationPage (new Views.Main (), _("Home"));
 		navigation_view.add (main_page);
 
@@ -165,10 +166,16 @@ public class Tuba.Dialogs.MainWindow: Adw.ApplicationWindow, Saveable {
 		if (view.is_sidebar_item) {
 			navigation_view.replace ({ main_page, page });
 		} else {
+			if (last_view != null) last_view.update_last_widget ();
 			navigation_view.push (page);
 		}
 
 		return view;
+	}
+
+	public void on_popped () {
+		var content_base = navigation_view.visible_page.child as Views.Base;
+		if (content_base != null && content_base.last_widget != null) content_base.last_widget.grab_focus ();
 	}
 
 	public bool back () {

--- a/src/Dialogs/MainWindow.vala
+++ b/src/Dialogs/MainWindow.vala
@@ -44,7 +44,6 @@ public class Tuba.Dialogs.MainWindow: Adw.ApplicationWindow, Saveable {
 		if (is_media_viewer_visible || media_viewer_source_widget == null) return;
 
 		Gtk.Widget focusable_widget = media_viewer_source_widget;
-		while (focusable_widget != null && !focusable_widget.focusable) focusable_widget = focusable_widget.get_parent ();
 		if (focusable_widget != null) focusable_widget.grab_focus ();
 		media_viewer_source_widget = null;
 	}
@@ -102,16 +101,16 @@ public class Tuba.Dialogs.MainWindow: Adw.ApplicationWindow, Saveable {
 		media_viewer.add_media (url, media_type, preview, as_is, alt_text, user_friendly_url, stream, source_widget, load_and_scroll);
 
 		if (reveal_media_viewer) {
+			media_viewer_source_widget = app.main_window.get_focus ();
 			media_viewer.reveal (source_widget);
-			media_viewer_source_widget = source_widget;
 		}
 	}
 
 	public void reveal_media_viewer_manually (Gtk.Widget? source_widget = null) {
 		if (is_media_viewer_visible) return;
 
+		media_viewer_source_widget = app.main_window.get_focus ();
 		media_viewer.reveal (source_widget);
-		media_viewer_source_widget = source_widget;
 	}
 
 	public void show_book (API.BookWyrm book, string? fallback = null) {

--- a/src/Views/Base.vala
+++ b/src/Views/Base.vala
@@ -13,6 +13,7 @@ public class Tuba.Views.Base : Adw.BreakpointBin {
 	public int badge_number { get; set; default = 0; }
 	public int uid { get; set; default = -1; }
 	protected SimpleActionGroup actions { get; set; default = new SimpleActionGroup (); }
+	public weak Gtk.Widget? last_widget { get; private set; default=null; }
 
 	private bool _show_back_button = true;
 	public bool show_back_button {
@@ -131,6 +132,7 @@ public class Tuba.Views.Base : Adw.BreakpointBin {
 		app.notify["is-mobile"].connect (update_back_btn);
 	}
 	~Base () {
+		this.last_widget = null;
 		debug (@"Destroying base $label");
 	}
 
@@ -166,6 +168,7 @@ public class Tuba.Views.Base : Adw.BreakpointBin {
 	}
 
 	public virtual void clear () {
+		this.last_widget = null;
 		base_status = null;
 	}
 
@@ -190,5 +193,9 @@ public class Tuba.Views.Base : Adw.BreakpointBin {
 		status_image.visible = true;
 		status_button.visible = true;
 		status_button.sensitive = true;
+	}
+
+	public void update_last_widget () {
+		this.last_widget = app.main_window.get_focus ();
 	}
 }

--- a/src/Views/ContentBase.vala
+++ b/src/Views/ContentBase.vala
@@ -89,7 +89,7 @@ public class Tuba.Views.ContentBase : Views.Base {
 
 	public override void clear () {
 		base.clear ();
-		model.remove_all ();
+		this.model.remove_all ();
 	}
 
 	protected virtual void clear_all_but_first () {


### PR DESCRIPTION
fix: #865 

needs memory leak check

a bit weird way to do this but it's the best non-listbox-specific way I could think of

Fixed the focus on media viewer toggling too since it didn't work as expected