### PR TITLE
fix(advanced-search): mark title as translatable

### DIFF
--- a/data/ui/dialogs/advanced_search.ui
+++ b/data/ui/dialogs/advanced_search.ui
@@ -9,7 +9,7 @@
 		<property name="height_request">200</property>
 		<property name="can-close">False</property>
 		<!-- translators: window title -->
-		<property name="title">Advanced Search</property>
+		<property name="title" translatable="yes">Advanced Search</property>
 
 		<child>
 			<object class="AdwToolbarView">


### PR DESCRIPTION
no need to regen potfile as it was already marked in a different instance