### PR TITLE
feat(InstanceAccount): do not increase the notification counter on excluded types

### DIFF
--- a/src/Services/Accounts/InstanceAccount.vala
+++ b/src/Services/Accounts/InstanceAccount.vala
@@ -629,7 +629,8 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 			if (id > last_received_id) {
 				last_received_id = id;
 
-				unread_count++;
+				if (!(entity.kind in settings.notification_filters))
+					unread_count++;
 				send_toast (entity);
 			}
 		} catch (Error e) {


### PR DESCRIPTION
fix: https://github.com/GeopJr/Tuba/pull/995#issuecomment-2175857425 (partially)

The issues with counting still apply:

> Agreed, though I don't think I can completely get rid of it. The way marking notifications as read works, is by setting a 'marker' to the last read notification. So, while I can avoid increasing the count when Tuba received a filtered notification type, it won't be able to do it if the marker increased while offline. E.g. You make a post and close Tuba. All notification have been read. While offline, you get 10 favourites. When you re-open Tuba the marker will be less than the last notification id, so now there are 10 unread notifications you can't see because they are filtered...

But now, if Tuba, while running, receives an excluded notification, it won't increase the counter.

Internally, it will still count it, as in, it will mark it as read when opening the notifications tab