### PR TITLE
feat(mv): enable graphics offload on 4.16

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -113,6 +113,10 @@ if gtk_dep.version().version_compare('>=4.14')
   add_project_arguments(['--define=GTK_4_14'], language: 'vala')
 endif
 
+if gtk_dep.version().version_compare('>=4.16')
+  add_project_arguments(['--define=GTK_4_16'], language: 'vala')
+endif
+
 sources = files()
 subdir('src')
 


### PR DESCRIPTION
Per #1064, graphics offload crashes were fixed upstream and will be available on 4.16. This PR adds a meson check for 4.16 which sets GO to enabled and removes all the hacks we made to fix it on 4.14.

Eventually, when 4.16 releases, anything <4.16 will have GO disabled and use-graphics-offload will be removed.