### PR TITLE
feat(Notifications): requests

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -1,4 +1,4 @@
-.ttl-sidebar .badge {
+.notification-badge {
 	font-weight: bold;
 	font-size: 0.8em;
 	border-radius: 10px;
@@ -8,7 +8,7 @@
 	color: @text_view_bg;
 }
 
-.ttl-sidebar .badge.no-attention {
+.notification-badge.no-attention {
 	background: alpha(@sidebar_fg_color, .4);
 }
 
@@ -209,7 +209,7 @@ headerbar.flat.no-title .title {
 	border-right: solid 1px @sidebar_border_color;
 }
 
-.ttl-profile-fields-box-container.odd > .ttl-profile-fields-box > flowboxchild:last-child > .ttl-profile-field { 
+.ttl-profile-fields-box-container.odd > .ttl-profile-fields-box > flowboxchild:last-child > .ttl-profile-field {
 	border-bottom: none;
 }
 

--- a/data/ui/dialogs/preferences.ui
+++ b/data/ui/dialogs/preferences.ui
@@ -249,6 +249,47 @@
 						</child>
 					</object>
 				</child>
+				<child>
+					<object class="AdwPreferencesGroup" id="filtered_notifications_group">
+						<property name="visible">0</property>
+						<!-- translators: Preferences group title -->
+						<property name="title" translatable="yes">Filter Notifications Out</property>
+						<!-- translators: Preferences group description -->
+						<property name="description" translatable="yes">Filter out notifications from people you may not know</property>
+						<child>
+							<object class="AdwSwitchRow" id="filter_notifications_following_switch">
+								<!-- translators: Preferences switch title about filtering out notifications; you can find this string translated on https://github.com/mastodon/mastodon/tree/main/app/javascript/mastodon/locales -->
+								<property name="title" translatable="yes">People you don't follow</property>
+								<!-- translators: Preferences switch subtitle about filtering out 'People you don't follow'; you can find this string translated on https://github.com/mastodon/mastodon/tree/main/app/javascript/mastodon/locales -->
+								<property name="subtitle" translatable="yes">Until you manually approve them</property>
+							</object>
+						</child>
+						<child>
+							<object class="AdwSwitchRow" id="filter_notifications_follower_switch">
+								<!-- translators: Preferences switch title about filtering out notifications; you can find this string translated on https://github.com/mastodon/mastodon/tree/main/app/javascript/mastodon/locales -->
+								<property name="title" translatable="yes">People not following you</property>
+								<!-- translators: Preferences switch subtitle about filtering out 'People not following you'; you can find this string translated on https://github.com/mastodon/mastodon/tree/main/app/javascript/mastodon/locales -->
+								<property name="subtitle" translatable="yes">Including people who have been following you fewer than 3 days</property>
+							</object>
+						</child>
+						<child>
+							<object class="AdwSwitchRow" id="filter_notifications_new_account_switch">
+								<!-- translators: Preferences switch title about filtering out notifications; you can find this string translated on https://github.com/mastodon/mastodon/tree/main/app/javascript/mastodon/locales -->
+								<property name="title" translatable="yes">New accounts</property>
+								<!-- translators: Preferences switch subtitle about filtering out 'New accounts'; you can find this string translated on https://github.com/mastodon/mastodon/tree/main/app/javascript/mastodon/locales -->
+								<property name="subtitle" translatable="yes">Created within the past 30 days</property>
+							</object>
+						</child>
+						<child>
+							<object class="AdwSwitchRow" id="filter_notifications_dm_switch">
+								<!-- translators: Preferences switch title about filtering out notifications; you can find this string translated on https://github.com/mastodon/mastodon/tree/main/app/javascript/mastodon/locales -->
+								<property name="title" translatable="yes">Unsolicited private mentions</property>
+								<!-- translators: Preferences switch subtitle about filtering out 'Unsolicited private mentions'; you can find this string translated on https://github.com/mastodon/mastodon/tree/main/app/javascript/mastodon/locales -->
+								<property name="subtitle" translatable="yes">Filtered unless it's in reply to your own mention or if you follow the sender</property>
+							</object>
+						</child>
+					</object>
+				</child>
 			</object>
 		</child>
 		<child>

--- a/data/ui/views/profile_header.ui
+++ b/data/ui/views/profile_header.ui
@@ -45,7 +45,6 @@
                         </child>
                         <style>
                           <class name="linked" />
-                          <class name="badge" />
                           <class name="heading" />
                           <class name="osd" />
                           <class name="cover-badge" />

--- a/data/ui/views/sidebar/account.ui
+++ b/data/ui/views/sidebar/account.ui
@@ -36,7 +36,7 @@
 						<property name="ellipsize">end</property>
 						<property name="visible">0</property>
 						<style>
-							<class name="badge" />
+							<class name="notification-badge" />
 						</style>
 					</object>
 				</child>

--- a/data/ui/views/sidebar/item.ui
+++ b/data/ui/views/sidebar/item.ui
@@ -30,7 +30,7 @@
             <property name="visible">0</property>
             <property name="valign">center</property>
             <style>
-              <class name="badge"/>
+              <class name="notification-badge"/>
             </style>
           </object>
         </child>

--- a/data/ui/widgets/profile.ui
+++ b/data/ui/widgets/profile.ui
@@ -34,7 +34,6 @@
 								</child>
 								<style>
 									<class name="linked" />
-									<class name="badge" />
 									<class name="heading" />
 									<class name="osd" />
 									<class name="cover-badge" />

--- a/src/API/NotificationFilter.vala
+++ b/src/API/NotificationFilter.vala
@@ -1,0 +1,34 @@
+public class Tuba.API.NotificationFilter {
+	public class Policy : Entity {
+		public class Summary : Entity {
+			public int32 pending_requests_count { get; set; default=0; }
+			public int32 pending_notifications_count { get; set; default=0; }
+		}
+
+		public bool filter_not_following { get; set; default=false; }
+		public bool filter_not_followers { get; set; default=false; }
+		public bool filter_new_accounts { get; set; default=false; }
+		public bool filter_private_mentions { get; set; default=false; }
+		public Summary? summary { get; set; default=null; }
+
+		public static Policy from (Json.Node node) throws Error {
+			return Entity.from_json (typeof (Policy), node) as Policy;
+		}
+	}
+
+	public class Request : Entity, Widgetizable {
+		public string id { get; set; }
+		//  public string created_at { get; set; }
+		//  public string? updated_at { get; set; default=null; }
+		public string notifications_count { get; set; default="0"; }
+		public API.Account account { get; set; }
+
+		public override Gtk.Widget to_widget () {
+			return new Widgets.NotificationRequest (this);
+		}
+
+		public static Request from (Json.Node node) throws Error {
+			return Entity.from_json (typeof (Request), node) as Request;
+		}
+	}
+}

--- a/src/API/meson.build
+++ b/src/API/meson.build
@@ -15,6 +15,7 @@ sources += files(
     'List.vala',
     'Mention.vala',
     'Notification.vala',
+    'NotificationFilter.vala',
     'PeerTube.vala',
     'Poll.vala',
     'PollOption.vala',

--- a/src/Dialogs/Preferences.vala
+++ b/src/Dialogs/Preferences.vala
@@ -137,6 +137,12 @@ public class Tuba.Dialogs.Preferences : Adw.PreferencesDialog {
 	[GtkChild] unowned Adw.SwitchRow poll_results_notifications_switch;
 	[GtkChild] unowned Adw.SwitchRow edits_notifications_switch;
 
+	[GtkChild] unowned Adw.PreferencesGroup filtered_notifications_group;
+	[GtkChild] unowned Adw.SwitchRow filter_notifications_following_switch;
+	[GtkChild] unowned Adw.SwitchRow filter_notifications_follower_switch;
+	[GtkChild] unowned Adw.SwitchRow filter_notifications_new_account_switch;
+	[GtkChild] unowned Adw.SwitchRow filter_notifications_dm_switch;
+
 	//  [GtkChild] unowned Adw.PreferencesPage filters_page;
 	[GtkChild] unowned Adw.PreferencesGroup keywords_group;
 
@@ -193,9 +199,39 @@ public class Tuba.Dialogs.Preferences : Adw.PreferencesDialog {
 
 		setup_languages_combo_row ();
 		setup_notification_mutes ();
+		setup_notification_filters ();
 		setup_filters ();
 		bind ();
 		closed.connect (on_window_closed);
+	}
+
+	private Gee.HashMap<Adw.SwitchRow, bool>? notification_filter_policy_status = null;
+	void setup_notification_filters () {
+		if (!accounts.active.probably_has_notification_filters) return;
+
+		new Request.GET ("/api/v1/notifications/policy")
+			.with_account (accounts.active)
+			.then ((in_stream) => {
+				var parser = Network.get_parser_from_inputstream (in_stream);
+				var node = network.parse_node (parser);
+				if (node == null) return;
+
+				filtered_notifications_group.visible = true;
+				var policies = API.NotificationFilter.Policy.from (node);
+
+				notification_filter_policy_status = new Gee.HashMap<Adw.SwitchRow, bool> ();
+				notification_filter_policy_status.set (filter_notifications_following_switch, policies.filter_not_following);
+				notification_filter_policy_status.set (filter_notifications_follower_switch, policies.filter_not_followers);
+				notification_filter_policy_status.set (filter_notifications_new_account_switch, policies.filter_new_accounts);
+				notification_filter_policy_status.set (filter_notifications_dm_switch, policies.filter_private_mentions);
+
+				notification_filter_policy_status.@foreach (entry => {
+					((Adw.SwitchRow) entry.key).active = (bool) entry.value;
+
+					return true;
+				});
+			})
+			.exec ();
 	}
 
 	void setup_filters () {
@@ -323,6 +359,44 @@ public class Tuba.Dialogs.Preferences : Adw.PreferencesDialog {
 	}
 
 	private void on_window_closed () {
+		if (notification_filter_policy_status != null) {
+			bool changed = false;
+			notification_filter_policy_status.@foreach (entry => {
+				if (((Adw.SwitchRow) entry.key).active != (bool) entry.value) {
+					changed = true;
+					return false;
+				}
+
+				return true;
+			});
+
+			if (changed) {
+				var builder = new Json.Builder ();
+				builder.begin_object ();
+
+				builder.set_member_name ("filter_not_following");
+				builder.add_boolean_value (filter_notifications_following_switch.active);
+
+				builder.set_member_name ("filter_not_followers");
+				builder.add_boolean_value (filter_notifications_follower_switch.active);
+
+				builder.set_member_name ("filter_new_accounts");
+				builder.add_boolean_value (filter_notifications_new_account_switch.active);
+
+				builder.set_member_name ("filter_private_mentions");
+				builder.add_boolean_value (filter_notifications_dm_switch.active);
+
+				builder.end_object ();
+
+				new Request.PUT ("/api/v1/notifications/policy")
+					.with_account (accounts.active)
+					.body_json (builder)
+					.exec ();
+			}
+
+			notification_filter_policy_status.clear ();
+		}
+
 		if (lang_changed) {
 			var new_lang = ((Tuba.Locales.Locale) default_language_combo_row.selected_item).locale;
 			if (settings.default_language != ((Tuba.Locales.Locale) default_language_combo_row.selected_item).locale) {

--- a/src/Services/Accounts/InstanceAccount.vala
+++ b/src/Services/Accounts/InstanceAccount.vala
@@ -29,6 +29,7 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 	public string? access_token { get; set; }
 	public bool needs_update { get; set; default=false; }
 	public Error? error { get; set; } //TODO: use this field when server invalidates the auth token
+	public bool probably_has_notification_filters { get; set; default=false; }
 
 	public GLib.ListStore known_places = new GLib.ListStore (typeof (Place));
 
@@ -339,6 +340,7 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 
 	public int unreviewed_follow_requests { get; set; default = 0; }
 	public int unread_announcements { get; set; default = 0; }
+	public int filtered_notifications_count { get; set; default = 0; }
 	public int unread_count { get; set; default = 0; }
 	public int last_read_id { get; set; default = 0; }
 	public int last_received_id { get; set; default = 0; }
@@ -439,10 +441,11 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 				var node = network.parse_node (parser);
 				if (node == null) return;
 
+				this.probably_has_notification_filters = true;
 				var instance_v2 = API.InstanceV2.from (node);
 
 				if (instance_v2 != null && instance_v2.configuration != null && instance_v2.configuration.translation != null) {
-					instance_info.tuba_can_translate = instance_v2.configuration.translation.enabled;
+					this.instance_info.tuba_can_translate = instance_v2.configuration.translation.enabled;
 				}
 			})
 			.exec ();

--- a/src/Views/NotificationRequests.vala
+++ b/src/Views/NotificationRequests.vala
@@ -1,0 +1,50 @@
+public class Tuba.Views.NotificationRequests : Views.Timeline {
+	construct {
+		url = "/api/v1/notifications/requests";
+		label = _("Filtered Notifications");
+		icon = "tuba-bell-outline-symbolic";
+		accepts = typeof (API.NotificationFilter.Request);
+		empty_state_title = _("No Filtered Notifications");
+	}
+
+	public override Gtk.Widget on_create_model_widget (Object obj) {
+		var widget = base.on_create_model_widget (obj);
+		var widget_notification_req = widget as Widgets.NotificationRequest;
+
+		if (widget_notification_req != null) {
+			widget_notification_req.dismissed.connect (on_response);
+			widget_notification_req.accepted.connect (on_response);
+		}
+
+		return widget;
+	}
+
+	private void on_response (Widgets.NotificationRequest wdg, Request req, API.NotificationFilter.Request api_req) {
+		wdg.btns_box.sensitive = false;
+		req
+			.then ((in_stream) => {
+				uint indx;
+				var found = model.find (api_req, out indx);
+				if (found) {
+					model.remove (indx);
+
+					if (accounts.active.filtered_notifications_count > 0) {
+						int to_remove = int.parse (api_req.notifications_count);
+						if (to_remove < 1) to_remove = 1;
+
+						accounts.active.filtered_notifications_count -= to_remove;
+					}
+				} else {
+					wdg.btns_box.sensitive = true;
+				}
+			})
+			.on_error (() => {
+				wdg.btns_box.sensitive = true;
+			})
+			.exec ();
+	}
+
+	public override void on_content_item_activated (Gtk.ListBoxRow row) {
+		((Widgets.NotificationRequest) row).open ();
+	}
+}

--- a/src/Views/NotificationRequestsList.vala
+++ b/src/Views/NotificationRequestsList.vala
@@ -1,0 +1,52 @@
+public class Tuba.Views.NotificationRequestsList : Views.Timeline {
+	Widgets.NotificationRequest notification_req_wdg;
+
+	public NotificationRequestsList (string account_id, string account_handle, Widgets.NotificationRequest notification_req_wdg) {
+		Object (
+			url: @"/api/v1/notifications?account_id=$account_id",
+			// translators: the variable is a user handle
+			label: _("Notifications by %s").printf (account_handle),
+			icon: "tuba-bell-outline-symbolic",
+			// translators: the variable is a user handle
+			empty_state_title: _("No Notifications by %s").printf (account_handle)
+		);
+
+		this.accepts = typeof (API.Notification);
+		this.notification_req_wdg = notification_req_wdg;
+	}
+
+	private Gtk.Button dismiss_btn;
+	private Gtk.Button accept_btn;
+	protected override void build_header () {
+		base.build_header ();
+
+		dismiss_btn = new Gtk.Button () {
+			icon_name = "user-trash-symbolic",
+			css_classes = { "flat", "error" },
+			tooltip_text = _("Dismiss")
+		};
+		dismiss_btn.clicked.connect (on_dismiss);
+
+		accept_btn = new Gtk.Button () {
+			icon_name = "tuba-check-round-outline-symbolic",
+			css_classes = { "flat", "success" },
+			tooltip_text = _("Accept")
+		};
+		accept_btn.clicked.connect (on_accept);
+
+		header.pack_end (accept_btn);
+		header.pack_end (dismiss_btn);
+	}
+
+	private void on_dismiss () {
+		dismiss_btn.sensitive = accept_btn.sensitive = false;
+		notification_req_wdg.on_dismiss ();
+		app.main_window.back ();
+	}
+
+	private void on_accept () {
+		dismiss_btn.sensitive = accept_btn.sensitive = false;
+		notification_req_wdg.on_dismiss ();
+		app.main_window.back ();
+	}
+}

--- a/src/Views/Notifications.vala
+++ b/src/Views/Notifications.vala
@@ -1,6 +1,25 @@
 public class Tuba.Views.Notifications : Views.Timeline, AccountHolder, Streamable {
 	protected InstanceAccount? last_account = null;
 	private Binding badge_number_binding;
+	private Binding filtered_notifications_count_binding;
+	private Adw.Banner notifications_filter_banner;
+
+	public int32 filtered_notifications {
+		set {
+			if (notifications_filter_banner == null) return;
+
+			if (value > 0) {
+				notifications_filter_banner.title = GLib.ngettext (
+					"%d Filtered Notification",
+					"%d Filtered Notifications",
+					(ulong) value
+				).printf (value);
+				notifications_filter_banner.revealed = true;
+			} else {
+				notifications_filter_banner.revealed = false;
+			}
+		}
+	}
 
 	construct {
 		url = "/api/v1/notifications";
@@ -22,6 +41,24 @@ public class Tuba.Views.Notifications : Views.Timeline, AccountHolder, Streamabl
 				}
 			});
 		#endif
+
+		notifications_filter_banner = new Adw.Banner ("") {
+			use_markup = true,
+			button_label = _("View"),
+			revealed = false
+		};
+		notifications_filter_banner.button_clicked.connect (on_notifications_filter_banner_button_clicked);
+
+		var box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0) {
+			vexpand = true
+		};
+		box.append (notifications_filter_banner);
+		scrolled.child = box;
+		box.append (content_box);
+	}
+
+	private void on_notifications_filter_banner_button_clicked () {
+		app.main_window.open_view (new Views.NotificationRequests ());
 	}
 
 	public override bool should_hide (Entity entity) {
@@ -45,6 +82,9 @@ public class Tuba.Views.Notifications : Views.Timeline, AccountHolder, Streamabl
 		if (badge_number_binding != null)
 			badge_number_binding.unbind ();
 
+		if (filtered_notifications_count_binding != null)
+			filtered_notifications_count_binding.unbind ();
+
 		badge_number_binding = accounts.active.bind_property (
 			"unread-count",
 			this,
@@ -59,6 +99,19 @@ public class Tuba.Views.Notifications : Views.Timeline, AccountHolder, Streamabl
 				return true;
 			}
 		);
+
+		filtered_notifications_count_binding = accounts.active.bind_property (
+			"filtered-notifications-count",
+			this,
+			"filtered-notifications",
+			BindingFlags.SYNC_CREATE,
+			on_filtered_notifications_count_change
+		);
+	}
+
+	private bool on_filtered_notifications_count_change (Binding binding, Value from_value, ref Value to_value) {
+		to_value.set_int (from_value.get_int ());
+		return true;
 	}
 
 	public override void on_shown () {
@@ -69,6 +122,9 @@ public class Tuba.Views.Notifications : Views.Timeline, AccountHolder, Streamabl
 					? account.last_received_id
 					: account.last_read_id
 			);
+
+			if (account.probably_has_notification_filters)
+				update_filtered_notifications ();
 		}
 	}
 
@@ -77,6 +133,28 @@ public class Tuba.Views.Notifications : Views.Timeline, AccountHolder, Streamabl
 		if (account != null) {
 			account.unread_count = 0;
 		}
+	}
+
+	public void update_filtered_notifications () {
+		new Request.GET ("/api/v1/notifications/policy")
+			.with_account (accounts.active)
+			.then ((in_stream) => {
+				var parser = Network.get_parser_from_inputstream (in_stream);
+				var node = network.parse_node (parser);
+				if (node == null) {
+					accounts.active.filtered_notifications_count = 0;
+					return;
+				};
+
+				var policies = API.NotificationFilter.Policy.from (node);
+				if (policies.summary != null) {
+					accounts.active.filtered_notifications_count = policies.summary.pending_notifications_count;
+				}
+			})
+			.on_error (() => {
+				accounts.active.filtered_notifications_count = 0;
+			})
+			.exec ();
 	}
 
 	public override string? get_stream_url () {

--- a/src/Views/meson.build
+++ b/src/Views/meson.build
@@ -19,6 +19,8 @@ sources += files(
     'Main.vala',
     'MediaViewer.vala',
     'MutesBlocks.vala',
+    'NotificationRequests.vala',
+    'NotificationRequestsList.vala',
     'Notifications.vala',
     'Profile.vala',
     'Search.vala',

--- a/src/Widgets/NotificationRequest.vala
+++ b/src/Widgets/NotificationRequest.vala
@@ -1,0 +1,91 @@
+public class Tuba.Widgets.NotificationRequest : Gtk.ListBoxRow {
+	public signal void dismissed (Request req, API.NotificationFilter.Request api_req);
+	public signal void accepted (Request req, API.NotificationFilter.Request api_req);
+	public Gtk.Box btns_box;
+
+	API.NotificationFilter.Request request;
+	public NotificationRequest (API.NotificationFilter.Request request) {
+		this.request = request;
+
+		var box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 12) {
+			hexpand = true,
+			margin_top = 8,
+			margin_bottom = 8,
+			margin_start = 12,
+			margin_end = 12,
+		};
+
+		var name_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 6) {
+			vexpand = true,
+			valign = Gtk.Align.CENTER
+		};
+
+		var name = new RichLabel () {
+			vexpand = true,
+			use_markup = false,
+			smaller_emoji_pixel_size = true
+		};
+		name.instance_emojis = request.account.emojis_map;
+		name.label = request.account.display_name;
+		name_box.append (name);
+
+		name_box.append (new Gtk.Label (request.account.handle) {
+			single_line_mode = true,
+			xalign = 0.0f,
+			wrap = true,
+			wrap_mode = Pango.WrapMode.WORD_CHAR,
+			css_classes = {"body", "dim-label"},
+			valign = Gtk.Align.CENTER
+		});
+
+		box.append (new Widgets.Avatar () {
+			account = request.account,
+			can_focus = false,
+		});
+		box.append (name_box);
+		box.append (new Gtk.Label (request.notifications_count) {
+			valign = Gtk.Align.CENTER,
+			css_classes = {"notification-badge"}
+		});
+
+		var dismiss_btn = new Gtk.Button () {
+			icon_name = "user-trash-symbolic",
+			valign = Gtk.Align.CENTER,
+			halign = Gtk.Align.CENTER,
+			css_classes = { "flat", "circular", "error" },
+			tooltip_text = _("Dismiss")
+		};
+		dismiss_btn.clicked.connect (on_dismiss);
+
+		var accept_btn = new Gtk.Button () {
+			icon_name = "tuba-check-round-outline-symbolic",
+			valign = Gtk.Align.CENTER,
+			halign = Gtk.Align.CENTER,
+			css_classes = { "flat", "circular", "success" },
+			tooltip_text = _("Accept")
+		};
+		accept_btn.clicked.connect (on_accept);
+
+		btns_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6) {
+			hexpand = true,
+			halign = Gtk.Align.END
+		};
+		btns_box.append (dismiss_btn);
+		btns_box.append (accept_btn);
+		box.append (btns_box);
+
+		this.child = box;
+	}
+
+	public void on_dismiss () {
+		dismissed (new Request.POST (@"/api/v1/notifications/requests/$(request.id)/dismiss").with_account (accounts.active), request);
+	}
+
+	public void on_accept () {
+		accepted (new Request.POST (@"/api/v1/notifications/requests/$(request.id)/accept").with_account (accounts.active), request);
+	}
+
+	public void open () {
+		app.main_window.open_view (new Views.NotificationRequestsList (request.account.id, request.account.handle, this));
+	}
+}

--- a/src/Widgets/Status/FollowRequestRow.vala
+++ b/src/Widgets/Status/FollowRequestRow.vala
@@ -1,6 +1,6 @@
 public class Tuba.Widgets.FollowRequestRow : Gtk.Box {
-	public signal void declined (FollowRequestRow fr_row, Request req);
-	public signal void accepted (FollowRequestRow fr_row, Request req);
+	public signal void declined (Request req);
+	public signal void accepted (Request req);
 
 	public string id { get; set; }
 
@@ -29,11 +29,11 @@ public class Tuba.Widgets.FollowRequestRow : Gtk.Box {
 	}
 
 	void on_decline () {
-		declined (this, new Request.POST (@"/api/v1/follow_requests/$id/reject").with_account (accounts.active));
+		declined (new Request.POST (@"/api/v1/follow_requests/$id/reject").with_account (accounts.active));
 	}
 
 	void on_accept () {
-		accepted (this, new Request.POST (@"/api/v1/follow_requests/$id/authorize").with_account (accounts.active));
+		accepted (new Request.POST (@"/api/v1/follow_requests/$id/authorize").with_account (accounts.active));
 	}
 
 	public FollowRequestRow (string t_id) {

--- a/src/Widgets/meson.build
+++ b/src/Widgets/meson.build
@@ -12,6 +12,7 @@ sources += files(
     'ListBoxRowWrapper.vala',
     'MarkupView.vala',
     'Notification.vala',
+    'NotificationRequest.vala',
     'PreviewCard.vala',
     'ProfileCover.vala',
     'RelationshipButton.vala',


### PR DESCRIPTION
Mastodon 4.3 introduced notification requests / junk. Users set a policy for rejecting notifications, like if the actor is a new account or doesn't follow you etc. and when they send you a notification, it ends up in a dedicated space where you can see them, dismiss them or accept them.

This PR adds the whole feature: Dedicated space for them, approving/declining and policy settings

<hr />

This is undocumented so far, but I did write the spec to keep track of it myself, in case any other fellow fedidevs need it:

# Policy Entity

## Attributes:

- `filter_not_following` : `Bool`

Whether you are filtering people you don't follow

- `filter_not_followers` : `Bool`

Whether you are filtering people that do not follow you

- `filter_new_accounts` : `Bool`

Whether you are filtering accounts created the past 30 days

- `filter_private_mentions` : `Bool`

Whether you are filtering private mentions unless the author is replying to you or you follow them

- `summary` : `SummaryEntity`

Stats of the filter inbox

# Summary Entity

One account can send you multiple filtered notifications, so they don't always match.

## Attributes

- `pending_requests_count` : `Int`

Amount of filter accounts

- `pending_notifications_count` : `Int`

Amount of filtered notifications

# Request Entity

## Attributes:

- `id` : `String`

Request ID

- `created_at` : `String`

DateTime of the request creation

- `updated_at` : `String`

DateTime of the request update (this is not null if the request hasn't been updated, but it will match `created_at`)

- `notifications_count` : `String`

The amount of notifications the request includes (remember, 1 request = 1 user but >= 1 notifications). This is a string cast from an int, e.g. `"2"`

- `account` : `Account`

The account that made the request

- `last_status` : `Status`

I assume this is option but haven't done a thorough test. The last status attached to the request.


# `GET` `/api/v1/notifications/policy`

Call this when you need to check if there's any filtered notifications or get the active policies.

## Returns: `PolicyEntity`

## Example:

```json
{
  "filter_not_following": true,
  "filter_not_followers": true,
  "filter_new_accounts": true,
  "filter_private_mentions": true,
  "summary": {
    "pending_requests_count": 1,
    "pending_notifications_count": 2
  }
}
```

# `PUT` `/api/v1/notifications/policy`

Update policies.

## Returns: `PolicyEntity`

## Params:

- `filter_not_following` : `Bool` [OPTIONAL]

- `filter_not_followers` : `Bool` [OPTIONAL]

- `filter_new_accounts` : `Bool` [OPTIONAL]

- `filter_private_mentions` : `Bool` [OPTIONAL]

## Example:

```json
{
  "filter_not_following": false
}
```

# `GET` `/api/v1/notifications/requests`

Get the 'filtered notifications' inbox aka requests. This is a timeline, so the usual query params are available.

## Returns: `RequestEntity[]`

## Example:

```json
[
  {
    "id": "112537648409652955",
    "created_at": "2024-05-31T20:43:58.699Z",
    "updated_at": "2024-05-31T20:43:58.699Z",
    "notifications_count": "2",
    "account": {
      "id": "112537647853644195",
      "username": "agent1y278390812",
      "acct": "agent1y278390812@mastodon.online",
      "display_name": "agent12973y29138",
      "locked": false,
      "bot": false,
      "discoverable": false,
      "indexable": false,
      "group": false,
      "created_at": "2023-02-17T00:00:00.000Z",
      "note": "",
      "url": "https://mastodon.online/@agent1y278390812",
      "uri": "https://mastodon.online/users/agent1y278390812",
      "avatar": "https://mastodon.social/avatars/original/missing.png",
      "avatar_static": "https://mastodon.social/avatars/original/missing.png",
      "header": "https://mastodon.social/headers/original/missing.png",
      "header_static": "https://mastodon.social/headers/original/missing.png",
      "followers_count": 1,
      "following_count": 2,
      "statuses_count": 10,
      "last_status_at": null,
      "hide_collections": false,
      "emojis": [],
      "fields": []
    },
    "last_status": {
      "id": "112537648329693223",
      "created_at": "2024-05-31T20:43:56.000Z",
      "in_reply_to_id": null,
      "in_reply_to_account_id": null,
      "sensitive": false,
      "spoiler_text": "",
      "visibility": "direct",
      "language": "en",
      "uri": "https://mastodon.online/users/agent1y278390812/statuses/112537648261061944",
      "url": "https://mastodon.online/@agent1y278390812/112537648261061944",
      "replies_count": 0,
      "reblogs_count": 0,
      "favourites_count": 0,
      "edited_at": null,
      "favourited": false,
      "reblogged": false,
      "muted": false,
      "bookmarked": false,
      "content": "<p>hi <span class=\"h-card\" translate=\"no\"><a href=\"https://mastodon.social/@agenthsudabbuwiadn\" class=\"u-url mention\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">@<span>agenthsudabbuwiadn</span></a></span></p>",
      "filtered": [],
      "reblog": null,
      "account": {
        "id": "112537647853644195",
        "username": "agent1y278390812",
        "acct": "agent1y278390812@mastodon.online",
        "display_name": "agent12973y29138",
        "locked": false,
        "bot": false,
        "discoverable": false,
        "indexable": false,
        "group": false,
        "created_at": "2023-02-17T00:00:00.000Z",
        "note": "",
        "url": "https://mastodon.online/@agent1y278390812",
        "uri": "https://mastodon.online/users/agent1y278390812",
        "avatar": "https://mastodon.social/avatars/original/missing.png",
        "avatar_static": "https://mastodon.social/avatars/original/missing.png",
        "header": "https://mastodon.social/headers/original/missing.png",
        "header_static": "https://mastodon.social/headers/original/missing.png",
        "followers_count": 1,
        "following_count": 2,
        "statuses_count": 10,
        "last_status_at": null,
        "hide_collections": false,
        "emojis": [],
        "fields": []
      },
      "media_attachments": [],
      "mentions": [
        {
          "id": "110371061354627964",
          "username": "agenthsudabbuwiadn",
          "url": "https://mastodon.social/@agenthsudabbuwiadn",
          "acct": "agenthsudabbuwiadn"
        }
      ],
      "tags": [],
      "emojis": [],
      "card": null,
      "poll": null
    }
  }
]
```

# `POST` `/api/v1/notifications/requests/<id>/accept`

Accept a request. There's no error if the request has already been accepted.

## Returns: `{}`

## Query Params:

- `id`

The request ID you are accepting.

# `POST` `/api/v1/notifications/requests/<id>/dismiss`

Dismiss a request. There's no error if the request has already been dismissed.

## Returns: `{}`

## Query Params:

- `id`

The request ID you are dismissing.

