### PR TITLE
fix(mv): gestures not working always

### DIFF
--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -515,7 +515,7 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 		var gesture = new Gtk.GestureZoom ();
 		gesture.scale_changed.connect (on_scale_changed);
 		gesture.end.connect (on_scale_end);
-		add_controller (gesture);
+		carousel.add_controller (gesture);
 
 		var motion = new Gtk.EventControllerMotion ();
 		motion.motion.connect (on_motion);


### PR DESCRIPTION
Managed to reproduce the pinch to zoom issue somewhat reliably, I think adding the pinch controller directly to the carousel is probably the best solution.