### PR TITLE
feat(Composer): goodbye dispose

### DIFF
--- a/src/Dialogs/Composer/AttachmentsPage.vala
+++ b/src/Dialogs/Composer/AttachmentsPage.vala
@@ -199,11 +199,18 @@ public class Tuba.AttachmentsPage : ComposerPage {
 	protected Adw.StatusPage empty_state;
 	protected Gtk.ListBox list;
 	protected Gtk.Button add_media_action_button;
+	protected Gtk.ToggleButton sensitive_media_button;
 
 	public override void dispose () {
 		if (list != null)
 			list.bind_model (null, null);
 		base.dispose ();
+	}
+
+	public override void unbind_listboxes () {
+		if (list != null)
+			list.bind_model (null, null);
+		base.unbind_listboxes ();
 	}
 
 	public override void on_build () {
@@ -240,7 +247,7 @@ public class Tuba.AttachmentsPage : ComposerPage {
 		};
 		add_media_action_button.clicked.connect (show_file_selector);
 
-		var sensitive_media_button = new Gtk.ToggleButton () {
+		sensitive_media_button = new Gtk.ToggleButton () {
 			icon_name = "tuba-eye-open-negative-filled-symbolic",
 			valign = Gtk.Align.CENTER,
 			halign = Gtk.Align.CENTER,
@@ -249,24 +256,8 @@ public class Tuba.AttachmentsPage : ComposerPage {
 			css_classes = {"flat"},
 			active = status.sensitive
 		};
-		sensitive_media_button.bind_property (
-			"active",
-			this,
-			"media_sensitive",
-			GLib.BindingFlags.SYNC_CREATE,
-			(b, src, ref target) => {
-				var sensitive_media_button_active = src.get_boolean ();
-				target.set_boolean (sensitive_media_button_active);
-				sensitive_media_button.icon_name = sensitive_media_button_active
-					? "tuba-eye-not-looking-symbolic"
-					: "tuba-eye-open-negative-filled-symbolic";
-				sensitive_media_button.tooltip_text = sensitive_media_button_active
-					// translators: sensitive as in not safe for work or similar
-					? _("Unmark media as sensitive")
-					: _("Mark media as sensitive");
-				return true;
-			}
-		);
+		sensitive_media_button.toggled.connect (on_sensitive_media_button_toggle);
+		on_sensitive_media_button_toggle ();
 
 		bottom_bar.pack_start (add_media_action_button);
 		bottom_bar.pack_start (sensitive_media_button);
@@ -299,6 +290,18 @@ public class Tuba.AttachmentsPage : ComposerPage {
 		}
 
 		if (dialog != null) dialog.on_paste_activated.connect (on_paste_activated);
+	}
+
+	void on_sensitive_media_button_toggle () {
+		var sensitive_media_button_active = sensitive_media_button.active;
+		this.media_sensitive = sensitive_media_button_active;
+		sensitive_media_button.icon_name = sensitive_media_button_active
+			? "tuba-eye-not-looking-symbolic"
+			: "tuba-eye-open-negative-filled-symbolic";
+		sensitive_media_button.tooltip_text = sensitive_media_button_active
+			// translators: sensitive as in not safe for work or similar
+			? _("Unmark media as sensitive")
+			: _("Mark media as sensitive");
 	}
 
 	void on_paste_activated (string page_title) {

--- a/src/Dialogs/Composer/Dialog.vala
+++ b/src/Dialogs/Composer/Dialog.vala
@@ -361,8 +361,8 @@ public class Tuba.Dialogs.Compose : Adw.Dialog {
 	void on_close () {
 		this.force_close ();
 		foreach (var page in t_pages) {
+			page.unbind_listboxes ();
 			stack.remove (page);
-			page.dispose ();
 		}
 	}
 

--- a/src/Dialogs/Composer/Page.vala
+++ b/src/Dialogs/Composer/Page.vala
@@ -13,6 +13,8 @@ public class Tuba.ComposerPage : Gtk.Box {
 	protected Gtk.Box content;
 	protected Gtk.ActionBar bottom_bar;
 
+	public virtual void unbind_listboxes () {}
+
 	~ComposerPage () {
 		debug (@"Destroying $title Page");
 	}

--- a/src/Dialogs/Composer/PollPage.vala
+++ b/src/Dialogs/Composer/PollPage.vala
@@ -90,6 +90,8 @@ public class Tuba.PollPage : ComposerPage {
 		add_poll_row ();
 	}
 
+	Gtk.ToggleButton sensitive_media_button;
+	Gtk.ToggleButton multi_button;
 	public override void on_build () {
 		base.on_build ();
 
@@ -116,50 +118,25 @@ public class Tuba.PollPage : ComposerPage {
 		};
 		add_poll_action_button.clicked.connect (add_poll_row_without_title);
 
-		var multi_button = new Gtk.ToggleButton () {
+		multi_button = new Gtk.ToggleButton () {
 			icon_name = "radio-checked-symbolic",
 			valign = Gtk.Align.CENTER,
 			halign = Gtk.Align.CENTER,
 			tooltip_text = _("Enable Multiple Choice"),
 			css_classes = {"flat"}
 		};
-		multi_button.bind_property (
-			"active",
-			this,
-			"multiple-choice",
-			GLib.BindingFlags.SYNC_CREATE,
-			(b, src, ref target) => {
-				var multi_button_active = src.get_boolean ();
-				target.set_boolean (multi_button_active);
-				multi_button.icon_name = multi_button_active ? "checkbox-checked-symbolic" : "radio-checked-symbolic";
-				// translators: multiple choice as in allow the user to pick multiple poll options
-				multi_button.tooltip_text = multi_button_active ? _("Disable Multiple Choice") : _("Enable Multiple Choice");
-				return true;
-			}
-		);
+		multi_button.toggled.connect (on_multi_button_toggle);
+		on_multi_button_toggle ();
 
-		var sensitive_media_button = new Gtk.ToggleButton () {
+		sensitive_media_button = new Gtk.ToggleButton () {
 			icon_name = "tuba-eye-open-negative-filled-symbolic",
 			valign = Gtk.Align.CENTER,
 			halign = Gtk.Align.CENTER,
 			tooltip_text = _("Hide Total Votes"),
 			css_classes = {"flat"}
 		};
-		sensitive_media_button.bind_property (
-			"active",
-			this,
-			"hide-totals",
-			GLib.BindingFlags.SYNC_CREATE,
-			(b, src, ref target) => {
-				var sensitive_media_button_active = src.get_boolean ();
-				target.set_boolean (sensitive_media_button_active);
-				sensitive_media_button.icon_name = sensitive_media_button_active
-					? "tuba-eye-not-looking-symbolic"
-					: "tuba-eye-open-negative-filled-symbolic";
-				sensitive_media_button.tooltip_text = sensitive_media_button_active ? _("Show Total Votes") : _("Hide Total Votes");
-				return true;
-			}
-		);
+		sensitive_media_button.toggled.connect (on_sensitive_media_button_toggle);
+		on_sensitive_media_button_toggle ();
 
 		bottom_bar.pack_start (add_poll_action_button);
 		bottom_bar.pack_start (multi_button);
@@ -182,6 +159,23 @@ public class Tuba.PollPage : ComposerPage {
 		bottom_bar.show ();
 	}
 
+	void on_multi_button_toggle () {
+		var multi_button_active = multi_button.active;
+		this.multiple_choice = multi_button_active;
+		multi_button.icon_name = multi_button_active ? "checkbox-checked-symbolic" : "radio-checked-symbolic";
+		// translators: multiple choice as in allow the user to pick multiple poll options
+		multi_button.tooltip_text = multi_button_active ? _("Disable Multiple Choice") : _("Enable Multiple Choice");
+	}
+
+	void on_sensitive_media_button_toggle () {
+		var sensitive_media_button_active = sensitive_media_button.active;
+		this.hide_totals = sensitive_media_button_active;
+		sensitive_media_button.icon_name = sensitive_media_button_active
+					? "tuba-eye-not-looking-symbolic"
+					: "tuba-eye-open-negative-filled-symbolic";
+		sensitive_media_button.tooltip_text = sensitive_media_button_active ? _("Show Total Votes") : _("Hide Total Votes");
+	}
+
 	private void add_poll_row (string? content = null) {
 		var row = new Tuba.PollPage.Poll () {
 			// translators: the variable is a number
@@ -195,13 +189,14 @@ public class Tuba.PollPage : ComposerPage {
 
 		bind_property ("can-delete", row.delete_button, "visible", GLib.BindingFlags.SYNC_CREATE);
 		row.deleted.connect (remove_poll_row);
-		row.bind_property ("is-valid", this, "is-valid", GLib.BindingFlags.SYNC_CREATE, (b, src, ref target) => {
-			target.set_boolean (!check_invalid ());
-
-			return true;
-		});
+		row.notify["is-valid"].connect (on_row_invalid);
+		on_row_invalid ();
 
 		check_poll_items ();
+	}
+
+	private void on_row_invalid () {
+		this.is_valid = !check_invalid ();
 	}
 
 	public bool check_invalid () {


### PR DESCRIPTION
Ages ago, we had to dispose the composer due to an undefined/unfixable memory leak. Some experience on fixing leaks later, we now now that it's lambdas and bind_models. For bind_models, I used the same workaround as timelines - removing all items when its time to clean them aka when the window closes. For lambdas, the typical moving them into their own methods. This time however, using bind_property without lambdas would also leak, so they became notifications.

On #805, tuba would segfault due to libspelling. That was because the user would close the composer while libspelling was finishing a task, and since closing required disposing, the composer page would get disposing along with libspelling before it was done and result into a segfault.

fix: #805