### PR TITLE
feat(mv): audio visualizer

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           msystem: mingw64
           update: true
-          install: git make zip wget mingw-w64-x86_64-meson mingw-w64-x86_64-gcc mingw-w64-x86_64-vala mingw-w64-x86_64-libsoup3 mingw-w64-x86_64-libxml2 mingw-w64-x86_64-gtksourceview5 mingw-w64-x86_64-webp-pixbuf-loader mingw-w64-x86_64-libadwaita mingw-w64-x86_64-libgee mingw-w64-x86_64-json-glib mingw-w64-x86_64-libsecret mingw-w64-x86_64-desktop-file-utils mingw-w64-x86_64-imagemagick mingw-w64-x86_64-icu
+          install: git make zip wget mingw-w64-x86_64-meson mingw-w64-x86_64-gcc mingw-w64-x86_64-vala mingw-w64-x86_64-libsoup3 mingw-w64-x86_64-libxml2 mingw-w64-x86_64-gtksourceview5 mingw-w64-x86_64-webp-pixbuf-loader mingw-w64-x86_64-libadwaita mingw-w64-x86_64-libgee mingw-w64-x86_64-json-glib mingw-w64-x86_64-libsecret mingw-w64-x86_64-desktop-file-utils mingw-w64-x86_64-imagemagick mingw-w64-x86_64-icu mingw-w64-x86_64-libspelling mingw-w64-x86_64-gstreamer
       - run: make windows
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           msystem: mingw64
           update: true
-          install: git make zip wget mingw-w64-x86_64-meson mingw-w64-x86_64-gcc mingw-w64-x86_64-vala mingw-w64-x86_64-libsoup3 mingw-w64-x86_64-libxml2 mingw-w64-x86_64-gtksourceview5 mingw-w64-x86_64-webp-pixbuf-loader mingw-w64-x86_64-libadwaita mingw-w64-x86_64-libgee mingw-w64-x86_64-json-glib mingw-w64-x86_64-libsecret mingw-w64-x86_64-desktop-file-utils mingw-w64-x86_64-imagemagick mingw-w64-x86_64-icu mingw-w64-x86_64-libspelling mingw-w64-x86_64-gstreamer
+          install: git make zip wget mingw-w64-x86_64-meson mingw-w64-x86_64-gcc mingw-w64-x86_64-vala mingw-w64-x86_64-libsoup3 mingw-w64-x86_64-libxml2 mingw-w64-x86_64-gtksourceview5 mingw-w64-x86_64-webp-pixbuf-loader mingw-w64-x86_64-libadwaita mingw-w64-x86_64-libgee mingw-w64-x86_64-json-glib mingw-w64-x86_64-libsecret mingw-w64-x86_64-desktop-file-utils mingw-w64-x86_64-imagemagick mingw-w64-x86_64-icu mingw-w64-x86_64-libspelling mingw-w64-x86_64-gstreamer mingw-w64-x86_64-gst-plugins-base mingw-w64-x86_64-gst-plugins-good
       - run: make windows
       - uses: actions/upload-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,13 @@ __windows_copy_deps:
 	cp -f /mingw64/bin/libwebp-7.dll /mingw64/bin/librsvg-2-2.dll /mingw64/bin/libgnutls-30.dll /mingw64/bin/libgthread-2.0-0.dll /mingw64/bin/libgmp-10.dll /mingw64/bin/libproxy-1.dll ${PREFIX}/bin
 	cp -r /mingw64/lib/gio/ $(PREFIX)/lib
 	cp -r /mingw64/lib/gdk-pixbuf-2.0 $(PREFIX)/lib/gdk-pixbuf-2.0
+	cp -r /mingw64/lib/gstreamer-1.0 $(PREFIX)/lib/gstreamer-1.0
 
 	cp -f /mingw64/share/gtksourceview-5/styles/Adwaita.xml /mingw64/share/gtksourceview-5/styles/Adwaita-dark.xml ${PREFIX}/share/gtksourceview-5/styles/
 	cp -f /mingw64/share/gtksourceview-5/language-specs/xml.lang /mingw64/share/gtksourceview-5/language-specs/markdown.lang /mingw64/share/gtksourceview-5/language-specs/html.lang ${PREFIX}/share/gtksourceview-5/language-specs/
 
 	ldd $(PREFIX)/lib/gio/*/*.dll | grep '\/mingw.*\.dll' -o | xargs -I{} cp "{}" $(PREFIX)/bin
+	ldd $(PREFIX)/lib/gstreamer-1.0/*.dll | grep '\/mingw.*\.dll' -o | xargs -I{} cp "{}" $(PREFIX)/bin
 
 __windows_schemas:
 	cp -r /mingw64/share/glib-2.0/schemas/*.xml ${PREFIX}/share/glib-2.0/schemas/

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ __windows_copy_deps:
 
 	ldd $(PREFIX)/lib/gio/*/*.dll | grep '\/mingw.*\.dll' -o | xargs -I{} cp "{}" $(PREFIX)/bin
 	ldd $(PREFIX)/lib/gstreamer-1.0/*.dll | grep '\/mingw.*\.dll' -o | xargs -I{} cp "{}" $(PREFIX)/bin
+	ldd $(PREFIX)/bin/*.dll | grep '\/mingw.*\.dll' -o | xargs -I{} cp "{}" $(PREFIX)/bin
 
 __windows_schemas:
 	cp -r /mingw64/share/glib-2.0/schemas/*.xml ${PREFIX}/share/glib-2.0/schemas/

--- a/data/gresource.xml
+++ b/data/gresource.xml
@@ -86,6 +86,7 @@
         <file>ui/views/sidebar/view.ui</file>
         <file>ui/views/sidebar/account.ui</file>
         <file>ui/views/sidebar/item.ui</file>
+        <file>ui/widgets/audiocontrols.ui</file>
         <file>ui/widgets/bookwyrmpage.ui</file>
         <file>ui/widgets/announcement.ui</file>
         <file>ui/widgets/status.ui</file>

--- a/data/style.css
+++ b/data/style.css
@@ -374,7 +374,7 @@ flowboxchild,
 	padding: 12px;
 }
 
-video > overlay > revealer > controls {
+video > overlay > revealer > controls, .audio-controls {
 	padding: 12px;
 }
 

--- a/data/ui/widgets/audiocontrols.ui
+++ b/data/ui/widgets/audiocontrols.ui
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Taken from https://gitlab.gnome.org/GNOME/gtk/-/blob/074bcd33be7d13ec9425b5ca0926bab9e4571f3f/gtk/ui/gtkmediacontrols.ui -->
+<interface>
+	<object class="GtkAdjustment" id="time_adjustment">
+		<property name="upper">10</property>
+		<property name="step-increment">1</property>
+		<property name="page-increment">10</property>
+	</object>
+	<object class="GtkAdjustment" id="volume_adjustment">
+		<property name="upper">1</property>
+		<property name="step-increment">0.1</property>
+		<property name="page-increment">1</property>
+		<property name="value">1</property>
+		<signal name="value-changed" handler="volume_adjustment_changed" object="TubaWidgetsAudioControls" swapped="no"/>
+	</object>
+	<template class="TubaWidgetsAudioControls" parent="GtkBox">
+		<style>
+			<class name="audio-controls" />
+			<class name="osd" />
+		</style>
+		<!-- <property name="sensitive">0</property> -->
+		<property name="sensitive">1</property>
+		<property name="spacing">6</property>
+		<child>
+			<object class="GtkButton" id="play_button">
+				<property name="receives-default">1</property>
+				<property name="halign">3</property>
+				<property name="valign">3</property>
+				<property name="has-frame">0</property>
+				<property name="icon-name">media-playback-start-symbolic</property>
+				<property name="tooltip-text" context="media controls tooltip" translatable="yes">Play</property>
+				<signal name="clicked" handler="play_button_clicked" object="TubaWidgetsAudioControls" swapped="no"/>
+			</object>
+		</child>
+		<child>
+			<object class="GtkBox" id="time_box">
+				<child>
+					<object class="GtkLabel" id="time_label">
+						<attributes>
+							<attribute name="font-features" value="tnum=1"></attribute>
+						</attributes>
+					</object>
+				</child>
+				<child>
+					<object class="GtkScale" id="seek_scale">
+						<property name="adjustment">time_adjustment</property>
+						<property name="restrict-to-fill-level">0</property>
+						<property name="hexpand">1</property>
+						<accessibility>
+							<property name="label" translatable="yes" context="media controls">Position</property>
+						</accessibility>
+					</object>
+				</child>
+				<child>
+					<object class="GtkLabel" id="duration_label">
+						<attributes>
+							<attribute name="font-features" value="tnum=1"></attribute>
+						</attributes>
+					</object>
+				</child>
+			</object>
+		</child>
+		<child>
+			<object class="GtkVolumeButton" id="volume_button">
+				<property name="adjustment">volume_adjustment</property>
+				<property name="valign">center</property>
+				<accessibility>
+					<property name="label" translatable="yes" context="media controls">Volume</property>
+				</accessibility>
+			</object>
+		</child>
+	</template>
+</interface>

--- a/data/ui/widgets/audiocontrols.ui
+++ b/data/ui/widgets/audiocontrols.ui
@@ -9,7 +9,7 @@
 	<object class="GtkAdjustment" id="volume_adjustment">
 		<property name="upper">1</property>
 		<property name="step-increment">0.1</property>
-		<property name="page-increment">1</property>
+		<property name="page-increment">0.1</property>
 		<property name="value">1</property>
 		<signal name="value-changed" handler="volume_adjustment_changed" object="TubaWidgetsAudioControls" swapped="no"/>
 	</object>

--- a/data/ui/widgets/audiocontrols.ui
+++ b/data/ui/widgets/audiocontrols.ui
@@ -11,7 +11,6 @@
 		<property name="step-increment">0.1</property>
 		<property name="page-increment">0.1</property>
 		<property name="value">1</property>
-		<signal name="value-changed" handler="volume_adjustment_changed" object="TubaWidgetsAudioControls" swapped="no"/>
 	</object>
 	<template class="TubaWidgetsAudioControls" parent="GtkBox">
 		<style>

--- a/meson.build
+++ b/meson.build
@@ -102,6 +102,11 @@ if gtksourceview_dep.version().version_compare('>=5.7.1')
   add_project_arguments(['--define=GTKSOURCEVIEW_5_7_1'], language: 'vala')
 endif
 
+if libadwaita_dep.version().version_compare('>=1.6')
+  add_project_arguments(['--define=ADW_1_6'], language: 'vala')
+endif
+
+
 if clapper_support and clapper_dep.found () and clapper_dep.version().version_compare('>=0.6.0') and clapper_gtk_dep.found ()
   add_project_arguments(['--define=CLAPPER'], language: 'vala')
   if (clapper_dep.get_variable('features').split().contains('mpris'))

--- a/meson.build
+++ b/meson.build
@@ -78,6 +78,7 @@ asresources = gnome.compile_resources(
     c_name: 'as',
 )
 
+gstreamer = false
 gtk_dep = dependency('gtk4', version: '>=4.13.4', required: true)
 libadwaita_dep = dependency('libadwaita-1', version: '>=1.5', required: true)
 gtksourceview_dep = dependency('gtksourceview-5', required: true, version: '>=5.6.0')
@@ -85,6 +86,7 @@ libwebp_dep = dependency('libwebp', required: false)
 libspelling = dependency('libspelling-1', required: false)
 clapper_dep = dependency('clapper-0.0', required: false)
 clapper_gtk_dep = dependency('clapper-gtk-0.0', required: false)
+gstreamer_dep = dependency('gstreamer-1.0', required: false)
 
 if not libwebp_dep.found ()
   warning('WebP support might be missing, please install webp-pixbuf-loader.')
@@ -106,6 +108,10 @@ if libadwaita_dep.version().version_compare('>=1.6')
   add_project_arguments(['--define=ADW_1_6'], language: 'vala')
 endif
 
+if gstreamer_dep.found ()
+  add_project_arguments(['--define=GSTREAMER'], language: 'vala')
+  gstreamer = true
+endif
 
 if clapper_support and clapper_dep.found () and clapper_dep.version().version_compare('>=0.6.0') and clapper_gtk_dep.found ()
   add_project_arguments(['--define=CLAPPER'], language: 'vala')

--- a/meson.build
+++ b/meson.build
@@ -149,7 +149,8 @@ final_deps = [
   libadwaita_dep,
   meson.get_compiler('c').find_library('m', required: false),
   clapper_dep,
-  clapper_gtk_dep
+  clapper_gtk_dep,
+  gstreamer_dep
 ]
 
 executable(

--- a/src/API/Status/PreviewCard.vala
+++ b/src/API/Status/PreviewCard.vala
@@ -208,7 +208,7 @@ public class Tuba.API.PreviewCard : Entity, Widgetizable {
 					Host.open_url (card_url);
 				} else {
 					if (bookwyrm_obj == null) {
-						app.main_window.show_media_viewer (res_url, Tuba.Attachment.MediaType.VIDEO, null, null, false, null, card_url, true);
+						app.main_window.show_media_viewer (res_url, Tuba.Attachment.MediaType.VIDEO, null, null, false, null, card_url, null, true);
 					} else {
 						app.main_window.show_book (bookwyrm_obj, card_url);
 					}

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -169,7 +169,9 @@ namespace Tuba {
 				warning (e.message);
 			}
 
-			Gst.init (ref args);
+			#if GSTREAMER
+				Gst.init (ref args);
+			#endif
 			#if CLAPPER
 				Clapper.init (ref args);
 				GLib.Environment.set_variable ("CLAPPER_USE_PLAYBIN3", "1", false);

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -169,6 +169,7 @@ namespace Tuba {
 				warning (e.message);
 			}
 
+			Gst.init (ref args);
 			#if CLAPPER
 				Clapper.init (ref args);
 				GLib.Environment.set_variable ("CLAPPER_USE_PLAYBIN3", "1", false);

--- a/src/Dialogs/MainWindow.vala
+++ b/src/Dialogs/MainWindow.vala
@@ -100,13 +100,25 @@ public class Tuba.Dialogs.MainWindow: Adw.ApplicationWindow, Saveable {
 		bool as_is = false,
 		string? alt_text = null,
 		string? user_friendly_url = null,
+		string? blurhash = null,
 		bool stream = false,
 		bool? load_and_scroll = null,
 		bool reveal_media_viewer = true
 	) {
 		if (as_is && preview == null) return;
 
-		media_viewer.add_media (url, media_type, preview, as_is, alt_text, user_friendly_url, stream, source_widget, load_and_scroll);
+		media_viewer.add_media (
+			url,
+			media_type,
+			preview,
+			as_is,
+			alt_text,
+			user_friendly_url,
+			blurhash,
+			stream,
+			source_widget,
+			load_and_scroll
+		);
 
 		if (reveal_media_viewer) {
 			media_viewer_source_widget = app.main_window.get_focus ();

--- a/src/Utils/Blurhash.vala
+++ b/src/Utils/Blurhash.vala
@@ -1,7 +1,7 @@
 // Blurhash decoding in pure Vala inspired by
 // https://github.com/woltapp/blurhash and https://github.com/mad-gooze/fast-blurhash/
 public class Tuba.Blurhash {
-	struct AverageColor {
+	public struct AverageColor {
 		int r;
 		int g;
 		int b;
@@ -100,7 +100,7 @@ public class Tuba.Blurhash {
 		return true;
 	}
 
-	private static AverageColor get_blurhash_average_color (string blurhash) {
+	public static AverageColor get_blurhash_average_color (string blurhash) {
 		int val = decode_partial (blurhash, 2, 6);
 		return { val >> 16, (val >> 8) & 255, val & 255 };
 	}

--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -202,6 +202,7 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 			zoom (0.5);
 		}
 
+		uint spinner_timeout = 0;
 		construct {
 			hexpand = true;
 			vexpand = true;
@@ -222,12 +223,13 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 				css_classes = { "osd", "circular-spinner" }
 			};
 
-			GLib.Timeout.add_once (1000, add_spinner_to_overlay);
+			spinner_timeout = GLib.Timeout.add_once (1000, add_spinner_to_overlay);
 			stack.add_named (overlay, "spinner");
 			this.child = stack;
 		}
 
 		private void add_spinner_to_overlay () {
+			spinner_timeout = 0;
 			if (is_done) return;
 
 			overlay.add_overlay (spinner);
@@ -257,6 +259,8 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 
 		~Item () {
 			debug ("Destroying MediaViewer.Item");
+
+			if (spinner_timeout > 0) GLib.Source.remove (spinner_timeout);
 
 			if (is_audio) {
 				#if GSTREAMER

--- a/src/Widgets/Attachment/Box.vala
+++ b/src/Widgets/Attachment/Box.vala
@@ -11,8 +11,10 @@ public class Tuba.Widgets.Attachment.Box : Adw.Bin {
 		}
 	}
 
-	public bool has_thumbnailess_audio { get; private set; default=false; }
-	public Gdk.Paintable? audio_fallback_paintable { get; set; default=null; }
+	#if GSTREAMER
+		public bool has_thumbnailess_audio { get; private set; default=false; }
+		public Gdk.Paintable? audio_fallback_paintable { get; set; default=null; }
+	#endif
 
 	private bool _has_spoiler = false;
 	public bool has_spoiler {
@@ -127,9 +129,11 @@ public class Tuba.Widgets.Attachment.Box : Adw.Bin {
 
 				((Widgets.Attachment.Image) widget).on_any_attachment_click.connect (open_all_attachments);
 
-				if (!this.has_thumbnailess_audio && ((Widgets.Attachment.Image) widget).media_kind == Tuba.Attachment.MediaType.AUDIO) {
-					this.has_thumbnailess_audio = item.blurhash == null || item.blurhash == "" || ((Widgets.Attachment.Image) widget).pic.paintable == null;
-				}
+				#if GSTREAMER
+					if (!this.has_thumbnailess_audio && ((Widgets.Attachment.Image) widget).media_kind == Tuba.Attachment.MediaType.AUDIO) {
+						this.has_thumbnailess_audio = item.blurhash == null || item.blurhash == "" || ((Widgets.Attachment.Image) widget).pic.paintable == null;
+					}
+				#endif
 			} catch (Oopsie e) {
 				warning (@"Error updating attachments: $(e.message)");
 			}
@@ -162,12 +166,14 @@ public class Tuba.Widgets.Attachment.Box : Adw.Bin {
 			var paintable = attachment_widgets[i].pic.paintable;
 			var stream = false;
 
-			if (attachment_widgets[i].media_kind == Tuba.Attachment.MediaType.AUDIO) {
-				if (paintable == null) {
-					paintable = this.audio_fallback_paintable;
+			#if GSTREAMER
+				if (attachment_widgets[i].media_kind == Tuba.Attachment.MediaType.AUDIO) {
+					if (paintable == null) {
+						paintable = this.audio_fallback_paintable;
+					}
+					stream = true;
 				}
-				stream = true;
-			}
+			#endif
 
 			app.main_window.show_media_viewer (
 				attachment_widgets[i].entity.url,

--- a/src/Widgets/Attachment/Box.vala
+++ b/src/Widgets/Attachment/Box.vala
@@ -11,6 +11,9 @@ public class Tuba.Widgets.Attachment.Box : Adw.Bin {
 		}
 	}
 
+	public bool has_thumbnailess_audio { get; private set; default=false; }
+	public Gdk.Paintable? audio_fallback_paintable { get; set; default=null; }
+
 	private bool _has_spoiler = false;
 	public bool has_spoiler {
 		get {
@@ -123,6 +126,10 @@ public class Tuba.Widgets.Attachment.Box : Adw.Bin {
 				}
 
 				((Widgets.Attachment.Image) widget).on_any_attachment_click.connect (open_all_attachments);
+
+				if (!this.has_thumbnailess_audio && ((Widgets.Attachment.Image) widget).media_kind == Tuba.Attachment.MediaType.AUDIO) {
+					this.has_thumbnailess_audio = item.blurhash == null || item.blurhash == "" || ((Widgets.Attachment.Image) widget).pic.paintable == null;
+				}
 			} catch (Oopsie e) {
 				warning (@"Error updating attachments: $(e.message)");
 			}
@@ -152,15 +159,26 @@ public class Tuba.Widgets.Attachment.Box : Adw.Bin {
 			if (attachment_length > 1)
 				is_main = attachment_widgets[i].entity.url == url;
 
+			var paintable = attachment_widgets[i].pic.paintable;
+			var stream = false;
+
+			if (attachment_widgets[i].media_kind == Tuba.Attachment.MediaType.AUDIO) {
+				if (paintable == null) {
+					paintable = this.audio_fallback_paintable;
+				}
+				stream = true;
+			}
+
 			app.main_window.show_media_viewer (
 				attachment_widgets[i].entity.url,
 				attachment_widgets[i].media_kind,
-				attachment_widgets[i].pic.paintable,
+				paintable,
 				attachment_widgets[i],
 				false,
 				attachment_widgets[i].pic.alternative_text,
 				null,
-				false,
+				attachment_widgets[i].entity.blurhash,
+				stream,
 				is_main,
 				is_main == null
 			);

--- a/src/Widgets/AudioPlayer/Controls.vala
+++ b/src/Widgets/AudioPlayer/Controls.vala
@@ -1,10 +1,8 @@
 [GtkTemplate (ui = "/dev/geopjr/Tuba/ui/widgets/audiocontrols.ui")]
 public class Tuba.Widgets.Audio.Controls : Gtk.Box {
 	[GtkChild] unowned Gtk.Adjustment time_adjustment;
-	[GtkChild] unowned Gtk.Adjustment volume_adjustment;
 	[GtkChild] unowned Gtk.Button play_button;
 	[GtkChild] unowned Gtk.Label time_label;
-	[GtkChild] unowned Gtk.Scale seek_scale;
 	[GtkChild] unowned Gtk.Label duration_label;
 	[GtkChild] unowned Gtk.VolumeButton volume_button;
 
@@ -94,12 +92,6 @@ public class Tuba.Widgets.Audio.Controls : Gtk.Box {
 		volume_button.bind_property ("value", this, "volume", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
 		time_adjustment_changed_id = time_adjustment.value_changed.connect (time_adjustment_changed);
 
-	}
-
-	[GtkCallback] private void volume_adjustment_changed () {
-		if (volume_adjustment.value == this.volume) return;
-
-		this.volume = volume_adjustment.value;
 	}
 
 	private void time_adjustment_changed () {

--- a/src/Widgets/AudioPlayer/Controls.vala
+++ b/src/Widgets/AudioPlayer/Controls.vala
@@ -5,10 +5,12 @@ public class Tuba.Widgets.Audio.Controls : Gtk.Box {
 	[GtkChild] unowned Gtk.Label time_label;
 	[GtkChild] unowned Gtk.Label duration_label;
 	[GtkChild] unowned Gtk.VolumeButton volume_button;
+	[GtkChild] unowned Gtk.Box time_box;
 
 	public signal void state_button_clicked ();
 	public double volume { get; set; default=1.0; }
 	public double progress { get; set; default=0.0; }
+	public bool ready { get; set; default=false; }
 
 	private bool _playing = false;
 	public bool playing {
@@ -92,6 +94,7 @@ public class Tuba.Widgets.Audio.Controls : Gtk.Box {
 		volume_button.bind_property ("value", this, "volume", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
 		time_adjustment_changed_id = time_adjustment.value_changed.connect (time_adjustment_changed);
 
+		this.bind_property ("ready", time_box, "sensitive", BindingFlags.SYNC_CREATE);
 	}
 
 	private void time_adjustment_changed () {

--- a/src/Widgets/AudioPlayer/Controls.vala
+++ b/src/Widgets/AudioPlayer/Controls.vala
@@ -1,0 +1,118 @@
+[GtkTemplate (ui = "/dev/geopjr/Tuba/ui/widgets/audiocontrols.ui")]
+public class Tuba.Widgets.Audio.Controls : Gtk.Box {
+	[GtkChild] unowned Gtk.Adjustment time_adjustment;
+	[GtkChild] unowned Gtk.Adjustment volume_adjustment;
+	[GtkChild] unowned Gtk.Button play_button;
+	[GtkChild] unowned Gtk.Label time_label;
+	[GtkChild] unowned Gtk.Scale seek_scale;
+	[GtkChild] unowned Gtk.Label duration_label;
+	[GtkChild] unowned Gtk.VolumeButton volume_button;
+
+	public signal void state_button_clicked ();
+	public double volume { get; set; default=1.0; }
+	public double progress { get; set; default=0.0; }
+
+	private bool _playing = false;
+	public bool playing {
+		get { return _playing; }
+		set {
+			if (value) {
+				play_button.icon_name = "media-playback-pause-symbolic";
+				// translators: Media play bar play button tooltip
+				play_button.tooltip_text = _("Stop");
+			} else {
+				play_button.icon_name = "media-playback-start-symbolic";
+				// translators: Media play bar play button tooltip
+				play_button.tooltip_text = _("Play");
+			}
+
+			_playing = value;
+		}
+	}
+
+	private int64 _duration = 0;
+	public int64 duration {
+		get {
+			return _duration;
+		}
+		set {
+			_duration = value;
+			duration_label.label = nanoseconds_to_string (value);
+			update_scale ();
+		}
+	}
+
+	private int64 _current = 0;
+	public int64 current {
+		get {
+			return _current;
+		}
+		set {
+			int64 safe_val = int64.min (value, _duration);
+			_current = safe_val;
+			time_label.label = nanoseconds_to_string (safe_val);
+			update_scale ();
+		}
+	}
+
+	private string nanoseconds_to_string (int64 nanoseconds) {
+		double seconds_total = (double) nanoseconds / (1000 * 1000 * 1000);
+
+		int seconds = (int) (seconds_total % 60);
+		int minutes = (int) ((seconds_total / 60) % 60);
+		int hours = (int) ((seconds_total / (60 * 60)) % 24);
+
+		string seconds_prefix = seconds > 9 ? "" : "0";
+		string minutes_prefix = minutes > 9 ? "" : "0";
+		string hours_s = hours > 0 ? @"$hours:" : "";
+
+		return @"$hours_s$minutes_prefix$minutes:$seconds_prefix$seconds";
+	}
+
+	private void update_scale () {
+		if (this.duration == 0) return;
+
+		GLib.SignalHandler.block (time_adjustment, time_adjustment_changed_id);
+		time_adjustment.value = (double)this.current / (double)this.duration * 10;
+		GLib.SignalHandler.unblock (time_adjustment, time_adjustment_changed_id);
+	}
+
+	public void update_playing_button (bool playing) {
+		if (playing) {
+			play_button.icon_name = "media-playback-pause-symbolic";
+			// translators: Media play bar play button tooltip
+			play_button.tooltip_text = _("Stop");
+		} else {
+			play_button.icon_name = "media-playback-start-symbolic";
+			// translators: Media play bar play button tooltip
+			play_button.tooltip_text = _("Play");
+		}
+	}
+
+	ulong time_adjustment_changed_id;
+	construct {
+		volume_button.bind_property ("value", this, "volume", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
+		time_adjustment_changed_id = time_adjustment.value_changed.connect (time_adjustment_changed);
+
+	}
+
+	[GtkCallback] private void volume_adjustment_changed () {
+		if (volume_adjustment.value == this.volume) return;
+
+		this.volume = volume_adjustment.value;
+	}
+
+	private void time_adjustment_changed () {
+		if (time_adjustment.value == this.progress) return;
+
+		this.progress = time_adjustment.value;
+	}
+
+	[GtkCallback] private void play_button_clicked () {
+		this.playing = !this.playing;
+	}
+
+	~Controls () {
+		debug ("Destroying AudioControls");
+	}
+}

--- a/src/Widgets/AudioPlayer/Player.vala
+++ b/src/Widgets/AudioPlayer/Player.vala
@@ -2,6 +2,7 @@ public class Tuba.Widgets.Audio.Player : Adw.Bin {
 	Audio.Stream player;
 	Gtk.Overlay overlay;
 	Audio.Visualizer visualizer;
+	Gtk.Revealer controls_revealer;
 
 	public string url {
 		get { return player.url; }
@@ -41,7 +42,13 @@ public class Tuba.Widgets.Audio.Player : Adw.Bin {
 		controls.bind_property ("volume", this, "volume", BindingFlags.SYNC_CREATE);
 		controls.bind_property ("progress", this, "progress", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
 		controls.bind_property ("playing", this, "playing", BindingFlags.BIDIRECTIONAL);
-		overlay.add_overlay (controls);
+
+		controls_revealer = new Gtk.Revealer () {
+			child = controls,
+			transition_type = Gtk.RevealerTransitionType.NONE,
+			valign = Gtk.Align.END
+		};
+		overlay.add_overlay (controls_revealer);
 
 		player.bind_property ("current", controls, "current", BindingFlags.SYNC_CREATE);
 		player.bind_property ("duration", controls, "duration", BindingFlags.SYNC_CREATE);
@@ -54,19 +61,78 @@ public class Tuba.Widgets.Audio.Player : Adw.Bin {
 		this.playing = false;
 	}
 
+	bool should_hide_controls = true;
+	protected void on_leave () {
+		should_hide_controls = false;
+	}
+
+	double on_motion_last_x = 0.0;
+	double on_motion_last_y = 0.0;
+	protected void on_motion (double x, double y) {
+		if (on_motion_last_x == x && on_motion_last_y == y) return;
+		should_hide_controls = true;
+
+		on_motion_last_x = x;
+		on_motion_last_y = y;
+
+		on_reveal_media_buttons ();
+	}
+
+	uint revealer_timeout = 0;
+	private void on_reveal_media_buttons () {
+		controls_revealer.set_reveal_child (true);
+		if (revealer_timeout > 0) GLib.Source.remove (revealer_timeout);
+		revealer_timeout = Timeout.add (5 * 1000, on_hide_media_buttons, Priority.LOW);
+	}
+
+	private bool on_hide_media_buttons () {
+		revealer_timeout = 0;
+		if (should_hide_controls) controls_revealer.set_reveal_child (false);
+
+		return GLib.Source.REMOVE;
+	}
+
+	protected void on_click_gesture () {
+		if (controls_revealer.reveal_child) {
+			controls_revealer.reveal_child = false;
+			revealer_timeout = 0;
+		} else {
+			on_reveal_media_buttons ();
+		}
+	}
+
 	public Player (Gdk.Texture? texture = null, string? blurhash = null) {
 		visualizer = new Audio.Visualizer (texture, blurhash) {
 			vexpand = true,
 			hexpand = true
 		};
 
+		var motion = new Gtk.EventControllerMotion () {
+			propagation_phase = Gtk.PropagationPhase.BUBBLE
+		};
+		motion.motion.connect (on_motion);
+		motion.leave.connect (on_leave);
+		visualizer.add_controller (motion);
+
+		var click_gesture = new Gtk.GestureClick () {
+			button = Gdk.BUTTON_PRIMARY,
+			propagation_phase = Gtk.PropagationPhase.BUBBLE
+		};
+		click_gesture.released.connect (on_click_gesture);
+		this.add_controller (click_gesture);
+
 		player.bind_property ("level", visualizer, "level", BindingFlags.SYNC_CREATE);
 		overlay.child = visualizer;
+	}
+
+	public override void unmap () {
+		if (revealer_timeout > 0) GLib.Source.remove (revealer_timeout);
+
+		base.unmap ();
 	}
 
 	~Player () {
 		debug ("Destroying AudioPlayer");
 		player.destroy ();
-		//  visualizer.set_draw_func (null);
 	}
 }

--- a/src/Widgets/AudioPlayer/Player.vala
+++ b/src/Widgets/AudioPlayer/Player.vala
@@ -1,0 +1,72 @@
+public class Tuba.Widgets.Audio.Player : Adw.Bin {
+	Audio.Stream player;
+	Gtk.Overlay overlay;
+	Audio.Visualizer visualizer;
+
+	public string url {
+		get { return player.url; }
+		set { player.url = value; }
+	}
+
+	private bool _playing = false;
+	public bool playing {
+		get { return _playing; }
+		set {
+			_playing = value;
+			player.state = value ? Gst.State.PLAYING : Gst.State.PAUSED;
+		}
+	}
+
+	public double volume { get; set; default=1.0; }
+	public double progress { get; set; default=0.0; }
+
+	public bool muted {
+		get { return volume == 0.0; }
+	}
+
+	construct {
+		overlay = new Gtk.Overlay () {
+			vexpand = true,
+			hexpand = true
+		};
+
+		player = new Audio.Stream ();
+		this.bind_property ("volume", player, "volume", BindingFlags.SYNC_CREATE);
+		this.bind_property ("progress", player, "progress", BindingFlags.SYNC_CREATE);
+
+		var controls = new Widgets.Audio.Controls () {
+			hexpand = true,
+			valign = Gtk.Align.END
+		};
+		controls.bind_property ("volume", this, "volume", BindingFlags.SYNC_CREATE);
+		controls.bind_property ("progress", this, "progress", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
+		controls.bind_property ("playing", this, "playing", BindingFlags.BIDIRECTIONAL);
+		overlay.add_overlay (controls);
+
+		player.bind_property ("current", controls, "current", BindingFlags.SYNC_CREATE);
+		player.bind_property ("duration", controls, "duration", BindingFlags.SYNC_CREATE);
+		player.ended.connect (on_ended);
+
+		this.child = overlay;
+	}
+
+	private void on_ended () {
+		this.playing = false;
+	}
+
+	public Player (Gdk.Texture? texture = null, string? blurhash = null) {
+		visualizer = new Audio.Visualizer (texture, blurhash) {
+			vexpand = true,
+			hexpand = true
+		};
+
+		player.bind_property ("level", visualizer, "level", BindingFlags.SYNC_CREATE);
+		overlay.child = visualizer;
+	}
+
+	~Player () {
+		debug ("Destroying AudioPlayer");
+		player.destroy ();
+		//  visualizer.set_draw_func (null);
+	}
+}

--- a/src/Widgets/AudioPlayer/Player.vala
+++ b/src/Widgets/AudioPlayer/Player.vala
@@ -20,6 +20,7 @@ public class Tuba.Widgets.Audio.Player : Adw.Bin {
 
 	public double volume { get; set; default=1.0; }
 	public double progress { get; set; default=0.0; }
+	public bool ready { get; set; default=false; }
 
 	public bool muted {
 		get { return volume == 0.0; }
@@ -42,6 +43,7 @@ public class Tuba.Widgets.Audio.Player : Adw.Bin {
 		controls.bind_property ("volume", this, "volume", BindingFlags.SYNC_CREATE);
 		controls.bind_property ("progress", this, "progress", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
 		controls.bind_property ("playing", this, "playing", BindingFlags.BIDIRECTIONAL);
+		controls.bind_property ("ready", this, "ready", BindingFlags.SYNC_CREATE);
 
 		controls_revealer = new Gtk.Revealer () {
 			child = controls,
@@ -52,6 +54,7 @@ public class Tuba.Widgets.Audio.Player : Adw.Bin {
 
 		player.bind_property ("current", controls, "current", BindingFlags.SYNC_CREATE);
 		player.bind_property ("duration", controls, "duration", BindingFlags.SYNC_CREATE);
+		player.bind_property ("ready", this, "ready", BindingFlags.SYNC_CREATE);
 		player.ended.connect (on_ended);
 
 		this.child = overlay;

--- a/src/Widgets/AudioPlayer/Player.vala
+++ b/src/Widgets/AudioPlayer/Player.vala
@@ -123,6 +123,8 @@ public class Tuba.Widgets.Audio.Player : Adw.Bin {
 
 		player.bind_property ("level", visualizer, "level", BindingFlags.SYNC_CREATE);
 		overlay.child = visualizer;
+
+		on_reveal_media_buttons ();
 	}
 
 	public override void unmap () {

--- a/src/Widgets/AudioPlayer/Player.vala
+++ b/src/Widgets/AudioPlayer/Player.vala
@@ -119,7 +119,7 @@ public class Tuba.Widgets.Audio.Player : Adw.Bin {
 			propagation_phase = Gtk.PropagationPhase.BUBBLE
 		};
 		click_gesture.released.connect (on_click_gesture);
-		this.add_controller (click_gesture);
+		visualizer.add_controller (click_gesture);
 
 		player.bind_property ("level", visualizer, "level", BindingFlags.SYNC_CREATE);
 		overlay.child = visualizer;

--- a/src/Widgets/AudioPlayer/Stream.vala
+++ b/src/Widgets/AudioPlayer/Stream.vala
@@ -10,6 +10,7 @@ public class Tuba.Widgets.Audio.Stream : GLib.Object {
 	public double level { get; private set; default=0.0; }
 	public double volume { get; set; default=1.0; }
 	public bool muted { get; set; default=false; }
+	public bool ready { get; private set; default=false; }
 
 	public double progress {
 		set {
@@ -63,6 +64,7 @@ public class Tuba.Widgets.Audio.Stream : GLib.Object {
 			break;
 		case Gst.MessageType.STATE_CHANGED:
 			message.parse_state_changed (null, out _state, null);
+			if (!ready && (_state == Gst.State.READY || _state == Gst.State.PLAYING)) this.ready = true;
 			break;
 		case Gst.MessageType.ELEMENT:
 			unowned Gst.Structure s = message.get_structure ();

--- a/src/Widgets/AudioPlayer/Stream.vala
+++ b/src/Widgets/AudioPlayer/Stream.vala
@@ -1,0 +1,155 @@
+// Smoothing function adapted from https://gitlab.gnome.org/GNOME/gnome-control-center/-/blob/ea8bafc5d1ebb945a0806b03dea0c3abf29c58d9/panels/sound/cc-level-bar.c
+
+public class Tuba.Widgets.Audio.Stream : GLib.Object {
+	const double SMOOTHING = 0.3;
+	Gst.Bin pipeline;
+	Gst.Bus bus;
+	Gst.Element uridecodebin;
+
+	public signal void ended ();
+	public double level { get; private set; default=0.0; }
+	public double volume { get; set; default=1.0; }
+	public bool muted { get; set; default=false; }
+
+	public double progress {
+		set {
+			pipeline.seek_simple (Gst.Format.TIME, Gst.SeekFlags.FLUSH | Gst.SeekFlags.KEY_UNIT, (int64) (value / 10 * duration));
+			update_metadata ();
+		}
+	}
+
+	public int64 duration { get; private set; default=0; }
+	public int64 current { get; private set; default=0; }
+
+	private string _url = "";
+	public string url {
+		get {
+			return _url;
+		}
+		set {
+			_url = value;
+			uridecodebin.set_property ("uri", value);
+		}
+	}
+
+	private Gst.State _state = Gst.State.NULL;
+	public Gst.State state {
+		get { return _state; }
+		set {
+			pipeline.set_state (value);
+		}
+	}
+
+	private bool update_metadata () {
+		if (bus == null) return false;
+		if (this.state < Gst.State.PAUSED) return true;
+		update_current ();
+
+		return true;
+	}
+
+	private bool bus_callback (Gst.Bus bus, Gst.Message message) {
+		switch (message.type) {
+		case Gst.MessageType.ERROR:
+			GLib.Error err;
+			string debug_log;
+			message.parse_error (out err, out debug_log);
+			critical (@"Gst Error: $(err.message)");
+			debug (@"Gst Error Debug: $debug_log");
+			break;
+		case Gst.MessageType.EOS:
+			pipeline.seek_simple (Gst.Format.TIME, Gst.SeekFlags.FLUSH, 0);
+			ended ();
+			break;
+		case Gst.MessageType.STATE_CHANGED:
+			message.parse_state_changed (null, out _state, null);
+			break;
+		case Gst.MessageType.ELEMENT:
+			unowned Gst.Structure s = message.get_structure ();
+
+			if (s != null && s.get_name () == "level") {
+				unowned GLib.Value peaks = s.get_value ("peak");
+				unowned GLib.ValueArray value_array = (GLib.ValueArray) peaks.get_boxed ();
+
+				double level_sum = 0;
+				foreach (var val in value_array) {
+				  level_sum += val.get_double ();
+				}
+
+				var levels = Math.pow (10, (level_sum / value_array.n_values) / 20);
+				level = (levels * SMOOTHING) + (level * (1.0 - SMOOTHING));
+			}
+			break;
+		case Gst.MessageType.ASYNC_DONE:
+			if (this.duration == 0) {
+				update_duration ();
+			}
+			break;
+		case Gst.MessageType.DURATION_CHANGED:
+			update_duration ();
+			break;
+		default:
+			break;
+		}
+
+		return true;
+	}
+
+	private void update_duration () {
+		int64 t_duration = 0;
+		if (!pipeline.query_duration (Gst.Format.TIME, out t_duration)) {
+			debug (@"Couldn't get duration of $url");
+			return;
+		}
+		if (t_duration != this.duration) this.duration = t_duration;
+	}
+
+	private void update_current () {
+		int64 t_current = 0;
+		if (!pipeline.query_position (Gst.Format.TIME, out t_current)) {
+			debug (@"Couldn't get current position of $url");
+			return;
+		}
+		if (t_current != this.current) this.current = t_current;
+	}
+
+	uint timeout_id = -1;
+	construct {
+		string pipestr = "uridecodebin name=uridecodebin ! audioconvert ! audio/x-raw,channels=2 ! volume name=volume ! level name=level interval=75000000 ! autoaudiosink name=sink";
+		try {
+			pipeline = (Gst.Bin) Gst.parse_launch (pipestr);
+			uridecodebin = pipeline.get_by_name ("uridecodebin");
+
+			var volume = pipeline.get_by_name ("volume");
+			this.bind_property ("volume", volume, "volume", BindingFlags.SYNC_CREATE);
+			//  this.bind_property ("muted", volume, "muted", BindingFlags.SYNC_CREATE);
+
+			var level = pipeline.get_by_name ("level");
+			level.set_property ("post-messages", true);
+
+			var sink = pipeline.get_by_name ("sink");
+			sink.set_property ("sync", true);
+
+			bus = pipeline.get_bus ();
+			bus.add_watch (0, bus_callback);
+
+			timeout_id = GLib.Timeout.add_seconds (1, update_metadata);
+		} catch (Error e) {
+			critical (@"Error while constructing pipeline: $(e.message)");
+		}
+	}
+
+	// Without disconnecting everything
+	// it leaks.
+	public void destroy () {
+		if (timeout_id > 0) GLib.Source.remove (timeout_id);
+		bus.remove_watch ();
+		bus = null;
+		this.state = Gst.State.NULL;
+		pipeline = null;
+	}
+
+	~Stream () {
+		debug ("Destroying AudioStream");
+	}
+}

--- a/src/Widgets/AudioPlayer/Visualizer.vala
+++ b/src/Widgets/AudioPlayer/Visualizer.vala
@@ -1,6 +1,9 @@
 public class Tuba.Widgets.Audio.Visualizer : Gtk.Widget {
-	Cairo.Context context;
 	const float SQR = 256;
+	const int MAX_CIRCLE_HEIGHT = 512;
+	const float ALPHA = 0.5f;
+
+	Cairo.Context context;
 	Gdk.RGBA color;
 	Gdk.Texture cover_texture;
 
@@ -28,7 +31,7 @@ public class Tuba.Widgets.Audio.Visualizer : Gtk.Widget {
 				avg.r / 255.0f,
 				avg.g / 255.0f,
 				avg.b / 255.0f,
-				0.8f
+				ALPHA
 			};
 
 			if (0.2126f * color.red + 0.7152f * color.green + 0.0722f * color.blue < 0.156862745f) {
@@ -38,12 +41,12 @@ public class Tuba.Widgets.Audio.Visualizer : Gtk.Widget {
 			}
 		} else {
 			// TODO: ADW 1.6 StyleManager accent-color
-			color = {
-				120 / 255.0f,
-				174 / 255.0f,
-				237 / 255.0f,
+				color = {
+					120 / 255.0f,
+					174 / 255.0f,
+					237 / 255.0f,
 				0.8f
-			};
+				};
 		}
 
 		cover_texture = texture;
@@ -59,7 +62,7 @@ public class Tuba.Widgets.Audio.Visualizer : Gtk.Widget {
 		var point = Graphene.Point ().init (new_center_w, new_center_h);
 		snapshot.translate (point);
 
-		float res = (float) level * (win_h - SQR) + SQR;
+		float res = (float) level * (int.min (MAX_CIRCLE_HEIGHT, win_h) - SQR) + SQR;
 
         var rect = Graphene.Rect ().init (- res / 2, - res / 2, res, res);
         var rounded_rect = Gsk.RoundedRect ().init_from_rect (rect, 9999);
@@ -70,7 +73,7 @@ public class Tuba.Widgets.Audio.Visualizer : Gtk.Widget {
 
 		if (cover_texture != null) {
 			var cover_rect = Graphene.Rect ().init (- SQR / 2, - SQR / 2, SQR, SQR);
-			var rounded_cover_rect = Gsk.RoundedRect ().init_from_rect (cover_rect, 9999);
+			var rounded_cover_rect = Gsk.RoundedRect ().init_from_rect (cover_rect, SQR);
 
         	snapshot.push_rounded_clip (rounded_cover_rect);
     		snapshot.append_texture (cover_texture, cover_rect);

--- a/src/Widgets/AudioPlayer/Visualizer.vala
+++ b/src/Widgets/AudioPlayer/Visualizer.vala
@@ -40,17 +40,28 @@ public class Tuba.Widgets.Audio.Visualizer : Gtk.Widget {
 			    color.blue = float.min (1, color.blue + 0.3f);
 			}
 		} else {
-			// TODO: ADW 1.6 StyleManager accent-color
+			#if ADW_1_6
+				Adw.StyleManager.get_default ().notify["accent-color-rgba"].connect (update_accent_color);
+				update_accent_color ();
+			#else
 				color = {
 					120 / 255.0f,
 					174 / 255.0f,
 					237 / 255.0f,
-				0.8f
+					ALPHA
 				};
+			#endif
 		}
 
 		cover_texture = texture;
 	}
+
+	#if ADW_1_6
+		private void update_accent_color () {
+			color = Adw.StyleManager.get_default ().accent_color_rgba;
+			color.alpha = ALPHA;
+		}
+	#endif
 
 	public override void snapshot (Gtk.Snapshot snapshot) {
 		int win_w = this.get_width ();

--- a/src/Widgets/AudioPlayer/Visualizer.vala
+++ b/src/Widgets/AudioPlayer/Visualizer.vala
@@ -1,6 +1,6 @@
 public class Tuba.Widgets.Audio.Visualizer : Gtk.Widget {
 	const float SQR = 256;
-	const int MAX_CIRCLE_HEIGHT = 512;
+	const int MAX_CIRCLE_HEIGHT = 800;
 	const float ALPHA = 0.5f;
 
 	Cairo.Context context;

--- a/src/Widgets/AudioPlayer/Visualizer.vala
+++ b/src/Widgets/AudioPlayer/Visualizer.vala
@@ -1,0 +1,84 @@
+public class Tuba.Widgets.Audio.Visualizer : Gtk.Widget {
+	Cairo.Context context;
+	const float SQR = 256;
+	Gdk.RGBA color;
+	Gdk.Texture cover_texture;
+
+	double _level = 0.0;
+	public double level {
+		get { return _level; }
+		set {
+			_level = value;
+			this.queue_draw ();
+		}
+	}
+
+	construct {
+		vexpand = true;
+		hexpand = true;
+	}
+
+	public Visualizer (Gdk.Texture? texture = null, string? blurhash = null) {
+		Cairo.ImageSurface surface = new Cairo.ImageSurface (Cairo.Format.ARGB32, (int)SQR, (int)SQR);
+		context = new Cairo.Context (surface);
+
+		if (blurhash != null && blurhash != "") {
+			var avg = Tuba.Blurhash.get_blurhash_average_color (blurhash);
+			color = {
+				avg.r / 255.0f,
+				avg.g / 255.0f,
+				avg.b / 255.0f,
+				0.8f
+			};
+
+			if (0.2126f * color.red + 0.7152f * color.green + 0.0722f * color.blue < 0.156862745f) {
+			    color.red = float.min (1, color.red + 0.3f);
+			    color.green = float.min (1, color.green + 0.3f);
+			    color.blue = float.min (1, color.blue + 0.3f);
+			}
+		} else {
+			// TODO: ADW 1.6 StyleManager accent-color
+			color = {
+				120 / 255.0f,
+				174 / 255.0f,
+				237 / 255.0f,
+				0.8f
+			};
+		}
+
+		cover_texture = texture;
+	}
+
+	public override void snapshot (Gtk.Snapshot snapshot) {
+		int win_w = this.get_width ();
+		int win_h = this.get_height ();
+
+		int new_center_w = win_w / 2;
+		int new_center_h = win_h / 2;
+
+		var point = Graphene.Point ().init (new_center_w, new_center_h);
+		snapshot.translate (point);
+
+		float res = (float) level * (win_h - SQR) + SQR;
+
+        var rect = Graphene.Rect ().init (- res / 2, - res / 2, res, res);
+        var rounded_rect = Gsk.RoundedRect ().init_from_rect (rect, 9999);
+
+        snapshot.push_rounded_clip (rounded_rect);
+        snapshot.append_color (color, rect);
+        snapshot.pop ();
+
+		if (cover_texture != null) {
+			var cover_rect = Graphene.Rect ().init (- SQR / 2, - SQR / 2, SQR, SQR);
+			var rounded_cover_rect = Gsk.RoundedRect ().init_from_rect (cover_rect, 9999);
+
+        	snapshot.push_rounded_clip (rounded_cover_rect);
+    		snapshot.append_texture (cover_texture, cover_rect);
+        	snapshot.pop ();
+		}
+	}
+
+	~Visualizer () {
+		debug ("Destroying AudioVisualizer");
+	}
+}

--- a/src/Widgets/AudioPlayer/meson.build
+++ b/src/Widgets/AudioPlayer/meson.build
@@ -1,0 +1,6 @@
+sources += files(
+    'Controls.vala',
+    'Player.vala',
+    'Stream.vala',
+    'Visualizer.vala',
+)

--- a/src/Widgets/Avatar.vala
+++ b/src/Widgets/Avatar.vala
@@ -90,6 +90,7 @@ public class Tuba.Widgets.Avatar : Gtk.Button {
 
 	void on_cache_response (Gdk.Paintable? data) {
 		avatar.custom_image = data;
+		this.notify_property ("custom-image");
 	}
 
 	private void on_network_change () {

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -973,6 +973,11 @@
 			attachments = new Widgets.Attachment.Box ();
 			attachments.has_spoiler = status.formal.sensitive;
 			attachments.list = status.formal.media_attachments;
+
+			if (attachments != null && attachments.has_thumbnailess_audio) {
+				bindings += avatar.bind_property ("custom-image", attachments, "audio-fallback-paintable", BindingFlags.SYNC_CREATE);
+			}
+
 			content_box.append (attachments);
 		}
 

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -974,9 +974,11 @@
 			attachments.has_spoiler = status.formal.sensitive;
 			attachments.list = status.formal.media_attachments;
 
-			if (attachments != null && attachments.has_thumbnailess_audio) {
-				bindings += avatar.bind_property ("custom-image", attachments, "audio-fallback-paintable", BindingFlags.SYNC_CREATE);
-			}
+			#if GSTREAMER
+				if (attachments != null && attachments.has_thumbnailess_audio) {
+					bindings += avatar.bind_property ("custom-image", attachments, "audio-fallback-paintable", BindingFlags.SYNC_CREATE);
+				}
+			#endif
 
 			content_box.append (attachments);
 		}

--- a/src/Widgets/meson.build
+++ b/src/Widgets/meson.build
@@ -27,5 +27,9 @@ sources += files(
 
 subdir('Admin')
 subdir('Attachment')
-subdir('AudioPlayer')
+
+if gstreamer
+  subdir('AudioPlayer')
+endif
+
 subdir('Status')

--- a/src/Widgets/meson.build
+++ b/src/Widgets/meson.build
@@ -27,4 +27,5 @@ sources += files(
 
 subdir('Admin')
 subdir('Attachment')
+subdir('AudioPlayer')
 subdir('Status')


### PR DESCRIPTION
I learnt more about gstreamer than I thought I would going into this...

Okay so, audio visualizer. Originally used cairo but converted it to snapshots because getting paintables into an imagesurface is more complicated than expected


If there's a thumbnail, it uses it + its blurhash to get the average color and themes the visualizer accordingly. If the color is too dark, it lightens it up.

https://github.com/user-attachments/assets/da4d77c8-96ce-4923-a5f6-490f5846a340

If there's no thumbnail, it will attempt to use the author's avi. I decided to go with accent color for the visualizer. With adw 1.6 we can get the custom ones too.

https://github.com/user-attachments/assets/5415a5ab-9d5c-4bc9-9aa9-b794a2d5b980



TODO:

- [x] hide controls on non-movement
- [x] leak test
- [x] test mv on multi-format media
- [x] flatpak + meson for gstreamer
- [x] adw 1.6 accent on non-thumbnail
- [x] fix any deprecation warnings if possible
- [x] keyboard shortcuts
- [x] volume slider adjustment feels too large?
- [x] insensitive until ready?