### PR TITLE
feat(search): bold matches

### DIFF
--- a/src/API/Account.vala
+++ b/src/API/Account.vala
@@ -1,5 +1,6 @@
-public class Tuba.API.Account : Entity, Widgetizable {
+public class Tuba.API.Account : Entity, Widgetizable, SearchResult {
 	public API.Relationship? tuba_rs { get; set; default=null; }
+	public string? tuba_search_query { get; set; default = null; }
 
 	public string id { get; set; }
 	public string username { get; set; }

--- a/src/API/Account.vala
+++ b/src/API/Account.vala
@@ -1,6 +1,6 @@
 public class Tuba.API.Account : Entity, Widgetizable, SearchResult {
 	public API.Relationship? tuba_rs { get; set; default=null; }
-	public string? tuba_search_query { get; set; default = null; }
+	public GLib.Regex? tuba_search_query_regex { get; set; default = null; }
 
 	public string id { get; set; }
 	public string username { get; set; }

--- a/src/API/SearchResult.vala
+++ b/src/API/SearchResult.vala
@@ -1,3 +1,3 @@
 public interface Tuba.API.SearchResult : GLib.Object {
-	public abstract string? tuba_search_query { get; set; default = null; }
+	public abstract GLib.Regex? tuba_search_query_regex { get; set; default = null; }
 }

--- a/src/API/SearchResult.vala
+++ b/src/API/SearchResult.vala
@@ -1,0 +1,3 @@
+public interface Tuba.API.SearchResult : GLib.Object {
+	public abstract string? tuba_search_query { get; set; default = null; }
+}

--- a/src/API/Status.vala
+++ b/src/API/Status.vala
@@ -89,7 +89,7 @@ public class Tuba.API.Status : Entity, Widgetizable, SearchResult {
 		}
 	}
 
-	public string? tuba_search_query { get; set; default = null; }
+	public GLib.Regex? tuba_search_query_regex { get; set; default = null; }
 	public Tuba.Views.Thread.ThreadRole tuba_thread_role { get; set; default = Tuba.Views.Thread.ThreadRole.NONE; }
 	public bool tuba_spoiler_revealed { get; set; default = settings.show_spoilers; }
 	public bool tuba_translatable { get; set; default = false; }

--- a/src/API/Status.vala
+++ b/src/API/Status.vala
@@ -1,4 +1,4 @@
-public class Tuba.API.Status : Entity, Widgetizable {
+public class Tuba.API.Status : Entity, Widgetizable, SearchResult {
 
 	~Status () {
 		debug (@"[OBJ] Destroyed $(uri ?? "")");
@@ -89,6 +89,7 @@ public class Tuba.API.Status : Entity, Widgetizable {
 		}
 	}
 
+	public string? tuba_search_query { get; set; default = null; }
 	public Tuba.Views.Thread.ThreadRole tuba_thread_role { get; set; default = Tuba.Views.Thread.ThreadRole.NONE; }
 	public bool tuba_spoiler_revealed { get; set; default = settings.show_spoilers; }
 	public bool tuba_translatable { get; set; default = false; }

--- a/src/API/meson.build
+++ b/src/API/meson.build
@@ -20,6 +20,7 @@ sources += files(
     'Poll.vala',
     'PollOption.vala',
     'Relationship.vala',
+    'SearchResult.vala',
     'SearchResults.vala',
     'Status.vala',
     'Suggestion.vala',

--- a/src/Views/Search.vala
+++ b/src/Views/Search.vala
@@ -124,6 +124,10 @@ public class Tuba.Views.Search : Views.TabbedBase {
 	}
 
 	bool append_entity (Views.ContentBase tab, owned Entity entity) {
+		API.SearchResult search_result_entity = entity as API.SearchResult;
+		if (search_result_entity != null) {
+			search_result_entity.tuba_search_query = this.query;
+		}
 		tab.model.append (entity);
 		return true;
 	}

--- a/src/Widgets/Account.vala
+++ b/src/Widgets/Account.vala
@@ -179,6 +179,7 @@ public class Tuba.Widgets.Account : Gtk.ListBoxRow {
 		display_name.content = account.display_name;
 		handle.label = account.handle;
 		avatar.account = account;
+		note.bold_text = account.tuba_search_query;
 		note.instance_emojis = account.emojis_map;
 		note.content = account.note;
 		cover_bot_badge.visible = account.bot;

--- a/src/Widgets/Account.vala
+++ b/src/Widgets/Account.vala
@@ -179,7 +179,7 @@ public class Tuba.Widgets.Account : Gtk.ListBoxRow {
 		display_name.content = account.display_name;
 		handle.label = account.handle;
 		avatar.account = account;
-		note.bold_text = account.tuba_search_query;
+		note.bold_text_regex = account.tuba_search_query_regex;
 		note.instance_emojis = account.emojis_map;
 		note.content = account.note;
 		cover_bot_badge.visible = account.bot;

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -869,7 +869,7 @@
 		actions.reply.connect (on_reply_button_clicked);
 		content_column.append (actions);
 
-		this.content.bold_text = status.tuba_search_query;
+		this.content.bold_text_regex = status.tuba_search_query_regex;
 		this.content.has_quote = status.formal.quote != null;
 		this.content.mentions = status.formal.mentions;
 		this.content.instance_emojis = status.formal.emojis_map;

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -869,6 +869,7 @@
 		actions.reply.connect (on_reply_button_clicked);
 		content_column.append (actions);
 
+		this.content.bold_text = status.tuba_search_query;
 		this.content.has_quote = status.formal.quote != null;
 		this.content.mentions = status.formal.mentions;
 		this.content.instance_emojis = status.formal.emojis_map;


### PR DESCRIPTION
Let's make search query keywords bold!

![Screenshot from 2024-08-13 00-39-23](https://github.com/user-attachments/assets/fffef812-b965-4551-8bd4-75e6675442cb)

But it's not ready:

![Screenshot from 2024-08-13 00-57-12](https://github.com/user-attachments/assets/9155042a-5619-48d0-b0fe-cd2c50901568)

the above problem is that we need to re-calculate the indexes based on the new text, `this is a test and another test` => `this is a <b>test</b> and another test` at this point the length of the string has changed, and we need to get the next `test`'s index from the new string

Problem being, this can be quite time consuming, might be better to just use regex instead.

Also from the first screenshot we can see that join**mastodon** is marked. 'mastodon' is inside a string and while it showed up, it probably only did because of the account name and not the link. We should probably only take into account words that start with the keyword

`mastodonCats` :heavy_check_mark: 
`meowMastodon` :x:

and lastly, words that are <= 3 characters should probably only count as whole

"foo **to** bar" :heavy_check_mark: 
"**to**mato" :x:

This is a draft, but the foundation has been laid and only the details are left


