### PR TITLE
fix(streams): do not url deocde payloads

### DIFF
--- a/src/Services/Network/Streamable.vala
+++ b/src/Services/Network/Streamable.vala
@@ -9,10 +9,8 @@ public abstract interface Tuba.Streamable : Object {
 		}
 
 		public Json.Node get_node () throws Error {
-			var data_str = get_string ();
-			var data = Uri.unescape_string (data_str);
 			var parser = new Json.Parser ();
-			parser.load_from_data (data ?? data_str, -1);
+			parser.load_from_data (get_string (), -1);
 			return parser.steal_root ();
 		}
 


### PR DESCRIPTION
fix: #1056 

Why were they getting url decoded to begin with?