### PR TITLE
Revert "fix(mv): set use-graphics-offload to false (#1049)"

### DIFF
--- a/data/dev.geopjr.Tuba.gschema.xml
+++ b/data/dev.geopjr.Tuba.gschema.xml
@@ -104,7 +104,7 @@
 			<default>''</default>
 		</key>
     <key name="use-graphics-offload" type="b">
-			<default>false</default>
+			<default>true</default>
 		</key>
 
 		<key name="window-w" type="i">


### PR DESCRIPTION
The previously observed crashes were most likely all cases of a wrong assert in the GTK offload code that affected multiple apps, fixed in https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/7407

Thus turn on offloading again.

This reverts commit 050f49c0e086eac5d2cac6d630cc63677e6b2f2f.

---

At least https://github.com/GeopJr/Tuba/issues/1025 ran into the assert fixed in the MR above. I've previously been running into the crash as well and tested the commit in this MR for a couple of days without any more problems, so I guess it things should be safe to reenable.