### PR TITLE
feat: network monitoring

### DIFF
--- a/src/Dialogs/MainWindow.vala
+++ b/src/Dialogs/MainWindow.vala
@@ -27,6 +27,14 @@ public class Tuba.Dialogs.MainWindow: Adw.ApplicationWindow, Saveable {
 		settings.notify["darken-images-on-dark-mode"].connect (settings_updated);
 
 		app.toast.connect (add_toast);
+		app.notify["is-online"].connect (on_network_change);
+	}
+
+	private void on_network_change () {
+		if (app.is_online) {
+			go_back_to_start ();
+			app.refresh ();
+		}
 	}
 
 	private void settings_updated () {

--- a/src/Dialogs/Offline.vala
+++ b/src/Dialogs/Offline.vala
@@ -1,0 +1,38 @@
+public class Tuba.Dialogs.Offline : Adw.Window {
+	construct {
+		if (network_monitor.network_available || app.is_online) return;
+		this.modal = true;
+
+		this.default_height = this.default_width = 360;
+		var toolbar_view = new Adw.ToolbarView () {
+			extend_content_to_top_edge = true,
+			content = new Adw.StatusPage () {
+				icon_name = "network-wireless-offline-symbolic",
+				title = _("Offline"),
+				//  description = _("") // ???
+			}
+		};
+
+		toolbar_view.add_top_bar (new Adw.HeaderBar () {
+			show_title = false
+		});
+
+		this.content = toolbar_view;
+
+		present ();
+		app.notify["is-online"].connect (on_network_change);
+	}
+
+	public override bool close_request () {
+		if (!app.is_online) {
+			app.quit ();
+		}
+		return base.close_request ();
+	}
+
+	void on_network_change () {
+		if (app.is_online) {
+			close_request ();
+		}
+	}
+}

--- a/src/Dialogs/meson.build
+++ b/src/Dialogs/meson.build
@@ -3,6 +3,7 @@ sources += files(
     'ListEdit.vala',
     'MainWindow.vala',
     'NewAccount.vala',
+    'Offline.vala',
     'Preferences.vala',
     'ProfileEdit.vala',
     'Report.vala',

--- a/src/Services/Accounts/InstanceAccount.vala
+++ b/src/Services/Accounts/InstanceAccount.vala
@@ -60,6 +60,13 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 		subscribed = false;
 	}
 
+	public void reconnect () {
+		gather_instance_info ();
+		gather_instance_custom_emojis ();
+		check_announcements ();
+		init_notifications ();
+	}
+
 	construct {
 		this.construct_streamable ();
 		this.stream_event[EVENT_NOTIFICATION].connect (on_notification_event);
@@ -318,6 +325,8 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 
 	public GLib.ListStore supported_mime_types = new GLib.ListStore (typeof (StatusContentType));
 	public void gather_instance_info () {
+		if (instance_info != null) return;
+
 		new Request.GET ("/api/v1/instance")
 			.with_account (this)
 			.then ((in_stream) => {
@@ -337,6 +346,8 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 	}
 
 	public void gather_instance_custom_emojis () {
+		if (instance_emojis != null) return;
+
 		new Request.GET ("/api/v1/custom_emojis")
 			.with_account (this)
 			.then ((in_stream) => {

--- a/src/Services/Network/Streamable.vala
+++ b/src/Services/Network/Streamable.vala
@@ -51,11 +51,20 @@ public abstract interface Tuba.Streamable : Object {
 
 		notify["subscribed"].connect (update_stream);
 		notify["stream_url"].connect (update_stream);
+		app.notify["is-online"].connect (on_network_change);
 		update_stream ();
 	}
 
 	protected void destruct_streamable () {
 		unsubscribe ();
+	}
+
+	protected void on_network_change () {
+		if (app.is_online) {
+			update_stream ();
+		} else {
+			unsubscribe ();
+		}
 	}
 
 	protected void update_stream () {

--- a/src/Widgets/Avatar.vala
+++ b/src/Widgets/Avatar.vala
@@ -39,6 +39,7 @@ public class Tuba.Widgets.Avatar : Gtk.Button {
 		css_classes = { "flat", "circular", "image-button", "ttl-flat-button" };
 
 		on_invalidated ();
+		app.notify["is-online"].connect (on_network_change);
 	}
 
 	void on_invalidated (API.Account? account = null) {
@@ -48,11 +49,19 @@ public class Tuba.Widgets.Avatar : Gtk.Button {
 		} else {
 			avatar.text = account.display_name;
 			avatar.show_initials = true;
-			Tuba.Helper.Image.request_paintable (account.avatar, null, on_cache_response);
+			avatar_url = account.avatar;
 		}
 	}
 
 	void on_cache_response (Gdk.Paintable? data) {
 		avatar.custom_image = data;
+	}
+
+	protected void on_network_change () {
+		// FIXME
+		//  if (app.is_online && avatar.get_custom_image () == null && this.avatar_url != null) {
+		//  	// trigger it again
+		//  	this.avatar_url = this.avatar_url;
+		//  }
 	}
 }


### PR DESCRIPTION
fix: #204 

Roadmap:

- [X] active account recovery (notifications, announcements, instance info, emojis)
- [X] websocket reconnections
- [x] timeline refreshes
- [x] check if you can access saved accounts at all (maybe don't even try until we are online?)
- [ ] finish offline window
- [ ] fix offline window closing => quitting (maybe an actual button?)
- [ ] avi recovery (maybe only for own accounts as timelines get refreshed?)
- [ ] recover any offline saved accounts
- [ ] tests tests and more tests

When the network changes from offline to online, it triggers a websocket and timeline refresh. That means we can skip recovering attachments and manually re-doing connections since they are getting refreshed.