### PR TITLE
feat(ScaleRevealer): finish crossfade early

### DIFF
--- a/src/Widgets/ScaleRevealer.vala
+++ b/src/Widgets/ScaleRevealer.vala
@@ -138,12 +138,9 @@ public class Tuba.Widgets.ScaleRevealer : Adw.Bin {
 			warning ("The source widget texture is None, using child snapshot as fallback");
 			this.snapshot_child (this.child, snapshot);
 		} else {
-			if (progress > 0.0) {
-				if (progress > 0.3) {
-					this.snapshot_child (this.child, snapshot);
-					return;
-				}
-
+			if (progress > 0.3) {
+				this.snapshot_child (this.child, snapshot);
+			} else if (progress > 0.0) {
 				snapshot.push_cross_fade (progress);
 				source_widget_texture.snapshot (
 					snapshot,
@@ -154,7 +151,7 @@ public class Tuba.Widgets.ScaleRevealer : Adw.Bin {
 
 				this.snapshot_child (this.child, snapshot);
 				snapshot.pop ();
-			} else if (progress <= 0.0) {
+			} else {
 				source_widget_texture.snapshot (
 					snapshot,
 					this.get_width (),

--- a/src/Widgets/ScaleRevealer.vala
+++ b/src/Widgets/ScaleRevealer.vala
@@ -139,7 +139,7 @@ public class Tuba.Widgets.ScaleRevealer : Adw.Bin {
 			this.snapshot_child (this.child, snapshot);
 		} else {
 			if (progress > 0.0) {
-				snapshot.push_cross_fade (progress);
+				snapshot.push_cross_fade (progress > 0.2 ? 1.0 : progress);
 				source_widget_texture.snapshot (
 					snapshot,
 					this.get_width (),

--- a/src/Widgets/ScaleRevealer.vala
+++ b/src/Widgets/ScaleRevealer.vala
@@ -75,7 +75,7 @@ public class Tuba.Widgets.ScaleRevealer : Adw.Bin {
 	construct {
 		var target = new Adw.CallbackAnimationTarget (animation_target_cb);
 		animation = new Adw.TimedAnimation (this, 0.0, 1.0, ANIMATION_DURATION, target) {
-			easing = Adw.Easing.EASE_OUT_QUART
+			easing = Adw.Easing.EASE_IN_OUT_QUART
 		};
 		animation.done.connect (on_animation_end);
 
@@ -139,7 +139,12 @@ public class Tuba.Widgets.ScaleRevealer : Adw.Bin {
 			this.snapshot_child (this.child, snapshot);
 		} else {
 			if (progress > 0.0) {
-				snapshot.push_cross_fade (progress > 0.2 ? 1.0 : progress);
+				if (progress > 0.3) {
+					this.snapshot_child (this.child, snapshot);
+					return;
+				}
+
+				snapshot.push_cross_fade (progress);
 				source_widget_texture.snapshot (
 					snapshot,
 					this.get_width (),


### PR DESCRIPTION
fix: #1122 ?

Previously the transition would crossfade between the source widget (attachment) and the target one (mediaviewer) relatively to the transition progress. That creates a seamless transition between them. However as shown on #1122, it also creates an unintended effect around the middle point.

For context, the media viewer's black background's opacity is also relative to the animation.

This PR changes it so as long as the animation progress is over 20%, it won't crossfade. This still looks a bit off, maybe just to me because I've seen it in slow mode.

Another idea would be to make the media viewer's background's opacity get darker sooner so the distorted snapshot of the attachment is not that visible?

whichever the path forward might be, this PR can be optimized further so it's a draft. (we can skip snapshoting the source on over 20% since the fade effect is done).