### PR TITLE
fix(composer): pixelfed posting

### DIFF
--- a/src/Dialogs/Composer/EditorPage.vala
+++ b/src/Dialogs/Composer/EditorPage.vala
@@ -290,7 +290,7 @@ public class Tuba.EditorPage : ComposerPage {
 		add_button (emoji_button);
 		emoji_picker.emoji_picked.connect (on_emoji_picked);
 
-		if (accounts.active.instance_emojis?.size > 0) {
+		if (accounts.active.instance_emojis != null && accounts.active.instance_emojis.size > 0) {
 			var custom_emoji_picker = new Widgets.CustomEmojiChooser ();
 			var custom_emoji_button = new Gtk.MenuButton () {
 				icon_name = "tuba-cat-symbolic",

--- a/src/Dialogs/ProfileEdit.vala
+++ b/src/Dialogs/ProfileEdit.vala
@@ -95,7 +95,7 @@ public class Tuba.Dialogs.ProfileEdit : Adw.Dialog {
 			adapter.enabled = true;
 		#endif
 
-		if (accounts.active.instance_emojis?.size > 0) {
+		if (accounts.active.instance_emojis != null && accounts.active.instance_emojis.size > 0) {
 			cepbtn.visible = true;
 		}
 	}


### PR DESCRIPTION
fix: #895 

The first commit will fix it but I'm not sure if the second should be merged.

The first issue is that Pixelfed for some reason broke their custom emojis api but also Vala's optional chaining not working as always. So it could be null and still return as truthy.

The second issue, which was just critical logs from json glib but should be taken into account, was that when attempting to get the json root, it could *not* be an object, as many edge cases are valid json but useless to us.

It makes sense to check but is also useless to assume that a server could *not* return an object. Well, if they implement mastoapi that is.