### PR TITLE
ui: Fix translatable usage

### DIFF
--- a/data/ui/dialogs/filter_edit.ui
+++ b/data/ui/dialogs/filter_edit.ui
@@ -5,7 +5,7 @@
   <template class="TubaDialogsFilterEdit" parent="AdwDialog">
     <property name="content_width">460</property>
     <property name="content_height">520</property>
-    <property name="title" translatable="1">Edit Filter</property>
+    <property name="title" translatable="yes">Edit Filter</property>
     <child>
       <object class="AdwToolbarView">
         <child type="top">

--- a/data/ui/dialogs/profile_edit.ui
+++ b/data/ui/dialogs/profile_edit.ui
@@ -9,7 +9,7 @@
   <template class="TubaDialogsProfileEdit" parent="AdwDialog">
     <property name="content_width">460</property>
     <property name="content_height">520</property>
-    <property name="title" translatable="1">Edit Profile</property>
+    <property name="title" translatable="yes">Edit Profile</property>
     <child>
       <object class="AdwToolbarView">
         <child type="top">


### PR DESCRIPTION
Marking translatable="yes" or translatable="1" actually achieves the same result, but almost all projects use the first one.

It's good to follow common practices.