### PR TITLE
feat(MediaViewer): enable GraphicsOffload for videos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,8 @@ jobs:
         manifest-path: "build-aux/dev.geopjr.Tuba.Devel.json"
         cache-key: flatpak-builder-${{ github.sha }}
         arch: ${{ matrix.arch }}
-        repository-name: flathub-beta
-        repository-url: https://flathub.org/beta-repo/flathub-beta.flatpakrepo # until GNOME 45
+        repository-name: flathub
+        repository-url: https://dl.flathub.org/repo/flathub.flatpakrepo
   snap-builder:
     name: "Snap Builder"
     runs-on: ubuntu-latest

--- a/build-aux/dev.geopjr.Tuba.Devel.json
+++ b/build-aux/dev.geopjr.Tuba.Devel.json
@@ -1,7 +1,7 @@
 {
     "app-id": "dev.geopjr.Tuba",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "46beta",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "command": "dev.geopjr.Tuba",
     "finish-args": [

--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -826,6 +826,9 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 
 		if (media_type.is_video ()) {
 			var video = new Gtk.Video ();
+
+			video.graphics_offload = Gtk.GraphicsOffloadEnabled.ENABLED;
+
 			if (media_type == Tuba.Attachment.MediaType.GIFV) {
 				video.loop = true;
 				video.autoplay = true;


### PR DESCRIPTION
In order to allow pass-through of video content to Wayland compositors, reducing copies on the GPU and thus improving battery life and performance.

This change should generally be safe to do, however given the higher chances of triggering driver bugs good testing is due.

---

An easy way to test this is to look at `intel_gpu_top`/`radeontop`/ similar tools - in many cases this should be able to reduce GPU work considerably, especially for high-res content.

Note that for now it only affect hardware-decoded content - this will hopefully change in the future.

Draft because:
 - [ ] More testing is needed
 - [ ] Some possible design changes to e.g. hide the top bar in fullscreen mode after a timeout would increase the effect even more. This might be worth to investigate before merging. Doing this with the GTK inspector allows me to get zero-copy playback, which especially on mobile and low-end devices is really good.