### PR TITLE
feat(PreviewCard): redesign

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -209,7 +209,7 @@ headerbar.flat.no-title .title {
 	border-right: solid 1px @sidebar_border_color;
 }
 
-.ttl-profile-fields-box-container.odd > .ttl-profile-fields-box > flowboxchild:last-child > .ttl-profile-field { 
+.ttl-profile-fields-box-container.odd > .ttl-profile-fields-box > flowboxchild:last-child > .ttl-profile-field {
 	border-bottom: none;
 }
 
@@ -332,17 +332,18 @@ flowboxchild,
 	padding: 0;
 }
 
-.preview_card_image:dir(ltr) {
+.preview_card_v {
+	border-radius: 6px 6px 0px 0px;
+}
+
+.preview_card_h:dir(ltr) {
 	border-radius: 6px 0px 0px 6px;
 }
 
-.preview_card_image:dir(rtl) {
+.preview_card_h:dir(rtl) {
 	border-radius: 0px 6px 6px 0px;
 }
 
-.preview_card_video {
-	border-radius: 6px 6px 0px 0px;
-}
 
 .bkwm-desc {
 	padding: 12px;
@@ -522,7 +523,7 @@ video > overlay > revealer > controls {
 .ttl-view .small.fake-content .card {
 	box-shadow: none;
 }
-.ttl-view .small .preview_card.explore .preview_card_image {
+.ttl-view .small .preview_card.explore .preview_card_h {
 	border-radius: 0px;
 }
 

--- a/data/ui/widgets/preview_card.ui
+++ b/data/ui/widgets/preview_card.ui
@@ -8,8 +8,7 @@
     </style>
     <child>
       <object class="GtkBox" id="box">
-        <property name="orientation">horizontal</property>
-        <property name="homogeneous">1</property>
+        <property name="orientation">vertical</property>
         <child>
           <object class="GtkBox">
             <property name="orientation">vertical</property>

--- a/data/ui/widgets/preview_card.ui
+++ b/data/ui/widgets/preview_card.ui
@@ -49,6 +49,9 @@
                 <property name="ellipsize">end</property>
                 <property name="halign">fill</property>
                 <property name="xalign">0</property>
+				<property name="lines">3</property>
+                <property name="wrap">1</property>
+                <property name="wrap-mode">word-char</property>
                 <property name="single-line-mode">1</property>
                 <style>
                   <class name="caption"/>

--- a/src/Widgets/PreviewCard.vala
+++ b/src/Widgets/PreviewCard.vala
@@ -49,9 +49,10 @@ public class Tuba.Widgets.PreviewCard : Gtk.Button {
 			image_widget = new Gtk.Image.from_icon_name (
 				is_video ? "media-playback-start-symbolic" : "tuba-earth-symbolic"
 			) {
-				css_classes = {"preview_card_v"},
+				css_classes = {"preview_card_h"},
 				icon_size = Gtk.IconSize.LARGE,
-				height_request = 100,
+				height_request = 70,
+				width_request = 70,
 			};
 		}
 		box.prepend (image_widget);

--- a/src/Widgets/PreviewCard.vala
+++ b/src/Widgets/PreviewCard.vala
@@ -54,6 +54,11 @@ public class Tuba.Widgets.PreviewCard : Gtk.Button {
 				height_request = 70,
 				width_request = 70,
 			};
+
+			box.orientation = Gtk.Orientation.HORIZONTAL;
+			box.homogeneous = false;
+
+			description_label.wrap = false;
 		}
 		box.prepend (image_widget);
 

--- a/src/Widgets/PreviewCard.vala
+++ b/src/Widgets/PreviewCard.vala
@@ -13,16 +13,13 @@ public class Tuba.Widgets.PreviewCard : Gtk.Button {
 	public PreviewCard (API.PreviewCard card_obj) {
 		var is_video = card_obj.kind == "video";
 
-		if (is_video) {
-			box.orientation = Gtk.Orientation.VERTICAL;
-			box.homogeneous = false;
-		}
-
 		Gtk.Widget image_widget;
 		if (card_obj.image != null) {
 			var image = new Gtk.Picture () {
 				width_request = 25,
-				content_fit = Gtk.ContentFit.COVER
+				content_fit = Gtk.ContentFit.COVER,
+				height_request = 250,
+				css_classes = {"preview_card_v"}
 			};
 
 			Tuba.Helper.Image.request_paintable (card_obj.image, card_obj.blurhash, (paintable) => {
@@ -30,9 +27,6 @@ public class Tuba.Widgets.PreviewCard : Gtk.Button {
 			});
 
 			if (is_video) {
-				image.height_request = 250;
-				image.add_css_class ("preview_card_video");
-
 				var overlay = new Gtk.Overlay () {
 					vexpand = true,
 					hexpand = true,
@@ -49,23 +43,16 @@ public class Tuba.Widgets.PreviewCard : Gtk.Button {
 
 				image_widget = overlay;
 			} else {
-				image.height_request = 70;
-				image.add_css_class ("preview_card_image");
-
 				image_widget = image;
 			}
 		} else {
 			image_widget = new Gtk.Image.from_icon_name (
 				is_video ? "media-playback-start-symbolic" : "tuba-earth-symbolic"
 			) {
-				height_request = 70,
-				width_request = 70,
-				icon_size = Gtk.IconSize.LARGE
+				css_classes = {"preview_card_v"},
+				icon_size = Gtk.IconSize.LARGE,
+				height_request = 100,
 			};
-			image_widget.add_css_class ("preview_card_image");
-
-			box.orientation = Gtk.Orientation.HORIZONTAL;
-			box.homogeneous = false;
 		}
 		box.prepend (image_widget);
 
@@ -90,6 +77,12 @@ public class Tuba.Widgets.PreviewCard : Gtk.Button {
 		}
 
 		if (card_obj.kind == "link" && card_obj.history != null && card_obj.history.size > 0) {
+				box.orientation = Gtk.Orientation.HORIZONTAL;
+				box.homogeneous = true;
+				image_widget.height_request = 70;
+				image_widget.add_css_class ("preview_card_h");
+				image_widget.remove_css_class ("preview_card_v");
+
 				this.add_css_class ("explore");
 
 				this.clicked.connect (() => Host.open_url (card_obj.url));

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -959,7 +959,7 @@
 		}
 
 		if (prev_card != null) content_box.remove (prev_card);
-		if (settings.show_preview_cards && status.formal.card != null && status.formal.card.kind in ALLOWED_CARD_TYPES) {
+		if (settings.show_preview_cards && !status.formal.has_media && status.formal.card != null && status.formal.card.kind in ALLOWED_CARD_TYPES) {
 			try {
 				prev_card = (Gtk.Button) status.formal.card.to_widget ();
 				prev_card.clicked.connect (open_card_url);


### PR DESCRIPTION
After the discussion on https://gitlab.gnome.org/Teams/Circle/-/issues/193#note_2109127, I believe the vertical layout is more desirable nowadays. Not only does it match the other platforms but also websites usually have large and wide preview images.

Link with image

![Screenshot from 2024-05-31 05-15-08](https://github.com/GeopJr/Tuba/assets/18014039/95219b5e-22c9-4d80-8b12-fac371638da3)

Link without image

![Screenshot from 2024-05-31 05-13-08](https://github.com/GeopJr/Tuba/assets/18014039/99400185-be54-40da-ad4e-6302a94039cb)

Without an image seems a bit wasteful, we could make it use the horizontal layout then or remove the image part completely.

Additionally, I noticed that mastodon-web doesn't show preview cards if there are attachments which seems logical, so I made Tuba do it too.

We could also increase the description to 2+ lines since we now have the height freedom to do so

cc: @bertob 