### PR TITLE
fix(Avatar): drop the popover's padding (#1042)

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -98,10 +98,6 @@ headerbar.flat.no-title .title {
 	background: @dialog_bg_color;
 }
 
-.large .header-image {
-	border-radius: 12px 12px 0 0;
-}
-
 /* Status action icons */
 @keyframes rotate_star {
 	from { -gtk-icon-transform: rotate(-72deg); }
@@ -698,4 +694,8 @@ GtkSourceAssistant row:last-child {
 
 .entry-button:not(:hover):not(:focus-within) > image {
 	opacity: 0.7;
+}
+
+popover.mini-profile > contents {
+	padding: 0;
 }

--- a/data/style.css
+++ b/data/style.css
@@ -98,6 +98,10 @@ headerbar.flat.no-title .title {
 	background: @dialog_bg_color;
 }
 
+.large .header-image {
+	border-radius: 12px 12px 0 0;
+}
+
 /* Status action icons */
 @keyframes rotate_star {
 	from { -gtk-icon-transform: rotate(-72deg); }

--- a/src/Widgets/Avatar.vala
+++ b/src/Widgets/Avatar.vala
@@ -127,6 +127,7 @@ public class Tuba.Widgets.Avatar : Gtk.Button {
 					propagate_natural_height = true
 				}
 			};
+			mini_profile.add_css_class ("mini-profile");
 			mini_profile.set_parent (this);
 			mini_profile.closed.connect (clear_mini);
 		}

--- a/src/Widgets/Avatar.vala
+++ b/src/Widgets/Avatar.vala
@@ -125,9 +125,9 @@ public class Tuba.Widgets.Avatar : Gtk.Button {
 					max_content_height = 500,
 					width_request = 360,
 					propagate_natural_height = true
-				}
+				},
+				css_classes = {"mini-profile"}
 			};
-			mini_profile.add_css_class ("mini-profile");
 			mini_profile.set_parent (this);
 			mini_profile.closed.connect (clear_mini);
 		}


### PR DESCRIPTION
### Before

![Capture d’écran du 2024-06-26 19-27-57](https://github.com/GeopJr/Tuba/assets/2536339/a066f4cd-c866-49a9-b22e-62a30c92dab6)
![Capture d’écran du 2024-06-26 19-28-19](https://github.com/GeopJr/Tuba/assets/2536339/725eb7e0-7599-461d-a9c5-a285c755cd5d)

### After

![Capture d’écran du 2024-06-26 19-28-45](https://github.com/GeopJr/Tuba/assets/2536339/aa1d14a9-6020-4779-b481-de7ab42da8e2)
![Capture d’écran du 2024-06-26 19-28-58](https://github.com/GeopJr/Tuba/assets/2536339/0d889098-7d52-437c-99d7-88d5c969f175)
