### PR TITLE
feat(emoji): libsoup cache lookup

### DIFF
--- a/src/Services/Helpers/Image.vala
+++ b/src/Services/Helpers/Image.vala
@@ -85,4 +85,12 @@ public class Tuba.Helper.Image {
 			cb (result);
 		});
 	}
+
+	public static Gdk.Paintable? lookup_cache (string uri) {
+		try {
+			return Gdk.Texture.from_filename (GLib.Path.build_path (GLib.Path.DIR_SEPARATOR_S, cache.cache_dir, GLib.str_hash (uri).to_string ()));
+		} catch {
+			return null;
+		}
+	}
 }

--- a/src/Widgets/Emoji.vala
+++ b/src/Widgets/Emoji.vala
@@ -25,7 +25,11 @@ public class Tuba.Widgets.Emoji : Adw.Bin {
 		}
 
 		GLib.Idle.add (() => {
-			Tuba.Helper.Image.request_paintable (emoji_url, null, on_cache_response);
+			var cached_paintable = Tuba.Helper.Image.lookup_cache (emoji_url);
+			if (cached_paintable == null)
+				Tuba.Helper.Image.request_paintable (emoji_url, null, on_cache_response);
+			else
+				on_cache_response (cached_paintable);
 			return GLib.Source.REMOVE;
 		});
 	}

--- a/src/Widgets/Emoji.vala
+++ b/src/Widgets/Emoji.vala
@@ -24,14 +24,11 @@ public class Tuba.Widgets.Emoji : Adw.Bin {
 			shortcode = t_shortcode;
 		}
 
-		GLib.Idle.add (() => {
-			var cached_paintable = Tuba.Helper.Image.lookup_cache (emoji_url);
-			if (cached_paintable == null)
-				Tuba.Helper.Image.request_paintable (emoji_url, null, on_cache_response);
-			else
-				on_cache_response (cached_paintable);
-			return GLib.Source.REMOVE;
-		});
+		var cached_paintable = Tuba.Helper.Image.lookup_cache (emoji_url);
+		if (cached_paintable == null)
+			Tuba.Helper.Image.request_paintable (emoji_url, null, on_cache_response);
+		else
+			on_cache_response (cached_paintable);
 	}
 
 	void on_cache_response (Gdk.Paintable? data) {


### PR DESCRIPTION
Suggested by Fabian on matrix, instead of going through libsoup's cache process, let's look it up ourselves.

Why? Because libsoup does complex cache checking that also needs to be decoded:

- Libsoup will respect etag, max cache and other headers
- Whether it hits cache or not, it still needs to go through all the process of getting decoded, orientation fixed etc

Compared to just, checking if the file exists already and loading it.

Libsoup's cache **is important**, especially on profile avatars and API responses. It's not that much on emojis and in situations where it has to load thousands at the same time (CEP), this seems faster

Quirk: libsoup maps images to cache entries using g_str_hash based on the url