### PR TITLE
fix(mini-profile): do not replace style classes

### DIFF
--- a/src/Widgets/Avatar.vala
+++ b/src/Widgets/Avatar.vala
@@ -125,9 +125,9 @@ public class Tuba.Widgets.Avatar : Gtk.Button {
 					max_content_height = 500,
 					width_request = 360,
 					propagate_natural_height = true
-				},
-				css_classes = {"mini-profile"}
+				}
 			};
+			mini_profile.add_css_class ("mini-profile");
 			mini_profile.set_parent (this);
 			mini_profile.closed.connect (clear_mini);
 		}


### PR DESCRIPTION
On #1043 I made a commit on top of the PR to avoid an extra call to add a class. However that ended up replacing the other classes the popover had.

In their infinite knowledge and UX expertise, GitHub decided that comments on reviews can end up as 'Pending' requiring submission. They appear to the author but nobody else :upside_down_face: I ended up merging my changes without ever seeing the additional comments made in that PR.