### PR TITLE
feat: v0.8.1

### DIFF
--- a/data/dev.geopjr.Tuba.metainfo.xml.in
+++ b/data/dev.geopjr.Tuba.metainfo.xml.in
@@ -62,6 +62,16 @@
     <control>touch</control>
   </recommends>
   <releases>
+    <release version="0.8.1" date="2024-06-23">
+      <description translate="no">
+        <ul>
+            <li>Added a gsettings options to disable graphics offload</li>
+            <li>Fixed Media Viewer gestures requiring an extra click sometimes to work</li>
+            <li>Fixed Media Viewer images not being marked as loaded</li>
+            <li>Updated translations</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.8.0" date="2024-06-22">
       <description translate="no">
         <ul>

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'dev.geopjr.Tuba',
     ['c', 'vala'],
-    version: '0.8.0',
+    version: '0.8.1',
     meson_version: '>= 0.56.0',
     default_options: [
         'warning_level=2',


### PR DESCRIPTION
```
# Added

- gsettings options to disable graphics offload in runtime, in case it crashes (#1028)

# Fixed

- Media Viewer gestures requiring an extra click sometimes to work (#1030)
- Media Viewer images not being marked as loaded (#1026)

**Full Changelog**: https://github.com/GeopJr/Tuba/compare/v0.8.0...v0.8.1
```