### PR TITLE
fix(mv): graphics offload crash with stack

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -77,6 +77,7 @@ asresources = gnome.compile_resources(
     c_name: 'as',
 )
 
+gtk_dep = dependency('gtk4', version: '>=4.13.4', required: true)
 libadwaita_dep = dependency('libadwaita-1', version: '>=1.5', required: true)
 gtksourceview_dep = dependency('gtksourceview-5', required: true, version: '>=5.6.0')
 libwebp_dep = dependency('libwebp', required: false)
@@ -98,6 +99,10 @@ if gtksourceview_dep.version().version_compare('>=5.7.1')
   add_project_arguments(['--define=GTKSOURCEVIEW_5_7_1'], language: 'vala')
 endif
 
+if gtk_dep.version().version_compare('>=4.14')
+  add_project_arguments(['--define=GTK_4_14'], language: 'vala')
+endif
+
 sources = files()
 subdir('src')
 
@@ -111,7 +116,7 @@ final_deps = [
   dependency('icu-uc'),
   libspelling,
   gtksourceview_dep,
-  dependency('gtk4', version: '>=4.13.4', required: true),
+  gtk_dep,
   libadwaita_dep,
   meson.get_compiler('c').find_library('m', required: false)
 ]

--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -207,6 +207,11 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 			stack.add_named (setup_scrolledwindow (child), "child");
 			this.url = t_url;
 
+			#if GTK_4_14
+				if (this.is_video)
+					stack.visible_child_name = "child";
+			#endif
+
 			if (paintable != null) overlay.child = new Gtk.Picture.for_paintable (paintable);
 		}
 
@@ -238,7 +243,9 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 			};
 
 			spinner.spinning = false;
-			stack.visible_child_name = "child";
+			#if !GTK_4_14
+				stack.visible_child_name = "child";
+			#endif
 
 			if (is_video) {
 				((Gtk.Video) child_widget).media_stream.volume = 1.0 - last_used_volume;
@@ -885,7 +892,9 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 
 		if (media_type.is_video ()) {
 			var video = new Gtk.Video () {
-				graphics_offload = Gtk.GraphicsOffloadEnabled.ENABLED
+				#if GTK_4_14
+					graphics_offload = Gtk.GraphicsOffloadEnabled.ENABLED
+				#endif
 			};
 
 			if (media_type == Tuba.Attachment.MediaType.GIFV) {


### PR DESCRIPTION
fix: #1006 

Follow up to the last fix. The issue has to do with the stack. For now let's just avoid using it and straight up show the video without the spinner.

Also locked graphics offload behind gtk 4.14