### PR TITLE
fix(profile-cover): remove single field border hack

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -208,7 +208,7 @@ headerbar.flat.no-title .title {
 	border-radius: 9999px;
 }
 
-.ttl-profile-fields-box > flowboxchild > .ttl-profile-field {
+.ttl-profile-fields-box-container:not(.single) > .ttl-profile-fields-box > flowboxchild > .ttl-profile-field {
 	border-bottom: solid 1px @sidebar_border_color;
 	border-right: solid 1px @sidebar_border_color;
 }
@@ -221,8 +221,8 @@ headerbar.flat.no-title .title {
 	border: none;
 }
 
-.ttl-profile-fields-box-container {
-	margin-right: -1px; /* much simplier than complex nth-child selectors */
+.ttl-profile-fields-box-container:not(.single) {
+	margin-right: -1px; /* much simpler than complex nth-child selectors */
 }
 
 .ttl-profile-field {

--- a/src/Widgets/ProfileCover.vala
+++ b/src/Widgets/ProfileCover.vala
@@ -304,6 +304,10 @@ protected class Tuba.Widgets.Cover : Gtk.Box {
 				fields_box_row.add_css_class ("odd");
 			}
 
+			if (total_fields == 1) {
+				fields_box_row.add_css_class ("single");
+			}
+
 			info.append (fields_box_row);
 			app.notify["is-mobile"].connect (update_fields_max_columns);
 		}


### PR DESCRIPTION
on odd amount of fileds, the last item would get a border right. That's was so it wouldn't look like it was expanded on the last row. When there's only a single item however, it should look like expanded

#983 