### PR TITLE
fix(MainWindow): check if last_widget is a GtkWidget before using

### DIFF
--- a/src/Dialogs/MainWindow.vala
+++ b/src/Dialogs/MainWindow.vala
@@ -184,7 +184,7 @@ public class Tuba.Dialogs.MainWindow: Adw.ApplicationWindow, Saveable {
 
 	public void on_popped () {
 		var content_base = navigation_view.visible_page.child as Views.Base;
-		if (content_base != null && content_base.last_widget != null && (content_base.last_widget as Gtk.Widget) != null)
+		if (content_base != null && content_base.last_widget != null)
 			content_base.last_widget.grab_focus ();
 		content_base.update_last_widget (true);
 	}

--- a/src/Dialogs/MainWindow.vala
+++ b/src/Dialogs/MainWindow.vala
@@ -186,6 +186,7 @@ public class Tuba.Dialogs.MainWindow: Adw.ApplicationWindow, Saveable {
 		var content_base = navigation_view.visible_page.child as Views.Base;
 		if (content_base != null && content_base.last_widget != null && (content_base.last_widget as Gtk.Widget) != null)
 			content_base.last_widget.grab_focus ();
+		content_base.update_last_widget (true);
 	}
 
 	public bool back () {

--- a/src/Dialogs/MainWindow.vala
+++ b/src/Dialogs/MainWindow.vala
@@ -184,7 +184,8 @@ public class Tuba.Dialogs.MainWindow: Adw.ApplicationWindow, Saveable {
 
 	public void on_popped () {
 		var content_base = navigation_view.visible_page.child as Views.Base;
-		if (content_base != null && content_base.last_widget != null) content_base.last_widget.grab_focus ();
+		if (content_base != null && content_base.last_widget != null && (content_base.last_widget as Gtk.Widget) != null)
+			content_base.last_widget.grab_focus ();
 	}
 
 	public bool back () {

--- a/src/Views/Base.vala
+++ b/src/Views/Base.vala
@@ -13,7 +13,7 @@ public class Tuba.Views.Base : Adw.BreakpointBin {
 	public int badge_number { get; set; default = 0; }
 	public int uid { get; set; default = -1; }
 	protected SimpleActionGroup actions { get; set; default = new SimpleActionGroup (); }
-	public weak Gtk.Widget? last_widget { get; private set; default=null; }
+	public Gtk.Widget? last_widget { get; private set; default=null; }
 	public string empty_timeline_icon { get; set; default="tuba-background-app-ghost-symbolic"; }
 
 	private bool _show_back_button = true;
@@ -210,8 +210,8 @@ public class Tuba.Views.Base : Adw.BreakpointBin {
 		status_button.sensitive = true;
 	}
 
-	public void update_last_widget () {
-		this.last_widget = app.main_window.get_focus ();
+	public void update_last_widget (bool clear = false) {
+		this.last_widget = clear ? null : app.main_window.get_focus ();
 		// Alternative way to grab focus of label links
 		// Currently replaced by RichLabel's activate_link's
 		// grab_focus as it's more reliable for this use case

--- a/src/Views/Base.vala
+++ b/src/Views/Base.vala
@@ -171,7 +171,9 @@ public class Tuba.Views.Base : Adw.BreakpointBin {
 	}
 
 	#if !USE_LISTVIEW
-		public virtual void unbind_listboxes () {}
+		public virtual void unbind_listboxes () {
+			this.last_widget = null;
+		}
 	#endif
 
 	protected virtual void build_actions () {}


### PR DESCRIPTION
~~Turns out that checking if last_widget (weak ref) is null is not enough, we actually have to check if it's also a widget.~~

Turns out that using weak ref at all is segfaulty :shrug: let's just use a normal ref and hope for no memory leaks (couldn't find any in my testing, we do try to clear the ref as often as possible (after the focus has been used, when the model gets cleared))

On my side, that resulted in a CRITICAL, but it turns out it can segfault too

fix: #1059 

<sub>When I'm in a 'why is this happening' competition and my opponent is vala</sub>