### PR TITLE
fix(Timeline): double content changed calls

### DIFF
--- a/src/Views/TabbedBase.vala
+++ b/src/Views/TabbedBase.vala
@@ -144,25 +144,11 @@ public class Tuba.Views.TabbedBase : Views.Base {
 		on_content_changed ();
 	}
 
-	// TODO: Why did I write this? What does it do??? Why does it crash????
 	public override void on_content_changed () {
-		// var empty = true;
 		foreach_tab (tab => {
-			// tab.visible = !tab.empty;
-			// if (tab.visible)
-			// 	empty = false;
-
 			tab.on_content_changed ();
 		});
 		base_status = null;
-
-		// if (empty) {
-		// 	state = "status";
-		// 	status_title = STATUS_EMPTY;
-		// }
-		// else {
-		// 	state = "content";
-		// }
 	}
 
 	public override void scroll_page (bool up = false) {

--- a/src/Views/Timeline.vala
+++ b/src/Views/Timeline.vala
@@ -217,7 +217,9 @@ public class Tuba.Views.Timeline : AccountHolder, Streamable, Views.ContentBase 
 
 				if (headers != null)
 					get_pages (headers.get_one ("Link"));
-				on_content_changed ();
+
+				if (to_add.length == 0)
+					on_content_changed ();
 				on_request_finish ();
 			})
 			.on_error (on_error)


### PR DESCRIPTION
on_content_changed runs when the content has changed. While it does run when the model's items change, it would also run at the end of requesting a page.

From what I can remember that was so we dealt with empty timelines, aka, when the request ends successfully but the model wasn't changed as there are no items in the timeline.

on_content_changed main use, while virtual, is to change the base status: are there any items? show the timeline, are there no items? show the empty state, is there an error? show the error view. So if it was ran multiple times it wouldnt have any noticeable effect.

But, at some point in 0.7, I added mass relationship requests. Instead of requesting every single account's relationship status, we can now do many at once, thus avoiding spamming the instance. This is done with a container view that overrides on_content_changed, so it requests the new relationships when new items are added/removed.

Since it would be called twice however, that would mean double the mass relationship requests, even though it was useless. So now to avoid the second `on_content_changed`, it only gets called when no items were added to the model.

---

For anyone more interested, yes, there are checks in place to avoid unnecessary mass relationship requests, by checking if accounts had already gotten their relationships. However, since both on_content_changed requests happened right after the other one, the first one didn't get the chance to finish. 