### PR TITLE
feat: v0.7.1

### DIFF
--- a/build-aux/dev.geopjr.Tuba.Devel.json
+++ b/build-aux/dev.geopjr.Tuba.Devel.json
@@ -34,7 +34,7 @@
             "sources" : [
                 {
                     "type" : "git",
-                    "url" : "https://gitlab.gnome.org/chergert/libspelling.git",
+                    "url" : "https://gitlab.gnome.org/GNOME/libspelling.git",
                     "branch" : "main"
                 }
             ]

--- a/data/dev.geopjr.Tuba.metainfo.xml.in
+++ b/data/dev.geopjr.Tuba.metainfo.xml.in
@@ -62,6 +62,18 @@
     <control>touch</control>
   </recommends>
   <releases>
+    <release version="0.7.1" date="2024-03-28">
+      <description translatable="no">
+        <ul>
+            <li>Fixed syntax highlighting not working on vanilla Mastodon instances</li>
+            <li>Fixed keyboard navigation losing focus between page changes</li>
+            <li>Fixed MediaViewer regressions with videos due to a race condition</li>
+            <li>Fixed MediaViewer showing the wrong widget when dismissing without using gestures</li>
+            <li>Fixed overlay icon missing its background on audio attachments with thumbnails</li>
+            <li>Updated translations</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.7.0" date="2024-03-20">
       <description translatable="no">
         <ul>

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'dev.geopjr.Tuba',
     ['c', 'vala'],
-    version: '0.7.0',
+    version: '0.7.1',
     meson_version: '>= 0.56.0',
     default_options: [
         'warning_level=2',


### PR DESCRIPTION
```
# Fixed

- Syntax highlighting not working if there are no available content types (#864)
- Keyboard navigation focus not being remembered between NavigationView page changes and MediaViewer reveal toggling (#866)
- Changed brand colors to ones with more contrast (#867, thanks [at]bertob)
- MediaViewer videos playing before being initialized and MediaViewer buttons not being updated to support the video layout due to a race condition (#869)
- MediaViewer scale revealer dismiss widget updating only when gestures are used instead of page changes, causing it to show a different widget when dismissing without using gestures (#872)
- Post audio attachments not having an overlay icon background when there's a thumbnail available (#873)

# Package maintainers

- It was omitted from the last changelog, but since v0.7.0, Tuba depends on `icu-uc` for extended character counting

**Full Changelog**: https://github.com/GeopJr/Tuba/compare/v0.7.0...v0.7.1
```