### PR TITLE
fix(mv): clapper: GIFV handling fixes

### DIFF
--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -944,14 +944,6 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 				var video = new ClapperGtk.Video () {
 					auto_inhibit = true
 				};
-				#if CLAPPER_MPRIS
-					var mpris = new Clapper.Mpris (
-						"org.mpris.MediaPlayer2.Tuba",
-						Build.NAME,
-						Build.DOMAIN
-					);
-					video.player.add_feature (mpris);
-				#endif
 				video.player.audio_filter = Gst.ElementFactory.make ("scaletempo", null);
 			#else
 				var video = new Gtk.Video () {
@@ -974,6 +966,13 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 				#endif
 			} else {
 				#if CLAPPER
+					#if CLAPPER_MPRIS
+						video.player.add_feature (new Clapper.Mpris (
+							"org.mpris.MediaPlayer2.Tuba",
+							Build.NAME,
+							Build.DOMAIN
+						));
+					#endif
 					video.add_fading_overlay (new ClapperGtk.SimpleControls () {
 						valign = Gtk.Align.END,
 						fullscreenable = false

--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -958,10 +958,8 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 			if (media_type == Tuba.Attachment.MediaType.GIFV) {
 				#if CLAPPER
 					video.player.queue.progression_mode = Clapper.QueueProgressionMode.REPEAT_ITEM;
-					video.player.autoplay = true;
 				#else
 					video.loop = true;
-					video.autoplay = true;
 				#endif
 			} else {
 				#if CLAPPER

--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -103,10 +103,12 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 				if (!is_video) return;
 				if (is_done) {
 					#if CLAPPER
+						Clapper.Player player = ((ClapperGtk.Video) child_widget).player;
+
 						if (value) {
-							((ClapperGtk.Video) child_widget).player.play ();
-						} else {
-							((ClapperGtk.Video) child_widget).player.pause ();
+							player.play ();
+						} else if (player.state > Clapper.PlayerState.STOPPED) {
+							player.pause ();
 						}
 					#else
 						((Gtk.Video) child_widget).media_stream.playing = value;
@@ -275,14 +277,16 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 
 			if (is_video) {
 				#if CLAPPER
+					Clapper.Player player = ((ClapperGtk.Video) child_widget).player;
+
 					if (pre_playing) {
-						((ClapperGtk.Video) child_widget).player.play ();
-					} else {
-						((ClapperGtk.Video) child_widget).player.pause ();
+						player.play ();
+					} else if (player.state > Clapper.PlayerState.STOPPED) {
+						player.pause ();
 					}
 
-					((ClapperGtk.Video) child_widget).player.volume = last_used_volume;
-					((ClapperGtk.Video) child_widget).player.notify["volume"].connect (on_manual_volume_change);
+					player.volume = last_used_volume;
+					player.notify["volume"].connect (on_manual_volume_change);
 				#else
 					((Gtk.Video) child_widget).media_stream.volume = 1.0 - last_used_volume;
 					((Gtk.Video) child_widget).media_stream.volume = last_used_volume;

--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -944,7 +944,6 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 				var video = new ClapperGtk.Video () {
 					auto_inhibit = true
 				};
-				video.player.audio_filter = Gst.ElementFactory.make ("scaletempo", null);
 			#else
 				var video = new Gtk.Video () {
 					#if GTK_4_16


### PR DESCRIPTION
Some fixes mainly related to handling multiple GIFV in a single post. More info in individual commits descriptions.

---

Ideally, Tuba could be more efficient by creating a single video instance, putting multiple GIFV in Clapper [Queue](https://rafostar.github.io/clapper/doc/clapper/class.Queue.html) and just switching between them (maybe even with overlaid pre-made [NextItemButton](https://rafostar.github.io/clapper/doc/clapper-gtk/class.NextItemButton.html) / [PreviousItemButton](https://rafostar.github.io/clapper/doc/clapper-gtk/class.PreviousItemButton.html)) instead of creating multiple video instances and switching widgets. Unfortunately, this would be probably too much/hard to implement while retaining support for GtkVideo which is the default backend within a single source code file, so for now a few changes working around that to remain compatible :smile: .