### PR TITLE
fix(MediaViewer): race condition between reveal and todo

### DIFF
--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -962,10 +962,7 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 	}
 
 	private void on_carousel_n_pages_changed () {
-		bool has_more_than_1_item = carousel.n_pages > 1;
-
-		if (!has_more_than_1_item) on_carousel_page_changed (0);
-		page_buttons_revealer.visible = has_more_than_1_item;
+		page_buttons_revealer.visible = carousel.n_pages > 1;
 	}
 
 	public void on_zoom_change () {

--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -582,8 +582,13 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 			swipe_progress = 0.0;
 			scale_revealer.source_widget = null;
 			reset_media_viewer ();
-		} else if (load_and_scroll_to != -1) {
+			return;
+		}
+
+		revealed = true;
+		if (load_and_scroll_to != -1) {
 			var scroll_to_widget = safe_get (load_and_scroll_to);
+			do_todo_item (scroll_to_widget);
 			for (int i = 0; i < load_and_scroll_to; i++) {
 				var item = safe_get (i);
 				if (item != null) {
@@ -592,6 +597,9 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 				} else break;
 			}
 		}
+
+		do_todo_items ();
+		on_carousel_page_changed ((int) carousel.position);
 	}
 
 	int? old_height;
@@ -799,9 +807,6 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 		this.visible = true;
 		scale_revealer.source_widget = widget;
 		scale_revealer.reveal_child = true;
-
-		revealed = true;
-		do_todo_items ();
 	}
 
 	int load_and_scroll_to = -1;
@@ -841,8 +846,7 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 						var path = download_video.end (res);
 						video.set_filename (path);
 						add_todo_item (item);
-					}
-					catch (Error e) {
+					} catch (Error e) {
 						var dlg = app.inform (_("Error"), e.message);
 						dlg.present (app.main_window);
 					}
@@ -887,13 +891,18 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 			todo_items.add (todo_item.url);
 		}
 	}
+
+	private void do_todo_item (Item item) {
+		item.done ();
+		todo_items.remove (item.url);
+	}
+
 	private void do_todo_items () {
 		if (todo_items.size == 0 || items.size == 0) return;
 
 		items.foreach (item => {
 			if (todo_items.contains (item.url)) {
-				item.done ();
-				todo_items.remove (item.url);
+				do_todo_item (item);
 			}
 			return true;
 		});


### PR DESCRIPTION
fix: #868 ??? (maybe?)
fix: #870 

Noticed a race condition between revealer and todo items. Since we changed the status attachments to reveal the MV at a later point, the MV gets revealed before the items finish resolving.

Instead, make the MV set itself as revealed when the scale transition finishes. At the same time, optimize the todo item resolving by resolving the one to be revealed first and then the rest.

Needs some testing