### PR TITLE
feat(Widgets.Account): reactive relationships

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -46,6 +46,7 @@ namespace Tuba {
 		public Streams app_streams { get {return Tuba.streams; } }
 
 		public signal void refresh ();
+		public signal void relationship_invalidated (API.Relationship new_relationship);
 		public signal void toast (string title, uint timeout = 5);
 
 		#if DEV_MODE

--- a/src/Widgets/Account.vala
+++ b/src/Widgets/Account.vala
@@ -4,7 +4,17 @@ public class Tuba.Widgets.Account : Gtk.ListBoxRow {
 		debug ("Destroying Widgets.Account");
 	}
 
-	public class RelationshipButton : Tuba.Widgets.RelationshipButton {
+	public class RelationshipButton : Widgets.RelationshipButton {
+		construct {
+			app.relationship_invalidated.connect (on_relationship_invalidated_global);
+		}
+
+		private void on_relationship_invalidated_global (API.Relationship new_relationship) {
+			if (rs == null || rs.id != new_relationship.id) return;
+
+			rs = new_relationship;
+		}
+
 		public override void invalidate () {
 			if (rs == null || rs.domain_blocking) {
 				visible = false;

--- a/src/Widgets/ProfileCover.vala
+++ b/src/Widgets/ProfileCover.vala
@@ -377,6 +377,8 @@ protected class Tuba.Widgets.Cover : Gtk.Box {
 		note_row.visible = _mini ? rs.note != "" : rs.note != null;
 		if (note_row.visible) note_entry_row.text = rs.note;
 
+		if (!_mini) app.relationship_invalidated (rs);
+
 		rs_invalidated ();
 		update_aria ();
 	}

--- a/src/Widgets/RelationshipButton.vala
+++ b/src/Widgets/RelationshipButton.vala
@@ -12,6 +12,7 @@ public class Tuba.Widgets.RelationshipButton : Gtk.Button {
 
 	protected void on_bound () {
 		if (rs != null) {
+			rs.invalidated.disconnect (invalidate);
 			rs.invalidated.connect (invalidate);
 		}
 		invalidate ();


### PR DESCRIPTION
fix: #937

The idea is that when the non-mini profile cover invalidates a relationship, the account widget relationship button will update with the new relationship through a global signal from app