### PR TITLE
fix: fractional scaling blurriness with gl

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -201,7 +201,11 @@ namespace Tuba {
 				if (GLib.Environment.get_variable ("SECRET_BACKEND") == "file")
 					GLib.Environment.set_variable ("SECRET_FILE_TEST_PASSWORD", @"$(GLib.Environment.get_user_name ())$(Build.DOMAIN)", false);
 			#endif
+
 			GLib.Environment.set_variable ("GSK_RENDERER", "gl", false);
+			if (GLib.Environment.get_variable ("GSK_RENDERER") == "gl") {
+				GLib.Environment.set_variable ("GDK_DEBUG", "gl-no-fractional", false);
+			}
 
 			app = new Application ();
 			return app.run (args);


### PR DESCRIPTION
fix: #885 

On 46, GTK defaults to ngl as its renderer. While it's a nice step forward, performance is not on par with gl yet and is very noticeable on Tuba, so we forced `gl` as the default on #847 until everything gets ironed out (gl is being used only if nothing else is set, so you can still override it).

On #885 an issue with fractional scaling and blurriness was raised and after researching on GTK's issue tracker, I discovered that setting `GDK_DEBUG=gl-no-fractional` reproduced the old behavior. This PR sets that if the renderer is gl.