### PR TITLE
feat(Attachment.Box): stream attachments by default

### DIFF
--- a/src/Widgets/Attachment/Box.vala
+++ b/src/Widgets/Attachment/Box.vala
@@ -160,7 +160,7 @@ public class Tuba.Widgets.Attachment.Box : Adw.Bin {
 				false,
 				attachment_widgets[i].pic.alternative_text,
 				null,
-				false,
+				true,
 				is_main,
 				is_main == null
 			);


### PR DESCRIPTION
The bug preventing this before has long been fixed in Gst 1.22.1.

---

Closes https://github.com/GeopJr/Tuba/issues/924