### PR TITLE
feat(MediaViewer): only add spinner after 1s

### DIFF
--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -211,9 +211,15 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 				css_classes = { "osd", "circular-spinner" }
 			};
 
-			overlay.add_overlay (spinner);
+			GLib.Timeout.add_once (1000, add_spinner_to_overlay);
 			stack.add_named (overlay, "spinner");
 			this.child = stack;
+		}
+
+		private void add_spinner_to_overlay () {
+			if (is_done) return;
+
+			overlay.add_overlay (spinner);
 		}
 
 		public Item (


### PR DESCRIPTION
Only show the per-item spinner after 1s has passed of not being loaded, to avoid it being shown very briefly

The implementation follows the dynamic sidebar one, where instead of trying to tame the race condition, it uses a second guard. In this case, the spinner will only be added after 1s if the item is not done loading, however the code can still change its spinning status regardless.

https://gitlab.gnome.org/Teams/Circle/-/issues/193#note_2202009