### PR TITLE
feat: v0.7.2

### DIFF
--- a/data/dev.geopjr.Tuba.metainfo.xml.in
+++ b/data/dev.geopjr.Tuba.metainfo.xml.in
@@ -62,6 +62,14 @@
     <control>touch</control>
   </recommends>
   <releases>
+    <release version="0.7.2" date="2024-04-07">
+      <description translate="no">
+        <ul>
+            <li>Fixed blurriness with fractional scaling</li>
+            <li>Updated translations</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.7.1" date="2024-03-28">
       <description translate="no">
         <ul>

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'dev.geopjr.Tuba',
     ['c', 'vala'],
-    version: '0.7.1',
+    version: '0.7.2',
     meson_version: '>= 0.56.0',
     default_options: [
         'warning_level=2',


### PR DESCRIPTION
```
# Added

- Better main screenshot for the banner (#887, thanks [at]bertob)

# Fixed

- Marking strings as non-translatable on metainfo (#877, thanks [at]yakushabb)
- Inconsistent 'translatable' values (#884, #889, thanks [at]yakushabb)
- Fractional scaling blurriness due with due to using gl instead of ngl (#886)

**Full Changelog**: https://github.com/GeopJr/Tuba/compare/v0.7.1...v0.7.2
```

This marks the end of the patching period, further commits will be available on 0.8