### PR TITLE
feat(admin-dashboard): protect admins from illegal media

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -704,3 +704,11 @@ GtkSourceAssistant row:last-child {
 popover.mini-profile > contents {
 	padding: 0;
 }
+
+.report-status .attachment-picture {
+	filter: blur(15px) grayscale(1);
+}
+
+.report-status:hover .attachment-picture {
+	filter: none;
+}

--- a/src/API/Attachment.vala
+++ b/src/API/Attachment.vala
@@ -11,6 +11,7 @@ public class Tuba.API.Attachment : Entity, Widgetizable {
 		get { return (this.t_preview_url == null || this.t_preview_url == "") ? url : t_preview_url; }
 	}
 	public string? tuba_translated_alt_text { get; set; default = null; }
+	public bool tuba_is_report { get; set; default = false; }
 
 	public File? source_file { get; set; }
 

--- a/src/Dialogs/Admin/Report.vala
+++ b/src/Dialogs/Admin/Report.vala
@@ -269,8 +269,16 @@ public class Tuba.Dialogs.Admin.Report : Dialogs.Admin.Base {
 		report.statuses.foreach (status => {
 			try {
 				status.formal.filtered = null;
-				status.formal.spoiler_text = null;
+				status.formal.tuba_spoiler_revealed = true;
+				if (status.formal.has_media) {
+					status.formal.media_attachments.foreach (e => {
+						e.tuba_is_report = true;
+
+						return true;
+					});
+				}
 				Widgets.Status widget = (Widgets.Status) status.to_widget ();
+				widget.add_css_class ("report-status");
 				widget.add_css_class ("card");
 				widget.add_css_class ("card-spacing");
 				widget.actions.visible = false;

--- a/src/Dialogs/Composer/AttachmentsPageAttachment.vala
+++ b/src/Dialogs/Composer/AttachmentsPageAttachment.vala
@@ -35,7 +35,7 @@ public class Tuba.AttachmentsPageAttachment : Widgets.Attachment.Item {
 			pic.file = file;
 		} else {
 			entity = t_entity;
-			Tuba.Helper.Image.request_paintable (t_entity.preview_url, null, on_cache_response);
+			Tuba.Helper.Image.request_paintable (t_entity.preview_url, null, false, on_cache_response);
 		}
 		button.child = pic;
 

--- a/src/Dialogs/Composer/Completion/EmojiProvider.vala
+++ b/src/Dialogs/Composer/Completion/EmojiProvider.vala
@@ -51,7 +51,7 @@ public class Tuba.EmojiProvider: Tuba.CompletionProvider {
 				var image = new Gtk.Image () {
 					pixel_size = 36
 				};
-				Tuba.Helper.Image.request_paintable (emoji.url, null, (paintable) => {
+				Tuba.Helper.Image.request_paintable (emoji.url, null, false, (paintable) => {
 					image.paintable = paintable;
 				});
 				cell.set_widget (image);

--- a/src/Dialogs/Composer/Completion/HandleProvider.vala
+++ b/src/Dialogs/Composer/Completion/HandleProvider.vala
@@ -48,7 +48,7 @@ public class Tuba.HandleProvider: Tuba.CompletionProvider {
 			case GtkSource.CompletionColumn.ICON:
 				var avatar = new Adw.Avatar (36, null, true);
 				avatar.name = account.display_name;
-				Tuba.Helper.Image.request_paintable (account.avatar, null, (paintable) => {
+				Tuba.Helper.Image.request_paintable (account.avatar, null, false, (paintable) => {
 					avatar.custom_image = paintable;
 				});
 				cell.set_widget (avatar);

--- a/src/Dialogs/ProfileEdit.vala
+++ b/src/Dialogs/ProfileEdit.vala
@@ -166,8 +166,8 @@ public class Tuba.Dialogs.ProfileEdit : Adw.Dialog {
 	int64 max_value_length;
 	public ProfileEdit (API.Account acc) {
 		profile = acc;
-		Tuba.Helper.Image.request_paintable (acc.header, null, on_background_cache_response);
-		Tuba.Helper.Image.request_paintable (acc.avatar, null, on_avi_cache_response);
+		Tuba.Helper.Image.request_paintable (acc.header, null, false, on_background_cache_response);
+		Tuba.Helper.Image.request_paintable (acc.avatar, null, false, on_avi_cache_response);
 		avi.text = acc.display_name;
 		name_row.text = acc.display_name;
 		bio_text_view.buffer.text = acc.source == null || acc.source.note == null ? "" : acc.source.note;

--- a/src/Services/Helpers/Image.vala
+++ b/src/Services/Helpers/Image.vala
@@ -59,8 +59,9 @@ public class Tuba.Helper.Image {
 		}
 	}
 
-	private static async Gdk.Paintable? fetch_paintable (string url) {
+	private static async Gdk.Paintable? fetch_paintable (string url, bool disable_cache = false) {
 		var download_msg = new Soup.Message ("GET", url);
+		if (disable_cache) download_msg.disable_feature (typeof (Soup.Cache));
 		try {
 			var in_stream = yield session.send_async (download_msg, 0, null);
 			return yield decode (download_msg, in_stream);
@@ -70,7 +71,7 @@ public class Tuba.Helper.Image {
 		}
 	}
 
-	public static void request_paintable (string? url, string? blurhash, owned OnItemChangedFn cb) {
+	public static void request_paintable (string? url, string? blurhash, bool disable_cache, owned OnItemChangedFn cb) {
 		if (url == null || url == "") return;
 		new Helper.Image ();
 		bool has_loaded = false;
@@ -85,7 +86,7 @@ public class Tuba.Helper.Image {
 			});
 		}
 
-		fetch_paintable.begin (url, (obj, res) => {
+		fetch_paintable.begin (url, disable_cache, (obj, res) => {
 			var result = fetch_paintable.end (res);
 			has_loaded = true;
 			cb (result);

--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -1010,7 +1010,7 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 			if (alt_text != null) picture.alternative_text = alt_text;
 
 			if (!as_is) {
-				Tuba.Helper.Image.request_paintable (url, null, (data) => {
+				Tuba.Helper.Image.request_paintable (url, null, false, (data) => {
 					picture.paintable = data;
 					if (data != null)
 						add_todo_item (item);

--- a/src/Widgets/Account.vala
+++ b/src/Widgets/Account.vala
@@ -194,7 +194,7 @@ public class Tuba.Widgets.Account : Gtk.ListBoxRow {
 		if (account.header.contains ("/headers/original/missing.png")) {
 			background.paintable = avatar.custom_image;
 		} else {
-			Tuba.Helper.Image.request_paintable (account.header, null, on_cache_response);
+			Tuba.Helper.Image.request_paintable (account.header, null, false, on_cache_response);
 		}
 
 		// translators: Used in profile stats.

--- a/src/Widgets/Announcement.vala
+++ b/src/Widgets/Announcement.vala
@@ -224,7 +224,7 @@ public class Tuba.Widgets.Announcement : Gtk.ListBoxRow {
 		handle_label.label = @"@$instance_uri";
 		avatar.text = name_label.label = instance_title;
 		if (instance_title != "") avatar.show_initials = true;
-		if (instance_thumbnail != "") Tuba.Helper.Image.request_paintable (instance_thumbnail, null, on_cache_response);
+		if (instance_thumbnail != "") Tuba.Helper.Image.request_paintable (instance_thumbnail, null, false, on_cache_response);
 
 		reactions = t_announcement.reactions;
 		reactions_count = t_announcement.reactions.size;

--- a/src/Widgets/Attachment/Image.vala
+++ b/src/Widgets/Attachment/Image.vala
@@ -21,7 +21,7 @@ public class Tuba.Widgets.Attachment.Image : Widgets.Attachment.Item {
 	}
 
 	void update_pic_content_fit () {
-		pic.content_fit = settings.letterbox_media ? Gtk.ContentFit.CONTAIN : Gtk.ContentFit.COVER;
+		pic.content_fit = settings.letterbox_media || (entity != null && entity.tuba_is_report) ? Gtk.ContentFit.CONTAIN : Gtk.ContentFit.COVER;
 	}
 
 	construct {
@@ -46,6 +46,7 @@ public class Tuba.Widgets.Attachment.Image : Widgets.Attachment.Item {
 	ulong pic_paintable_id = 0;
 	protected override void on_rebind () {
 		base.on_rebind ();
+		update_pic_content_fit ();
 
 		if (entity == null) {
 			pic.alternative_text = null;
@@ -80,7 +81,7 @@ public class Tuba.Widgets.Attachment.Image : Widgets.Attachment.Item {
 			media_icon.icon_size = Gtk.IconSize.LARGE;
 		}
 
-		Tuba.Helper.Image.request_paintable (entity.preview_url, entity.blurhash, on_cache_response);
+		Tuba.Helper.Image.request_paintable (entity.preview_url, entity.blurhash, (entity != null && entity.tuba_is_report), on_cache_response);
 		copy_media_simple_action.set_enabled (media_kind.can_copy ());
 	}
 

--- a/src/Widgets/Avatar.vala
+++ b/src/Widgets/Avatar.vala
@@ -47,7 +47,7 @@ public class Tuba.Widgets.Avatar : Gtk.Button {
 			_avatar_url = value;
 
 			if (value != null && (!retry_on_network_changes || (retry_on_network_changes && app.is_online))) {
-				Tuba.Helper.Image.request_paintable (value, null, on_cache_response);
+				Tuba.Helper.Image.request_paintable (value, null, false, on_cache_response);
 			}
 		}
 	}

--- a/src/Widgets/BookWyrmPage.vala
+++ b/src/Widgets/BookWyrmPage.vala
@@ -31,7 +31,7 @@ public class Tuba.Widgets.BookWyrmPage : Gtk.Box {
 		title.label = t_obj.title;
 
 		if (t_obj.cover != null && t_obj.cover.url != null && t_obj.cover.url != "") {
-			Tuba.Helper.Image.request_paintable (t_obj.cover.url, null, on_cache_response);
+			Tuba.Helper.Image.request_paintable (t_obj.cover.url, null, false, on_cache_response);
 
 			if (t_obj.cover.name != "") {
 				cover.alternative_text = cover.tooltip_text = t_obj.cover.name;

--- a/src/Widgets/Emoji.vala
+++ b/src/Widgets/Emoji.vala
@@ -27,7 +27,7 @@ public class Tuba.Widgets.Emoji : Adw.Bin {
 
 		var cached_paintable = Tuba.Helper.Image.lookup_cache (emoji_url);
 		if (cached_paintable == null)
-			Tuba.Helper.Image.request_paintable (emoji_url, null, on_cache_response);
+			Tuba.Helper.Image.request_paintable (emoji_url, null, false, on_cache_response);
 		else
 			on_cache_response (cached_paintable);
 	}

--- a/src/Widgets/PreviewCard.vala
+++ b/src/Widgets/PreviewCard.vala
@@ -22,7 +22,7 @@ public class Tuba.Widgets.PreviewCard : Gtk.Button {
 				css_classes = {"preview_card_v"}
 			};
 
-			Tuba.Helper.Image.request_paintable (card_obj.image, card_obj.blurhash, (paintable) => {
+			Tuba.Helper.Image.request_paintable (card_obj.image, card_obj.blurhash, false, (paintable) => {
 				image.paintable = paintable;
 			});
 

--- a/src/Widgets/ProfileCover.vala
+++ b/src/Widgets/ProfileCover.vala
@@ -211,7 +211,7 @@ protected class Tuba.Widgets.Cover : Gtk.Box {
 			background.paintable = avatar.custom_image;
 		} else {
 			header_url = profile.account.header ?? "";
-			Tuba.Helper.Image.request_paintable (profile.account.header, null, on_cache_response);
+			Tuba.Helper.Image.request_paintable (profile.account.header, null, false, on_cache_response);
 
 			if (!mini)
 				background.clicked.connect (open_header_in_media_viewer);


### PR DESCRIPTION
fix: #1034

- Blurs and grayscales media in reports, reveals them on hover
- Letterboxes media despite app settings (admins need to be able to see the whole image)
- Does not remove the spoiler, but instead shows it revealed
- Does not cache media