### PR TITLE
feat: mute expiration and notifications policy

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -663,6 +663,7 @@ namespace Tuba {
 				{ _("Yes"), Adw.ResponseAppearance.DEFAULT },
 				{ _("Cancel"), Adw.ResponseAppearance.DEFAULT }
 			},
+			Gtk.Widget? child = null,
 			bool skip = false // skip the dialog, used for preferences to avoid duplicate code
 		) {
 			if (skip) return QuestionAnswer.YES;
@@ -674,6 +675,8 @@ namespace Tuba {
 
 			dlg.heading_use_markup = title.use_markup;
 			if (msg != null) dlg.body_use_markup = msg.use_markup;
+
+			if (child != null) dlg.extra_child = child;
 
 			dlg.add_response ("no", buttons.no.label);
 			dlg.set_response_appearance ("no", buttons.no.appearance);

--- a/src/Dialogs/Composer/Dialog.vala
+++ b/src/Dialogs/Composer/Dialog.vala
@@ -206,6 +206,7 @@ public class Tuba.Dialogs.Compose : Adw.Dialog {
 				{_("Your progress will be lost."), false},
 				this,
 				{ { _("Discard"), Adw.ResponseAppearance.DESTRUCTIVE }, { _("Cancel"), Adw.ResponseAppearance.DEFAULT } },
+				null,
 				false,
 				(obj, res) => {
 					if (app.question.end (res).truthy ()) on_close ();

--- a/src/Dialogs/Preferences.vala
+++ b/src/Dialogs/Preferences.vala
@@ -79,6 +79,7 @@ public class Tuba.Dialogs.Preferences : Adw.PreferencesDialog {
 				null,
 				this.win,
 				{ { _("Delete"), Adw.ResponseAppearance.DESTRUCTIVE }, { _("Cancel"), Adw.ResponseAppearance.DEFAULT } },
+				null,
 				false,
 				(obj, res) => {
 					if (app.question.end (res).truthy ()) {

--- a/src/Dialogs/Report.vala
+++ b/src/Dialogs/Report.vala
@@ -331,6 +331,7 @@ public class Tuba.Dialogs.Report : Adw.Dialog {
 				null,
 				this,
 				{ { _("Submit"), Adw.ResponseAppearance.SUGGESTED }, { _("Cancel"), Adw.ResponseAppearance.DEFAULT } },
+				null,
 				false,
 				(obj, res) => {
 					if (app.question.end (res).truthy ()) {

--- a/src/Services/Accounts/SecretAccountStore.vala
+++ b/src/Services/Accounts/SecretAccountStore.vala
@@ -52,6 +52,7 @@ public class Tuba.SecretAccountStore : AccountStore {
 				{@"$help_msg.", false},
 				app.add_account_window,
 				{ {"Read More", Adw.ResponseAppearance.SUGGESTED }, { "Close", Adw.ResponseAppearance.DEFAULT } },
+				null,
 				false,
 				(obj, res) => {
 					if (app.question.end (res).truthy ()) Host.open_url (wiki_page);

--- a/src/Views/Lists.vala
+++ b/src/Views/Lists.vala
@@ -58,6 +58,7 @@ public class Tuba.Views.Lists : Views.Timeline {
 				{_("This action cannot be reverted."), false},
 				app.main_window,
 				{ { _("Delete"), Adw.ResponseAppearance.DESTRUCTIVE }, { _("Cancel"), Adw.ResponseAppearance.DEFAULT } },
+				null,
 				false,
 				(obj, res) => {
 					if (app.question.end (res).truthy ()) {

--- a/src/Views/Profile.vala
+++ b/src/Views/Profile.vala
@@ -220,7 +220,7 @@ public class Tuba.Views.Profile : Views.Accounts {
 
 		notify_on_new_post_action = new SimpleAction.stateful ("notify_on_post", null, false);
 		notify_on_new_post_action.change_state.connect (v => {
-			profile.rs.modify ("follow", "notify", v.get_boolean ().to_string ());
+			profile.rs.modify ("follow", {{"notify", v.get_boolean ().to_string ()}});
 			invalidate_actions (false);
 		});
 		actions.add_action (notify_on_new_post_action);
@@ -272,7 +272,11 @@ public class Tuba.Views.Profile : Views.Accounts {
 		muting_action = new SimpleAction.stateful ("muting", null, false);
 		muting_action.change_state.connect (v => {
 			var state = v.get_boolean ();
-			profile.rs.modify (state ? "mute" : "unmute");
+			if (state) {
+				profile.rs.question_modify_mute (profile.account.handle);
+			} else {
+				profile.rs.modify ("unmute");
+			}
 		});
 		actions.add_action (muting_action);
 
@@ -284,7 +288,7 @@ public class Tuba.Views.Profile : Views.Accounts {
 			}
 
 			var state = !v.get_boolean ();
-			profile.rs.modify ("follow", "reblogs", state.to_string ());
+			profile.rs.modify ("follow", {{"reblogs", state.to_string ()}});
 		});
 		actions.add_action (hiding_reblogs_action);
 
@@ -305,6 +309,7 @@ public class Tuba.Views.Profile : Views.Accounts {
 
 				app.main_window,
 				{ { block ? _("Block") : _("Unblock"), Adw.ResponseAppearance.DESTRUCTIVE }, { _("Cancel"), Adw.ResponseAppearance.DEFAULT } },
+				null,
 				false,
 				(obj, res) => {
 					if (app.question.end (res).truthy ()) {

--- a/src/Views/Sidebar.vala
+++ b/src/Views/Sidebar.vala
@@ -307,6 +307,7 @@ public class Tuba.Views.Sidebar : Gtk.Widget, AccountHolder {
 				{_("This account will be removed from the application."), false},
 				app.main_window,
 				{ { _("Forget"), Adw.ResponseAppearance.DESTRUCTIVE }, { _("Cancel"), Adw.ResponseAppearance.DEFAULT } },
+				null,
 				false,
 				(obj, res) => {
 					if (app.question.end (res).truthy ()) {

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -400,6 +400,7 @@
 			null,
 			app.main_window,
 			{ { _("Delete"), Adw.ResponseAppearance.DESTRUCTIVE }, { _("Cancel"), Adw.ResponseAppearance.DEFAULT } },
+			null,
 			false,
 			(obj, res) => {
 				if (app.question.end (res).truthy ()) {

--- a/src/Widgets/Status/ActionsRow.vala
+++ b/src/Widgets/Status/ActionsRow.vala
@@ -153,6 +153,7 @@ public class Tuba.Widgets.ActionsRow : Gtk.Box {
 				{_("You can still reply, but it may no longer be relevant."), false},
 				app.main_window,
 				{ { _("Reply"), Adw.ResponseAppearance.SUGGESTED }, { _("Don't remind me again"), Adw.ResponseAppearance.DEFAULT } },
+				null,
 				false,
 				(obj, res) => {
 					if (app.question.end (res) == Tuba.Application.QuestionAnswer.NO) {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/92881f20-f2b0-404c-a7c5-23a3c498cbb5)

This required some internal API changes:

- Question API gained a `child` field for setting its extra-child
- Relationship modify API now accepts arrays of param-value items instead of a single param and a single value
