### PR TITLE
fix(Notifications): update exclusion filters when the account changes

### DIFF
--- a/src/Views/Notifications.vala
+++ b/src/Views/Notifications.vala
@@ -95,6 +95,7 @@ public class Tuba.Views.Notifications : Views.Timeline, AccountHolder, Streamabl
 	}
 
 	public override void on_account_changed (InstanceAccount? acc) {
+		filters_changed (false);
 		base.on_account_changed (acc);
 
 		if (badge_number_binding != null)


### PR DESCRIPTION
Prior to this we only updated the exclusion filters on construct. However when the account changed, it wouldnt update them. It does now.