### PR TITLE
fix(mv): video offload crash

### DIFF
--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -237,14 +237,18 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 
 					return;
 				} else {
-					((Gtk.Video) child_widget).media_stream.volume = 1.0 - last_used_volume;
-					((Gtk.Video) child_widget).media_stream.volume = last_used_volume;
 					((Gtk.Video) child_widget).media_stream.playing = pre_playing;
-					((Gtk.Video) child_widget).media_stream.notify["volume"].connect (on_manual_volume_change);
 				}
 			};
 			spinner.spinning = false;
 			stack.visible_child_name = "child";
+
+			if (is_video) {
+				((Gtk.Video) child_widget).media_stream.volume = 1.0 - last_used_volume;
+				((Gtk.Video) child_widget).media_stream.volume = last_used_volume;
+				((Gtk.Video) child_widget).media_stream.notify["volume"].connect (on_manual_volume_change);
+			}
+
 			is_done = true;
 		}
 

--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -225,18 +225,34 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 			child_widget.destroy ();
 		}
 
+		ulong media_stream_signal_id = -1;
 		public void done () {
 			if (is_done) return;
 
+			if (is_video) {
+				if (((Gtk.Video) child_widget).media_stream == null) {
+					if (media_stream_signal_id == -1) {
+						media_stream_signal_id = ((Gtk.Video) child_widget).notify["media-stream"].connect (on_received_media_stream);
+					}
+
+					return;
+				} else {
+					((Gtk.Video) child_widget).media_stream.volume = 1.0 - last_used_volume;
+					((Gtk.Video) child_widget).media_stream.volume = last_used_volume;
+					((Gtk.Video) child_widget).media_stream.playing = pre_playing;
+					((Gtk.Video) child_widget).media_stream.notify["volume"].connect (on_manual_volume_change);
+				}
+			};
 			spinner.spinning = false;
 			stack.visible_child_name = "child";
-			if (is_video) {
-				((Gtk.Video) child_widget).media_stream.volume = 1.0 - last_used_volume;
-				((Gtk.Video) child_widget).media_stream.volume = last_used_volume;
-				((Gtk.Video) child_widget).media_stream.playing = pre_playing;
-				((Gtk.Video) child_widget).media_stream.notify["volume"].connect (on_manual_volume_change);
-			};
 			is_done = true;
+		}
+
+		private void on_received_media_stream () {
+			if (((Gtk.Video) child_widget).media_stream != null) {
+				done ();
+				((Gtk.Video) child_widget).disconnect (media_stream_signal_id);
+			}
 		}
 
 		private void on_manual_volume_change () {
@@ -866,9 +882,9 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 			revealer_widgets.set (items.size, revealer_widget);
 
 		if (media_type.is_video ()) {
-			var video = new Gtk.Video ();
-
-			video.graphics_offload = Gtk.GraphicsOffloadEnabled.ENABLED;
+			var video = new Gtk.Video () {
+				graphics_offload = Gtk.GraphicsOffloadEnabled.ENABLED
+			};
 
 			if (media_type == Tuba.Attachment.MediaType.GIFV) {
 				video.loop = true;

--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -229,23 +229,21 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 		public void done () {
 			if (is_done) return;
 
-			if (is_video) {
-				if (((Gtk.Video) child_widget).media_stream == null) {
-					if (media_stream_signal_id == -1) {
-						media_stream_signal_id = ((Gtk.Video) child_widget).notify["media-stream"].connect (on_received_media_stream);
-					}
-
-					return;
-				} else {
-					((Gtk.Video) child_widget).media_stream.playing = pre_playing;
+			if (is_video && ((Gtk.Video) child_widget).media_stream == null) {
+				if (media_stream_signal_id == -1) {
+					media_stream_signal_id = ((Gtk.Video) child_widget).notify["media-stream"].connect (on_received_media_stream);
 				}
+
+				return;
 			};
+
 			spinner.spinning = false;
 			stack.visible_child_name = "child";
 
 			if (is_video) {
 				((Gtk.Video) child_widget).media_stream.volume = 1.0 - last_used_volume;
 				((Gtk.Video) child_widget).media_stream.volume = last_used_volume;
+				((Gtk.Video) child_widget).media_stream.playing = pre_playing;
 				((Gtk.Video) child_widget).media_stream.notify["volume"].connect (on_manual_volume_change);
 			}
 


### PR DESCRIPTION
fix: #1006 

When offload is enabled, media_stream might be null by the time `done` is called. Technically, that shouldn't be the case. `done` is called *after* the video finishes downloads and gets set.

Either way, now if `media_stream` is null, it will listen to its notify signal, and if it becomes non-null it will proceed with the `done` process.

Now there's the following criticals:

```
(dev.geopjr.Tuba:179669): GStreamer-Player-CRITICAL **: 00:09:55.248: gst_player_set_mute: assertion 'GST_IS_PLAYER (self)' failed

(dev.geopjr.Tuba:179669): GStreamer-Player-CRITICAL **: 00:09:55.248: gst_player_set_volume: assertion 'GST_IS_PLAYER (self)' failed

(dev.geopjr.Tuba:179669): GStreamer-Player-CRITICAL **: 00:09:55.248: gst_player_set_mute: assertion 'GST_IS_PLAYER (self)' failed

(dev.geopjr.Tuba:179669): GStreamer-Player-CRITICAL **: 00:09:55.248: gst_player_set_volume: assertion 'GST_IS_PLAYER (self)' failed
```

non-fatal however

edit:

FWIW, it's not `prepared` nor does it become later

edit 2:

Changing the volume before becoming the visible child of the stack, caused the other issue