### PR TITLE
fix(visualizer): stream not getting destroyed in time

### DIFF
--- a/src/Widgets/AudioPlayer/Player.vala
+++ b/src/Widgets/AudioPlayer/Player.vala
@@ -134,10 +134,10 @@ public class Tuba.Widgets.Audio.Player : Adw.Bin {
 		if (revealer_timeout > 0) GLib.Source.remove (revealer_timeout);
 
 		base.unmap ();
+		player.destroy ();
 	}
 
 	~Player () {
 		debug ("Destroying AudioPlayer");
-		player.destroy ();
 	}
 }


### PR DESCRIPTION
Couldn't reproduce reliably so this is guesswork, but sometimes audio would still play even though the player was destroyed for a few seconds. I suspect that this is because the stream gets destroyed after the player.