### PR TITLE
fix(visualizer): position getting updated on pause

### DIFF
--- a/src/Widgets/AudioPlayer/Stream.vala
+++ b/src/Widgets/AudioPlayer/Stream.vala
@@ -43,7 +43,7 @@ public class Tuba.Widgets.Audio.Stream : GLib.Object {
 
 	private bool update_metadata () {
 		if (bus == null) return false;
-		if (this.state < Gst.State.PAUSED) return true;
+		if (this.state <= Gst.State.PAUSED) return true;
 		update_current ();
 
 		return true;


### PR DESCRIPTION
When pausing, sometimes the position would move to the next step, let's not update the position when paused.