### PR TITLE
feat(RichLabel): cleanup

### DIFF
--- a/src/API/Notification.vala
+++ b/src/API/Notification.vala
@@ -123,11 +123,11 @@ public class Tuba.API.Notification : Entity, Widgetizable {
 	public override void open () {
 		switch (kind) {
 			case InstanceAccount.KIND_SEVERED_RELATIONSHIPS:
-				Host.open_uri (@"$(accounts.active.instance)/severed_relationships");
+				Host.open_url (@"$(accounts.active.instance)/severed_relationships");
 				break;
 			case InstanceAccount.KIND_ADMIN_REPORT:
 				if (report != null)
-					Host.open_uri (@"$(accounts.active.instance)/admin/reports/$(report.id)");
+					Host.open_url (@"$(accounts.active.instance)/admin/reports/$(report.id)");
 				break;
 			default:
 				if (status != null) {

--- a/src/API/Status/PreviewCard.vala
+++ b/src/API/Status/PreviewCard.vala
@@ -56,7 +56,7 @@ public class Tuba.API.PreviewCard : Entity, Widgetizable {
 		public bool open_special_card (string t_url) {
 			switch (this) {
 				case BASIC:
-					Host.open_uri (t_url);
+					Host.open_url (t_url);
 					return true;
 				default:
 					return false;
@@ -171,7 +171,7 @@ public class Tuba.API.PreviewCard : Entity, Widgetizable {
 		try {
 			card_special_type.parse_url (card_url, out special_host, out special_api_url);
 		} catch {
-			Host.open_uri (card_url);
+			Host.open_url (card_url);
 			return;
 		}
 
@@ -205,7 +205,7 @@ public class Tuba.API.PreviewCard : Entity, Widgetizable {
 				}
 
 				if (failed || res_url == "") {
-					Host.open_uri (card_url);
+					Host.open_url (card_url);
 				} else {
 					if (bookwyrm_obj == null) {
 						app.main_window.show_media_viewer (res_url, Tuba.Attachment.MediaType.VIDEO, null, null, false, null, card_url, true);
@@ -215,7 +215,7 @@ public class Tuba.API.PreviewCard : Entity, Widgetizable {
 				}
 			})
 			.on_error (() => {
-				Host.open_uri (card_url);
+				Host.open_url (card_url);
 			})
 			.exec ();
 	}

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -145,9 +145,7 @@ namespace Tuba {
 				} catch (Error e) {
 					string msg = @"Failed to resolve URL \"$uri\": $(e.message)";
 					warning (msg);
-
-					var dlg = inform (_("Error"), msg);
-					dlg.present (app.main_window);
+					this.toast (msg);
 				}
 			});
 		}

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -136,7 +136,7 @@ namespace Tuba {
 			);
 		}
 
-		private void handle_web_ap (Uri uri) {
+		public void handle_web_ap (Uri uri) {
 			if (accounts.active == null) return;
 
 			accounts.active.resolve.begin (WebApHandler.from_uri (uri), (obj, res) => {

--- a/src/Dialogs/Composer/AttachmentsPageAttachment.vala
+++ b/src/Dialogs/Composer/AttachmentsPageAttachment.vala
@@ -84,7 +84,7 @@ public class Tuba.AttachmentsPageAttachment : Widgets.Attachment.Item {
 
 	protected override void on_click () {
 		if (attachment_file != null) {
-			Host.open_uri (attachment_file.get_path ());
+			Host.open_url (attachment_file.get_path ());
 		} else if (entity != null) {
 			base.on_click ();
 		}

--- a/src/Dialogs/MainWindow.vala
+++ b/src/Dialogs/MainWindow.vala
@@ -154,7 +154,7 @@ public class Tuba.Dialogs.MainWindow: Adw.ApplicationWindow, Saveable {
 
 			((Widgets.BookWyrmPage) book_widget).selectable = true;
 		} catch {
-			if (fallback != null) Host.open_uri (fallback);
+			if (fallback != null) Host.open_url (fallback);
 		}
 	}
 

--- a/src/Dialogs/NewAccount.vala
+++ b/src/Dialogs/NewAccount.vala
@@ -157,7 +157,7 @@ public class Tuba.Dialogs.NewAccount: Adw.Window {
 		var esc_redirect = Uri.escape_string (redirect_uri);
 		var pars = @"scope=$esc_scopes&response_type=code&redirect_uri=$esc_redirect&client_id=$(Uri.escape_string (account.client_id))";
 		var url = @"$(account.instance)/oauth/authorize?$pars";
-		Host.open_uri (url);
+		Host.open_url (url);
 	}
 
 	async void request_token () throws Error {

--- a/src/Services/Accounts/Mastodon/Account.vala
+++ b/src/Services/Accounts/Mastodon/Account.vala
@@ -210,7 +210,7 @@ public class Tuba.Mastodon.Account : InstanceAccount {
 			} catch (Error e) {
 				warning (@"Failed to resolve URL \"$url\":");
 				warning (e.message);
-				Host.open_uri (url);
+				Host.open_url (url);
 			}
 		});
 	}

--- a/src/Services/Accounts/SecretAccountStore.vala
+++ b/src/Services/Accounts/SecretAccountStore.vala
@@ -54,7 +54,7 @@ public class Tuba.SecretAccountStore : AccountStore {
 				{ {"Read More", Adw.ResponseAppearance.SUGGESTED }, { "Close", Adw.ResponseAppearance.DEFAULT } },
 				false,
 				(obj, res) => {
-					if (app.question.end (res).truthy ()) Host.open_uri (wiki_page);
+					if (app.question.end (res).truthy ()) Host.open_url (wiki_page);
 					Process.exit (1);
 				}
 			);

--- a/src/Utils/Tracking.vala
+++ b/src/Utils/Tracking.vala
@@ -60,19 +60,22 @@ public class Tuba.Tracking {
 	public static Uri strip_utm_from_uri (Uri uri) throws Error {
 		string[] res_params = {};
 
-		var iter = UriParamsIter (uri.get_query ());
-		string key;
-		string val;
-		while (iter.next (out key, out val)) {
-			var not_tracking_id = true;
-			foreach (var id in TRACKING_IDS) {
-				if (id in key.down ()) {
-					not_tracking_id = false;
-					break;
+		string? query = uri.get_query ();
+		if (query != null) {
+			var iter = UriParamsIter (query);
+			string key;
+			string val;
+			while (iter.next (out key, out val)) {
+				var not_tracking_id = true;
+				foreach (var id in TRACKING_IDS) {
+					if (id in key.down ()) {
+						not_tracking_id = false;
+						break;
+					}
 				}
-			}
 
-			if (not_tracking_id) res_params += @"$key=$val";
+				if (not_tracking_id) res_params += @"$key=$val";
+			}
 		}
 
 		string? res_query = res_params.length > 0 ? string.joinv ("&", res_params) : null;

--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -679,7 +679,7 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 		Item? page = safe_get ((int) carousel.position);
 		if (page == null) return;
 
-		Host.open_uri (page.url);
+		Host.open_url (page.url);
 	}
 
 	private void save_as () {

--- a/src/Views/Profile.vala
+++ b/src/Views/Profile.vala
@@ -247,7 +247,7 @@ public class Tuba.Views.Profile : Views.Accounts {
 
 		var open_in_browser_action = new SimpleAction ("open_in_browser", null);
 		open_in_browser_action.activate.connect (v => {
-			Host.open_uri (profile.account.url);
+			Host.open_url (profile.account.url);
 		});
 		actions.add_action (open_in_browser_action);
 

--- a/src/Views/Thread.vala
+++ b/src/Views/Thread.vala
@@ -195,7 +195,7 @@ public class Tuba.Views.Thread : Views.ContentBase, AccountHolder {
 					app.main_window.open_view (new Views.Thread (status));
 				}
 				else
-					Host.open_uri (q);
+					Host.open_url (q);
 			})
 			.exec ();
 	}

--- a/src/Widgets/Attachment/Item.vala
+++ b/src/Widgets/Attachment/Item.vala
@@ -23,7 +23,7 @@ public class Tuba.Widgets.Attachment.Item : Adw.Bin {
 	}
 
 	private void open_in_browser () {
-		Host.open_uri (entity.url);
+		Host.open_url (entity.url);
 	}
 
 	private void save_as () {
@@ -234,6 +234,6 @@ public class Tuba.Widgets.Attachment.Item : Adw.Bin {
 
 	protected async void open () throws Error {
 		var path = yield Host.download (entity.url);
-		Host.open_uri (path);
+		Host.open_url (path);
 	}
 }

--- a/src/Widgets/BookWyrmPage.vala
+++ b/src/Widgets/BookWyrmPage.vala
@@ -104,11 +104,11 @@ public class Tuba.Widgets.BookWyrmPage : Gtk.Box {
 
     [GtkCallback]
     void open_on_openlibrary () {
-        Host.open_uri (@"https://openlibrary.org/books/$(book.openlibraryKey)");
+        Host.open_url (@"https://openlibrary.org/books/$(book.openlibraryKey)");
     }
 
     [GtkCallback]
     void open_on_bw () {
-        Host.open_uri (book.id);
+        Host.open_url (book.id);
     }
 }

--- a/src/Widgets/PreviewCard.vala
+++ b/src/Widgets/PreviewCard.vala
@@ -92,7 +92,7 @@ public class Tuba.Widgets.PreviewCard : Gtk.Button {
         if (card_obj.kind == "link" && card_obj.history != null && card_obj.history.size > 0) {
 				this.add_css_class ("explore");
 
-				this.clicked.connect (() => Host.open_uri (card_obj.url));
+				this.clicked.connect (() => Host.open_url (card_obj.url));
 
                 if (description_label.visible) {
                     if (description_label.label.length > 109)

--- a/src/Widgets/RichLabel.vala
+++ b/src/Widgets/RichLabel.vala
@@ -116,6 +116,10 @@ public class Tuba.Widgets.RichLabel : Adw.Bin {
 						null
 					)
 				);
+				return true;
+			} else if (uri.get_scheme () == "web+ap") {
+				app.handle_web_ap (uri);
+
 			return true;
 			}
 		} catch (UriError e) {

--- a/src/Widgets/RichLabel.vala
+++ b/src/Widgets/RichLabel.vala
@@ -101,14 +101,25 @@ public class Tuba.Widgets.RichLabel : Adw.Bin {
 			if (found) return true;
 		}
 
-		if ("/tags/" in url) {
-			var from_url = Path.get_basename (url);
-			var decoded = Uri.unescape_string (from_url) ?? from_url;
-			var param_start = decoded.index_of_char ('?');
-			if (param_start != -1)
-				decoded = decoded.slice (0, param_start);
-			app.main_window.open_view (new Views.Hashtag (decoded, null));
+		GLib.Uri? uri = null;
+		try {
+			uri = Uri.parse (url, UriFlags.NONE);
+
+			// Hashtag urls are not resolvable.
+			// Handle them manually if they end in /tags/<tag>.
+			// Some backends might add query params, so using
+			// GLib.Uri is preferred.
+			if (Path.get_basename (Path.get_dirname (url)) == "tags") {
+				app.main_window.open_view (
+					new Views.Hashtag (
+						Path.get_basename (uri.get_path ()),
+						null
+					)
+				);
 			return true;
+			}
+		} catch (UriError e) {
+			warning (@"Failed to parse \"$url\": $(e.message)");
 		}
 
 		if (should_resolve_url (url)) {

--- a/src/Widgets/RichLabel.vala
+++ b/src/Widgets/RichLabel.vala
@@ -120,7 +120,7 @@ public class Tuba.Widgets.RichLabel : Adw.Bin {
 			} else if (uri.get_scheme () == "web+ap") {
 				app.handle_web_ap (uri);
 
-			return true;
+				return true;
 			}
 		} catch (UriError e) {
 			warning (@"Failed to parse \"$url\": $(e.message)");
@@ -130,15 +130,22 @@ public class Tuba.Widgets.RichLabel : Adw.Bin {
 			accounts.active.resolve.begin (url, (obj, res) => {
 				try {
 					accounts.active.resolve.end (res).open ();
-				}
-				catch (Error e) {
+				} catch (Error e) {
 					warning (@"Failed to resolve URL \"$url\":");
 					warning (e.message);
-					Host.open_uri (url);
+					if (uri == null) {
+						Host.open_url (url);
+					} else {
+						Host.open_uri (uri);
+					}
 				}
 			});
 		} else {
-			Host.open_uri (url);
+			if (uri == null) {
+				Host.open_url (url);
+			} else {
+				Host.open_uri (uri);
+			}
 		}
 
 		return true;

--- a/src/Widgets/RichLabel.vala
+++ b/src/Widgets/RichLabel.vala
@@ -130,6 +130,8 @@ public class Tuba.Widgets.RichLabel : Adw.Bin {
 	}
 
 	public static bool should_resolve_url (string url) {
-		return settings.aggressive_resolving || "@" in url || "user" in url;
+		return settings.aggressive_resolving
+			|| url.index_of_char ('@') != -1
+			|| "/user" in url;
 	}
 }

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -329,7 +329,7 @@
 	}
 
 	private void open_in_browser () {
-		Host.open_uri (status.formal.url ?? status.formal.account.url);
+		Host.open_url (status.formal.url ?? status.formal.account.url);
 	}
 
 	private void report_status () {


### PR DESCRIPTION
- Tuba will now open web+ap urls in-app (e.g. `web+ap://faraway.town/@GeopJr` will open my profile in-app instead of going through the process of asking your OS to open the default app for `web+ap` uris)
- Hashtag url resolving is now a lot more strict and valid (by using GLib.Uri)
- Host.open_uri was split into another method for opening GLib.Uris instead of strings
- Link resolving was optimized thanks to the above to use only one GLib.Uri instance instead of creating multiple for every single thing (checking the uri scheme to see if it's web+ap, tracking parameter splitting etc...)
- Fixed a critical in Utils/Tracking when attempting to iterate null query parameters
- Should_resolve conditions were optimized and became stricter