### PR TITLE
fix(syntax-highlighting): only match whole words

### DIFF
--- a/data/langs/fedi-basic.lang
+++ b/data/langs/fedi-basic.lang
@@ -7,13 +7,13 @@
 	</styles>
 	<definitions>
 		<context id="hashtag" style-ref="hashtag">
-			<match>#([^\s]+)</match>
+			<match>(?:\W|^)#([^\s]+)</match>
 		</context>
 		<context id="mention" style-ref="mention">
-			<match>@[a-zA-Z0-9_]+(@[a-zA-Z0-9_\.]+)?</match>
+			<match>(?:\W|^)@[a-zA-Z0-9_]+(@[a-zA-Z0-9_\.]+)?</match>
 		</context>
 		<context id="emoji" style-ref="emoji">
-			<match>:[a-zA-Z0-9_]{2,}:</match>
+			<match>(?:\W|^):[a-zA-Z0-9_]{2,}:</match>
 		</context>
 		<context id="fedi-syntax">
 			<include>


### PR DESCRIPTION
fix: #898 

Only match them if they start after a non-word or start of content