### PR TITLE
feat: secondary click popover mini profile

### DIFF
--- a/data/ui/widgets/status.ui
+++ b/data/ui/widgets/status.ui
@@ -54,6 +54,7 @@
                             <property name="size">48</property>
                             <property name="valign">start</property>
                             <property name="visible">true</property>
+                            <property name="allow-mini-profile">1</property>
                             <signal name="clicked" handler="on_avatar_clicked" swapped="no" />
                           </object>
                         </child>

--- a/src/Views/Profile.vala
+++ b/src/Views/Profile.vala
@@ -10,6 +10,10 @@ public class Tuba.Views.Profile : Views.Accounts {
 		public override Gtk.Widget to_widget () {
 			return new Widgets.Cover (this);
 		}
+
+		public Gtk.Widget to_mini_widget () {
+			return new Widgets.Cover (this, true);
+		}
 	}
 
 	public ProfileAccount profile { get; construct set; }

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -452,7 +452,8 @@
 					size = 34,
 					valign = Gtk.Align.START,
 					halign = Gtk.Align.START,
-					overflow = Gtk.Overflow.HIDDEN
+					overflow = Gtk.Overflow.HIDDEN,
+					allow_mini_profile = true
 				};
 				actor_avatar.add_css_class ("ttl-status-avatar-actor");
 


### PR DESCRIPTION
fix: #495 
fix: #774 

I made sure to make it have as minimal of a resource footprint by enabling it only on posts and making the popovers along with their contents get disposed.

Enabling it on other widgets would be trivial.