### PR TITLE
fix(translation): Add context to tracking param string 

### DIFF
--- a/src/Dialogs/Composer/EditorPage.vala
+++ b/src/Dialogs/Composer/EditorPage.vala
@@ -118,7 +118,7 @@ public class Tuba.EditorPage : ComposerPage {
 		editor.buffer.end_user_action ();
 
 		var toast = new Adw.Toast (
-			// Translators: "Stripped" is a past tense verb in this context, not an adjective.
+			// translators: "Stripped" is a past tense verb in this context, not an adjective.
 			_("Stripped tracking parameters")
 		) {
 			timeout = 3,


### PR DESCRIPTION
Just stumbled upon the tracking param stripper in action – thanks for having that! – and noticed that my translation of the string was wrong as I had translated "Stripped" as an adjective rather than as a verb. This PR adds a comment clarifying what to do for translators.