### PR TITLE
fix(flatpak): lock libspelling to 0.2.1

### DIFF
--- a/build-aux/dev.geopjr.Tuba.Clapper.json
+++ b/build-aux/dev.geopjr.Tuba.Clapper.json
@@ -46,9 +46,9 @@
             ],
             "sources" : [
                 {
-                    "type" : "git",
-                    "url" : "https://gitlab.gnome.org/GNOME/libspelling.git",
-                    "branch" : "main"
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/GNOME/libspelling.git",
+                    "tag": "0.2.1"
                 }
             ]
         },

--- a/build-aux/dev.geopjr.Tuba.Devel.json
+++ b/build-aux/dev.geopjr.Tuba.Devel.json
@@ -33,9 +33,9 @@
             ],
             "sources" : [
                 {
-                    "type" : "git",
-                    "url" : "https://gitlab.gnome.org/GNOME/libspelling.git",
-                    "branch" : "main"
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/GNOME/libspelling.git",
+                    "tag": "0.2.1"
                 }
             ]
         },


### PR DESCRIPTION
CI has been failing due to libspelling's build config not being able to find gtk, let's see if 0.3.0 fixes it else we will lock to the previous one

edit:

I really need to start reading the changelogs (but to my defense, I didn't expect libspelling to see that big of an update!)

> Currently, libspelling relies on GTK main until 4.15.5 is released
so do keep this in mind if you are a distributor.
