### PR TITLE
fix(attachments): audio thumbnail icon

### DIFF
--- a/src/Widgets/Attachment/Box.vala
+++ b/src/Widgets/Attachment/Box.vala
@@ -122,7 +122,7 @@ public class Tuba.Widgets.Attachment.Box : Adw.Bin {
 					widget.height_request = 334;
 				}
 
-				((Widgets.Attachment.Image) widget).on_any_attachment_click.connect (() => open_all_attachments (item.url));
+				((Widgets.Attachment.Image) widget).on_any_attachment_click.connect (open_all_attachments);
 			} catch (Oopsie e) {
 				warning (@"Error updating attachments: $(e.message)");
 			}


### PR DESCRIPTION
on #868 I noticed that audio files do actually have thumbnails sometimes, so let's give their overlay icon the osd style so it doesnt blend in the background. Only when there's a thumbnail.

![image](https://github.com/GeopJr/Tuba/assets/18014039/76fa9644-521c-415f-9648-c35778c7661d)

Oh also memory leak