### PR TITLE
feat(Views): stop disposing

### DIFF
--- a/src/API/Status.vala
+++ b/src/API/Status.vala
@@ -218,8 +218,7 @@ public class Tuba.API.Status : Entity, Widgetizable {
     }
 
 	public override void open () {
-		var view = new Views.Thread (formal);
-		app.main_window.open_view (view);
+		app.main_window.open_view (new Views.Thread (formal));
 	}
 
     public bool is_mine {

--- a/src/Views/Base.vala
+++ b/src/Views/Base.vala
@@ -123,10 +123,12 @@ public class Tuba.Views.Base : Adw.BreakpointBin {
 		// To work around that, we forcefully run dispose () -- which breaks any
 		// ref cycles -- when we get removed from our parent widget, the
 		// navigation view.
-		notify["parent"].connect (() => {
-			if (parent == null)
-				dispose ();
-		});
+		#if !USE_LISTVIEW
+			notify["parent"].connect (() => {
+				if (parent == null)
+					unbind_listboxes ();
+			});
+		#endif
 
 		scroll_to_top.clicked.connect (on_scroll_to_top);
 		app.notify["is-mobile"].connect (update_back_btn);
@@ -158,6 +160,10 @@ public class Tuba.Views.Base : Adw.BreakpointBin {
 		actions.dispose ();
 		base.dispose ();
 	}
+
+	#if !USE_LISTVIEW
+    	public virtual void unbind_listboxes () {}
+	#endif
 
     protected virtual void build_actions () {}
 

--- a/src/Views/Base.vala
+++ b/src/Views/Base.vala
@@ -120,9 +120,8 @@ public class Tuba.Views.Base : Adw.BreakpointBin {
 		// Unfortunately, Vala seems to create ref cycles out of thin air,
 		// especially when closures are involved, see e.g.
 		// https://gitlab.gnome.org/GNOME/vala/-/issues/957
-		// To work around that, we forcefully run dispose () -- which breaks any
-		// ref cycles -- when we get removed from our parent widget, the
-		// navigation view.
+		// or model binding.
+		// To work around that, we clear the binding manually.
 		#if !USE_LISTVIEW
 			notify["parent"].connect (() => {
 				if (parent == null)

--- a/src/Views/ContentBase.vala
+++ b/src/Views/ContentBase.vala
@@ -81,8 +81,7 @@ public class Tuba.Views.ContentBase : Views.Base {
 
 	public override void dispose () {
 		#if !USE_LISTVIEW
-			if (content != null)
-				content.bind_model (null, null);
+			unbind_listboxes ();
 		#endif
 		base.dispose ();
 	}
@@ -107,6 +106,13 @@ public class Tuba.Views.ContentBase : Views.Base {
 		}
 	}
 
+	#if !USE_LISTVIEW
+		public override void unbind_listboxes () {
+			if (content != null)
+				content.bind_model (null, null);
+			base.unbind_listboxes ();
+		}
+	#endif
 
 	public virtual Gtk.Widget on_create_model_widget (Object obj) {
 		var obj_widgetable = obj as Widgetizable;

--- a/src/Views/Lists.vala
+++ b/src/Views/Lists.vala
@@ -130,11 +130,8 @@ public class Tuba.Views.Lists : Views.Timeline {
 		buffer.set_text ("".data);
 	}
 
-	Gtk.Entry child_entry = new Gtk.Entry () {
-		input_purpose = Gtk.InputPurpose.FREE_FORM,
-		placeholder_text = _("New list title")
-	};
-
+	Gtk.Entry child_entry;
+	Gtk.Button add_button;
 	construct {
 		url = "/api/v1/lists";
 		label = _("Lists");
@@ -142,39 +139,38 @@ public class Tuba.Views.Lists : Views.Timeline {
 		accepts = typeof (API.List);
 		empty_state_title = _("No Lists");
 
+		child_entry = new Gtk.Entry () {
+			input_purpose = Gtk.InputPurpose.FREE_FORM,
+			placeholder_text = _("New list title")
+		};
+
 		var add_action_bar = new Gtk.ActionBar () {
 			css_classes = { "ttl-box-no-shadow" }
 		};
 
 		var child_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6);
 
-		var add_button = new Gtk.Button.with_label (_("Add list")) {
+		add_button = new Gtk.Button.with_label (_("Add list")) {
 			sensitive = false
 		};
 
-		add_button.clicked.connect (() => {
-			on_action_bar_activate (child_entry.buffer);
-		});
-		child_entry.activate.connect (() => {
-			on_action_bar_activate (child_entry.buffer);
-		});
-
-		child_entry.buffer.bind_property (
-			"length",
-			add_button,
-			"sensitive",
-			BindingFlags.SYNC_CREATE,
-			(b, src, ref target) => {
-				target.set_boolean ((uint) src > 0);
-				return true;
-			}
-		);
+		add_button.clicked.connect (new_item_cb);
+		child_entry.activate.connect (new_item_cb);
+		child_entry.notify["text"].connect (on_entry_changed);
 
 		child_box.append (child_entry);
 		child_box.append (add_button);
 
 		add_action_bar.set_center_widget (child_box);
 		toolbar_view.add_top_bar (add_action_bar);
+	}
+
+	void new_item_cb () {
+		on_action_bar_activate (child_entry.buffer);
+	}
+
+	void on_entry_changed () {
+		add_button.sensitive = child_entry.text.length > 0;
 	}
 
 	~Lists () {

--- a/src/Views/TabbedBase.vala
+++ b/src/Views/TabbedBase.vala
@@ -41,10 +41,18 @@ public class Tuba.Views.TabbedBase : Views.Base {
 
 		foreach (var tab in views) {
 			stack.remove (tab);
-			tab.dispose ();
 		}
 		views = {};
 	}
+
+	#if !USE_LISTVIEW
+		public override void unbind_listboxes () {
+			foreach (var tab in views) {
+				tab.unbind_listboxes ();
+			}
+			base.unbind_listboxes ();
+		}
+	#endif
 
 	protected virtual bool title_stack_page_visible {
 		get {

--- a/src/Views/Timeline.vala
+++ b/src/Views/Timeline.vala
@@ -127,6 +127,14 @@ public class Tuba.Views.Timeline : AccountHolder, Streamable, Views.ContentBase 
 		#endif
 	}
 
+	#if !USE_LISTVIEW
+		public override void unbind_listboxes () {
+			destruct_account_holder ();
+			destruct_streamable ();
+			base.unbind_listboxes ();
+		}
+	#endif
+
 	public override void dispose () {
 		destruct_streamable ();
 		base.dispose ();


### PR DESCRIPTION
This should fix all the random segfaults

# Why were we disposing?

Ref cycles would prevent Views from being destroyed. They would drop from \~60 to \~50 refs. That would also prevent websockets from closing.

Disposing unrefs everything, allowing them to be freed from memory however that had the cost of... losing reference to them and their children sometimes.

# Now what?

After some debugging, I pinned it down to `Gtk.ListBox#bind_model`. We have to clear the binding when it's time to be disposed, but there's no appropriate stage to do that on as dispose or destroy won't ever be called because of it.

Instead, manually remove the binding when it's time to be disposed, by using the same hack as before. The difference now is that we gracefully allow the view and its children to be destroyed, giving also the chance to notice and debug memory leaks.

# Why keep the hack?

I believe the current choices are:

1) Keep the hack but manually clear the binding (this PR)\*
2) Remove the hack but stop using `Gtk.ListBox#bind_model`

I don't want to do (2), at least not right now. Exposing just the model and letting descendants to just add items to it, rather than overriding a bunch of methods.

\* Another possibility would be to clear it when removing the pages, but... that's not always possible as we have to keep track of navigation view replacements and nested views
