### PR TITLE
fix(mv): set use-graphics-offload to false

### DIFF
--- a/data/dev.geopjr.Tuba.gschema.xml
+++ b/data/dev.geopjr.Tuba.gschema.xml
@@ -104,7 +104,7 @@
 			<default>''</default>
 		</key>
     <key name="use-graphics-offload" type="b">
-			<default>true</default>
+			<default>false</default>
 		</key>
 
 		<key name="window-w" type="i">


### PR DESCRIPTION
fix: #1025 #1048

Graphics offload is awesome but the random segfaults under *some* hardware are just so out of my control that I'd rather disable it for now.

Initially, the issue was the loading stack, but even after removing that, it still crashes on other people's hardware (it fixed it for me).

It's just not worth it. I can't even create a reproducer easily.