### PR TITLE
fix(profile-cover): background focus ring

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -91,6 +91,7 @@ headerbar.flat.no-title .title {
 
 .ttl-profile-cover .header-image {
 	background: grey;
+	border-radius: 0;
 }
 
 .ttl-profile-cover avatar, .profile-editor avatar {

--- a/src/Widgets/Background.vala
+++ b/src/Widgets/Background.vala
@@ -8,9 +8,8 @@ public class Tuba.Widgets.Background : Gtk.Button {
 	construct {
 		background = new Gtk.Picture () {
 			content_fit = Gtk.ContentFit.COVER,
-			css_classes = { "header-image" }
 		};
 		child = background;
-		css_classes = { "flat", "image-button", "ttl-flat-button" };
+		css_classes = { "flat", "image-button", "ttl-flat-button", "header-image" };
 	}
 }


### PR DESCRIPTION
On #1043 I noticed that the focus ring style broke. The background has a border radius on large but doesn't on all other sizes. The focus ring should reflect that.