### PR TITLE
feat(devmode): Flathub screenshot size for banner

### DIFF
--- a/data/screenshots/screenshot-1.png
+++ b/data/screenshots/screenshot-1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2c2ed01f88cea16a2e1392b901d518ec32ce4e27280d5b6853ed8e922035ea51
-size 351007
+oid sha256:8a0a1dfc84698dc617448e9d162d7c377a0cf312153247576e1a5bb8f98a8ac3
+size 417404

--- a/data/screenshots/screenshot-1.png
+++ b/data/screenshots/screenshot-1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8a0a1dfc84698dc617448e9d162d7c377a0cf312153247576e1a5bb8f98a8ac3
-size 417404
+oid sha256:f3fa6148aa80c0ef0d9a080e3628c26d14f81d8aab9edcaa7f5f1b5b738cf69f
+size 424922

--- a/src/Dialogs/DevConsole.vala
+++ b/src/Dialogs/DevConsole.vala
@@ -24,7 +24,8 @@ public class Tuba.Dialogs.Dev : Adw.PreferencesDialog {
 		new WindowSize (1200, 675),
 		new WindowSize (1600, 900),
 		new WindowSize (360, 654),
-		new WindowSize (720, 360)
+		new WindowSize (720, 360),
+		new WindowSize (1000, 700)
 	};
 
 	construct {


### PR DESCRIPTION
fix: #879 

![Screenshot from 2024-04-06 00-50-24](https://github.com/GeopJr/Tuba/assets/18014039/50c43d0d-046b-4e03-990c-730e0717d1d7)
![Screenshot from 2024-04-06 00-50-16](https://github.com/GeopJr/Tuba/assets/18014039/f8636f3c-cab7-4d6d-9969-d42d67c70813)

