### PR TITLE
fix(Blurhash): fix signed int multiplication overflow

### DIFF
--- a/src/Utils/Blurhash.vala
+++ b/src/Utils/Blurhash.vala
@@ -45,7 +45,7 @@ public class Tuba.Blurhash {
 				}
 				if (index == -1) return 0;
 
-				res = res * 83 + index;
+				res = (int)((uint)res * 83 + index);
 			}
 
 			return res;


### PR DESCRIPTION
when running the test suite with ubsan (-Db_sanitize=undefined):  

```
10/10 Blurhash                        FAIL            0.10s   killed by signal 6 SIGABRT
>>> ASAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1 MSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 UBSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 MALLOC_PERTURB_=35 /home/demon/src/Tuba/out/tests/Blurhash
――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― ✀  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
stdout:
TAP version 13
# random seed: R02S87911a9225926027a2dbd6e02e86ddff
1..4
stderr:
/home/demon/src/Tuba/src/Utils/Blurhash.vala:48:16: runtime error: signed integer overflow: 1190720005 * 83 cannot be represented in type 'int'
    #0 0x62797141f0ee in tuba_blurhash_base83_decode /home/demon/src/Tuba/src/Utils/Blurhash.vala:48:16
    #1 0x62797141b7c9 in test_base83_decode /home/demon/src/Tuba/out/../tests/Blurhash.test.vala:72:11
    #2 0x7b49faba24da in g_test_run_suite_internal (/lib/libglib-2.0.so.0+0x1374da) (BuildId: fc0f54b86ad436c7)
    #3 0x7b49faba04a1 in g_test_run_suite (/lib/libglib-2.0.so.0+0x1354a1) (BuildId: fc0f54b86ad436c7)
    #4 0x7b49faba01a9 in g_test_run (/lib/libglib-2.0.so.0+0x1351a9) (BuildId: fc0f54b86ad436c7)
    #5 0x62797141c4b6 in _vala_main /home/demon/src/Tuba/out/../tests/Blurhash.test.vala:125:11
    #6 0x62797141c4b6 in main /home/demon/src/Tuba/out/../tests/Blurhash.test.vala:118:9

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/demon/src/Tuba/src/Utils/Blurhash.vala:48:16 
```

cast it to make it not-UB
