### PR TITLE
feat(MainWindow): replace navigation stack when going back to start

### DIFF
--- a/src/Dialogs/MainWindow.vala
+++ b/src/Dialogs/MainWindow.vala
@@ -202,10 +202,7 @@ public class Tuba.Dialogs.MainWindow: Adw.ApplicationWindow, Saveable {
 	}
 
 	public void go_back_to_start () {
-		var navigated = true;
-		while (navigated) {
-			navigated = navigation_view.pop ();
-		}
+		navigation_view.replace ({ main_page });
 		((Views.TabbedBase) main_page.child).change_page_to_named ("1");
 	}
 


### PR DESCRIPTION
Can't remember if there was a reason we popped everything instead of replacing. The current popped signal handler is only used for widget focus wizardy, maybe we should just call on_popped in go_back_to_start?

This removes the back animation
https://gitlab.gnome.org/Teams/Circle/-/issues/193#note_2202009