### PR TITLE
feat(preferences): remove options

### DIFF
--- a/data/dev.geopjr.Tuba.gschema.xml
+++ b/data/dev.geopjr.Tuba.gschema.xml
@@ -28,9 +28,6 @@
 		<key name="active-account" type="s">
 			<default>''</default>
 		</key>
-		<key name="color-scheme" enum="dev.geopjr.Tuba.ColorScheme">
-			<default>'system'</default>
-		</key>
 		<key name="work-in-background" type="b">
 			<default>false</default>
 		</key>
@@ -46,16 +43,10 @@
 		<key name="show-spoilers" type="b">
 			<default>false</default>
 		</key>
-		<key name="show-preview-cards" type="b">
-			<default>true</default>
-		</key>
 		<key name="larger-font-size" type="b">
 			<default>false</default>
 		</key>
 		<key name="larger-line-height" type="b">
-			<default>false</default>
-		</key>
-		<key name="scale-emoji-hover" type="b">
 			<default>false</default>
 		</key>
 		<key name="aggressive-resolving" type="b">
@@ -67,14 +58,8 @@
 		<key name="letterbox-media" type="b">
 			<default>false</default>
 		</key>
-		<key name="media-viewer-expand-pictures" type="b">
-			<default>true</default>
-		</key>
 		<key name="enlarge-custom-emojis" type="b">
 			<default>false</default>
-		</key>
-		<key name="use-blurhash" type="b">
-			<default>true</default>
 		</key>
 		<key name="group-push-notifications" type="b">
 			<default>false</default>

--- a/data/style.css
+++ b/data/style.css
@@ -415,11 +415,11 @@ video > overlay > revealer > controls, .audio-controls {
 .theme-autism.about .app-version{background:linear-gradient(to bottom,#e5304355,#e5304355 16.66%,#f6834755 16.66%,#f6834755 33.33%,#fac85755 33.33%,#fac85755 66.67%,#99d67155 66.67%,#99d67155 83.33%,#21ae7555 83.33%,#21ae7555);}
 .theme-autism.about .app-version:hover{background:linear-gradient(to bottom,#e53043,#e53043 16.66%,#f68347 16.66%,#f68347 33.33%,#fac857 33.33%,#fac857 66.67%,#99d671 66.67%,#99d671 83.33%,#21ae75 83.33%,#21ae75);}
 
-.lww-scale-emoji-hover .lww-emoji {
+.lww-emoji {
 	transition-duration: 150ms;
 }
 
-.lww-scale-emoji-hover .lww-emoji:hover {
+.lww-emoji:hover {
 	transform: scale(2);
 }
 

--- a/data/ui/dialogs/preferences.ui
+++ b/data/ui/dialogs/preferences.ui
@@ -22,20 +22,6 @@
 					<object class="AdwPreferencesGroup">
 						<property name="title" translatable="yes">Appearance</property>
 						<child>
-							<object class="AdwComboRow" id="scheme_combo_row">
-								<property name="title" translatable="yes">Color Scheme</property>
-								<signal name="notify::selected-item" handler="on_scheme_changed" swapped="no" />
-
-								<property name="model">
-									<object class="TubaColorSchemeListModel" />
-								</property>
-
-								<property name="expression">
-									<lookup type="TubaColorSchemeListItem" name="name" />
-								</property>
-							</object>
-						</child>
-						<child>
 							<object class="AdwSwitchRow" id="larger_font_size">
 								<property name="title" translatable="yes">Large Text</property>
 								<property name="subtitle" translatable="yes">Increase the size of text in posts</property>
@@ -53,12 +39,6 @@
 							</object>
 						</child>
 						<child>
-							<object class="AdwSwitchRow" id="scale_emoji_hover">
-								<property name="title" translatable="yes">Scale Custom Emojis on Hover</property>
-								<property name="subtitle" translatable="yes">Slightly increases the size of custom emojis when you hover over them</property>
-							</object>
-						</child>
-						<child>
 							<object class="AdwSwitchRow" id="letterbox_media">
 								<!-- translators: if unsure, you can find the translation on glitch-soc https://github.com/glitch-soc/mastodon/tree/main/app/javascript/flavours/glitch/locales under the key "settings.media_letterbox" -->
 								<property name="title" translatable="yes">Letterbox Media</property>
@@ -67,27 +47,8 @@
 							</object>
 						</child>
 						<child>
-							<object class="AdwSwitchRow" id="media_viewer_expand_pictures">
-								<!-- translators: expand as in enlarge -->
-								<property name="title" translatable="yes">Expand Pictures in Media Viewer</property>
-								<!-- translators: expand as in enlarge -->
-								<property name="subtitle" translatable="yes">Expand pictures to fill the media viewer by default</property>
-							</object>
-						</child>
-						<child>
-							<object class="AdwSwitchRow" id="use_blurhash">
-								<property name="title" translatable="no">BlurHash</property>
-								<property name="subtitle" translatable="yes">Show a blurred version of the media until they fully load</property>
-							</object>
-						</child>
-						<child>
 							<object class="AdwSwitchRow" id="show_spoilers">
 								<property name="title" translatable="yes">Reveal Spoilers by Default</property>
-							</object>
-						</child>
-						<child>
-							<object class="AdwSwitchRow" id="show_preview_cards">
-								<property name="title" translatable="yes">Show Link Preview Cards</property>
 							</object>
 						</child>
 						<child>

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -300,10 +300,6 @@ namespace Tuba {
 				error (msg);
 			}
 
-			var style_manager = Adw.StyleManager.get_default ();
-			ColorScheme color_scheme = (ColorScheme) settings.get_enum ("color-scheme");
-			style_manager.color_scheme = color_scheme.to_adwaita_scheme ();
-
 			#if DEV_MODE
 				set_accels_for_action ("app.dev-only-window", {"F2"});
 			#endif

--- a/src/Dialogs/Preferences.vala
+++ b/src/Dialogs/Preferences.vala
@@ -107,7 +107,6 @@ public class Tuba.Dialogs.Preferences : Adw.PreferencesDialog {
 		public string event;
 	}
 
-	[GtkChild] unowned Adw.ComboRow scheme_combo_row;
 	[GtkChild] unowned Adw.ComboRow post_visibility_combo_row;
 	[GtkChild] unowned Adw.ComboRow default_language_combo_row;
 	[GtkChild] unowned Adw.ComboRow default_content_type_combo_row;
@@ -116,15 +115,11 @@ public class Tuba.Dialogs.Preferences : Adw.PreferencesDialog {
 	[GtkChild] unowned Adw.SwitchRow live_updates;
 	[GtkChild] unowned Adw.SwitchRow public_live_updates;
 	[GtkChild] unowned Adw.SwitchRow show_spoilers;
-	[GtkChild] unowned Adw.SwitchRow show_preview_cards;
 	[GtkChild] unowned Adw.SwitchRow larger_font_size;
 	[GtkChild] unowned Adw.SwitchRow larger_line_height;
-	[GtkChild] unowned Adw.SwitchRow scale_emoji_hover;
 	[GtkChild] unowned Adw.SwitchRow strip_tracking;
 	[GtkChild] unowned Adw.SwitchRow letterbox_media;
-	[GtkChild] unowned Adw.SwitchRow media_viewer_expand_pictures;
 	[GtkChild] unowned Adw.SwitchRow enlarge_custom_emojis;
-	[GtkChild] unowned Adw.SwitchRow use_blurhash;
 	[GtkChild] unowned Adw.SwitchRow group_push_notifications;
 	[GtkChild] unowned Adw.SwitchRow advanced_boost_dialog;
 	[GtkChild] unowned Adw.SwitchRow darken_images_on_dark_mode;
@@ -170,16 +165,9 @@ public class Tuba.Dialogs.Preferences : Adw.PreferencesDialog {
 	private bool lang_changed { get; set; default=false; }
 	private bool privacy_changed { get; set; default=false; }
 
-	static construct {
-		typeof (ColorSchemeListModel).ensure ();
-	}
-
 	construct {
 		proxy_entry.text = settings.proxy;
 		post_visibility_combo_row.model = accounts.active.visibility_list;
-
-		// Setup scheme combo row
-		scheme_combo_row.selected = settings.get_enum ("color-scheme");
 
 		uint default_visibility_index;
 		if (
@@ -285,15 +273,11 @@ public class Tuba.Dialogs.Preferences : Adw.PreferencesDialog {
 		settings.bind ("live-updates", live_updates, "active", SettingsBindFlags.DEFAULT);
 		settings.bind ("public-live-updates", public_live_updates, "active", SettingsBindFlags.DEFAULT);
 		settings.bind ("show-spoilers", show_spoilers, "active", SettingsBindFlags.DEFAULT);
-		settings.bind ("show-preview-cards", show_preview_cards, "active", SettingsBindFlags.DEFAULT);
 		settings.bind ("larger-font-size", larger_font_size, "active", SettingsBindFlags.DEFAULT);
 		settings.bind ("larger-line-height", larger_line_height, "active", SettingsBindFlags.DEFAULT);
-		settings.bind ("scale-emoji-hover", scale_emoji_hover, "active", SettingsBindFlags.DEFAULT);
 		settings.bind ("strip-tracking", strip_tracking, "active", SettingsBindFlags.DEFAULT);
 		settings.bind ("letterbox-media", letterbox_media, "active", SettingsBindFlags.DEFAULT);
-		settings.bind ("media-viewer-expand-pictures", media_viewer_expand_pictures, "active", SettingsBindFlags.DEFAULT);
 		settings.bind ("enlarge-custom-emojis", enlarge_custom_emojis, "active", SettingsBindFlags.DEFAULT);
-		settings.bind ("use-blurhash", use_blurhash, "active", SettingsBindFlags.DEFAULT);
 		settings.bind ("group-push-notifications", group_push_notifications, "active", SettingsBindFlags.DEFAULT);
 		settings.bind ("advanced-boost-dialog", advanced_boost_dialog, "active", SettingsBindFlags.DEFAULT);
 		settings.bind ("darken-images-on-dark-mode", darken_images_on_dark_mode, "active", SettingsBindFlags.DEFAULT);
@@ -307,15 +291,6 @@ public class Tuba.Dialogs.Preferences : Adw.PreferencesDialog {
 	private void dlcr_cb () {
 		lang_changed = true;
 		default_language_combo_row.disconnect (dlcr_id);
-	}
-
-	[GtkCallback]
-	private void on_scheme_changed () {
-		var selected_item = (ColorSchemeListItem) scheme_combo_row.selected_item;
-		var style_manager = Adw.StyleManager.get_default ();
-
-		style_manager.color_scheme = selected_item.adwaita_scheme;
-		settings.color_scheme = selected_item.color_scheme;
 	}
 
 	[GtkCallback]
@@ -453,49 +428,5 @@ public class Tuba.Dialogs.Preferences : Adw.PreferencesDialog {
 		} else if (settings.proxy != "") {
 			settings.proxy = "";
 		}
-	}
-}
-
-public class Tuba.ColorSchemeListModel : Object, ListModel {
-	private Gee.ArrayList<ColorSchemeListItem> array = new Gee.ArrayList<ColorSchemeListItem> ();
-
-	construct {
-		array.add (new ColorSchemeListItem (SYSTEM));
-		array.add (new ColorSchemeListItem (LIGHT));
-		array.add (new ColorSchemeListItem (DARK));
-	}
-
-	public Object? get_item (uint position) requires (position < array.size) {
-		return array.get ((int) position);
-	}
-
-	public Type get_item_type () {
-		return typeof (ColorSchemeListItem);
-	}
-
-	public uint get_n_items () {
-		return array.size;
-	}
-
-	public Object? get_object (uint position) {
-		return get_item (position);
-	}
-}
-
-public class Tuba.ColorSchemeListItem : Object {
-	public ColorScheme color_scheme { get; construct; }
-	public string name {
-		owned get {
-			return color_scheme.to_string ();
-		}
-	}
-	public Adw.ColorScheme adwaita_scheme {
-		get {
-			return color_scheme.to_adwaita_scheme ();
-		}
-	}
-
-	public ColorSchemeListItem (ColorScheme color_scheme) {
-		Object (color_scheme: color_scheme);
 	}
 }

--- a/src/Services/Settings.vala
+++ b/src/Services/Settings.vala
@@ -103,22 +103,17 @@ public class Tuba.Settings : GLib.Settings {
 		}
 	}
 
-	public ColorScheme color_scheme { get; set; }
 	public bool work_in_background { get; set; }
 	public int timeline_page_size { get; set; }
 	public bool live_updates { get; set; }
 	public bool public_live_updates { get; set; }
 	public bool show_spoilers { get; set; }
-	public bool show_preview_cards { get; set; }
 	public bool larger_font_size { get; set; }
 	public bool larger_line_height { get; set; }
-	public bool scale_emoji_hover { get; set; }
 	public bool aggressive_resolving { get; set; }
 	public bool strip_tracking { get; set; }
 	public bool letterbox_media { get; set; }
-	public bool media_viewer_expand_pictures { get; set; }
 	public bool enlarge_custom_emojis { get; set; }
-	public bool use_blurhash { get; set; }
 	public bool group_push_notifications { get; set; }
 	public bool advanced_boost_dialog { get; set; }
 	public bool reply_to_old_post_reminder { get; set; }
@@ -131,21 +126,16 @@ public class Tuba.Settings : GLib.Settings {
 
 	private static string[] keys_to_init = {
 		"active-account",
-		"color-scheme",
 		"timeline-page-size",
 		"live-updates",
 		"public-live-updates",
 		"show-spoilers",
-		"show-preview-cards",
 		"larger-font-size",
 		"larger-line-height",
 		"aggressive-resolving",
 		"strip-tracking",
-		"scale-emoji-hover",
 		"letterbox-media",
-		"media-viewer-expand-pictures",
 		"enlarge-custom-emojis",
-		"use-blurhash",
 		"group-push-notifications",
 		"advanced-boost-dialog",
 		"reply-to-old-post-reminder",
@@ -185,40 +175,5 @@ public class Tuba.Settings : GLib.Settings {
 		if (active_account_settings != null) active_account_settings.apply ();
 
 		this.apply ();
-	}
-}
-
-public enum Tuba.ColorScheme {
-	SYSTEM,
-	LIGHT,
-	DARK;
-
-	public string to_string () {
-		switch (this) {
-			case SYSTEM:
-				// translators: Follow System's dark mode preference
-				return _("Follow System");
-			case LIGHT:
-				// translators: Light mode theme
-				return _("Light");
-			case DARK:
-				// translators: Dark mode theme
-				return _("Dark");
-			default:
-				assert_not_reached ();
-		}
-	}
-
-	public Adw.ColorScheme to_adwaita_scheme () {
-		switch (this) {
-			case SYSTEM:
-				return DEFAULT;
-			case LIGHT:
-				return FORCE_LIGHT;
-			case DARK:
-				return FORCE_DARK;
-			default:
-				assert_not_reached ();
-		}
 	}
 }

--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -169,18 +169,13 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 		public void zoom (double zoom_level, int? old_width = null, int? old_height = null) {
 			// Don't zoom on video
 			if (is_video || is_audio) return;
-			if ((zoom_level > 1.0 && !can_zoom_in) || (zoom_level < 1.0 && !can_zoom_out && settings.media_viewer_expand_pictures) || zoom_level == 1.0) return;
+			if ((zoom_level > 1.0 && !can_zoom_in) || (zoom_level < 1.0 && !can_zoom_out) || zoom_level == 1.0) return;
 
 			var new_width = (old_width ?? child_width) * zoom_level;
 			var new_height = (old_height ?? child_height) * zoom_level;
 
-			if (settings.media_viewer_expand_pictures) {
-				if (new_width < scroller.hadjustment.page_size) new_width = scroller.hadjustment.page_size;
-				if (new_height < scroller.vadjustment.page_size) new_height = scroller.vadjustment.page_size;
-			} else {
-				if (new_width < 0) new_width = -1;
-				if (new_height < 0) new_height = -1;
-			}
+			if (new_width < scroller.hadjustment.page_size) new_width = scroller.hadjustment.page_size;
+			if (new_height < scroller.vadjustment.page_size) new_height = scroller.vadjustment.page_size;
 
 			child_widget.set_size_request ((int) new_width, (int) new_height);
 
@@ -1068,10 +1063,6 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 			#endif
 		} else {
 			var picture = new Gtk.Picture ();
-
-			if (!settings.media_viewer_expand_pictures) {
-				picture.valign = picture.halign = Gtk.Align.CENTER;
-			}
 
 			item = new Item (picture, final_friendly_url, final_preview);
 			item.zoom_changed.connect (on_zoom_change);

--- a/src/Views/Timeline.vala
+++ b/src/Views/Timeline.vala
@@ -100,7 +100,6 @@ public class Tuba.Views.Timeline : AccountHolder, Streamable, Views.ContentBase 
 		}
 
 		settings.notify["show-spoilers"].connect (on_refresh);
-		settings.notify["show-preview-cards"].connect (on_refresh);
 		settings.notify["enlarge-custom-emojis"].connect (on_refresh);
 
 		#if !USE_LISTVIEW

--- a/src/Widgets/Account.vala
+++ b/src/Widgets/Account.vala
@@ -120,10 +120,6 @@ public class Tuba.Widgets.Account : Gtk.ListBoxRow {
 		}
 	}
 
-	void toggle_scale_emoji_hover () {
-		Tuba.toggle_css (note, settings.scale_emoji_hover, "lww-scale-emoji-hover");
-	}
-
 	void on_cache_response (Gdk.Paintable? data) {
 		background.paintable = data;
 	}
@@ -170,10 +166,6 @@ public class Tuba.Widgets.Account : Gtk.ListBoxRow {
 		open.connect (account.open);
 		background.clicked.connect (account.open);
 		avatar.clicked.connect (account.open);
-
-		if (settings.scale_emoji_hover)
-			note.add_css_class ("lww-scale-emoji-hover");
-		settings.notify["scale-emoji-hover"].connect (toggle_scale_emoji_hover);
 
 		display_name.instance_emojis = account.emojis_map;
 		display_name.content = account.display_name;

--- a/src/Widgets/Announcement.vala
+++ b/src/Widgets/Announcement.vala
@@ -176,7 +176,6 @@ public class Tuba.Widgets.Announcement : Gtk.ListBoxRow {
 	void settings_updated () {
 		Tuba.toggle_css (this, settings.larger_font_size, "ttl-status-font-large");
 		Tuba.toggle_css (this, settings.larger_line_height, "ttl-status-line-height-large");
-		Tuba.toggle_css (this, settings.scale_emoji_hover, "lww-scale-emoji-hover");
 	}
 
 	construct {
@@ -188,12 +187,8 @@ public class Tuba.Widgets.Announcement : Gtk.ListBoxRow {
 		if (settings.larger_line_height)
 			add_css_class ("ttl-status-line-height-large");
 
-		if (settings.scale_emoji_hover)
-			add_css_class ("lww-scale-emoji-hover");
-
 		settings.notify["larger-font-size"].connect (settings_updated);
 		settings.notify["larger-line-height"].connect (settings_updated);
-		settings.notify["scale-emoji-hover"].connect (settings_updated);
 	}
 
 	string announcement_date;

--- a/src/Widgets/ProfileCover.vala
+++ b/src/Widgets/ProfileCover.vala
@@ -26,10 +26,6 @@ protected class Tuba.Widgets.Cover : Gtk.Box {
 		debug ("Destroying Profile Cover");
 	}
 
-	void toggle_scale_emoji_hover () {
-		Tuba.toggle_css (this, settings.scale_emoji_hover, "lww-scale-emoji-hover");
-	}
-
 	public string cover_badge_label {
 		get {
 			return cover_badge.label;
@@ -169,10 +165,6 @@ protected class Tuba.Widgets.Cover : Gtk.Box {
 	int total_fields = 0;
 	string stats_string = "";
 	public Cover (Views.Profile.ProfileAccount profile, bool mini = false) {
-		if (settings.scale_emoji_hover)
-			this.add_css_class ("lww-scale-emoji-hover");
-		settings.notify["scale-emoji-hover"].connect (toggle_scale_emoji_hover);
-
 		_mini = mini;
 		if (mini) note_row.sensitive = false;
 

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -160,7 +160,6 @@
 	void settings_updated () {
 		Tuba.toggle_css (this, settings.larger_font_size, "ttl-status-font-large");
 		Tuba.toggle_css (this, settings.larger_line_height, "ttl-status-line-height-large");
-		Tuba.toggle_css (this, settings.scale_emoji_hover, "lww-scale-emoji-hover");
 	}
 
 	construct {
@@ -176,12 +175,8 @@
 		if (settings.larger_line_height)
 			add_css_class ("ttl-status-line-height-large");
 
-		if (settings.scale_emoji_hover)
-			add_css_class ("lww-scale-emoji-hover");
-
 		settings.notify["larger-font-size"].connect (settings_updated);
 		settings.notify["larger-line-height"].connect (settings_updated);
-		settings.notify["scale-emoji-hover"].connect (settings_updated);
 
 		edit_history_simple_action = new SimpleAction ("edit-history", null);
 		edit_history_simple_action.activate.connect (view_edit_history);
@@ -1053,7 +1048,7 @@
 		}
 
 		if (prev_card != null) content_box.remove (prev_card);
-		if (settings.show_preview_cards && !status.formal.has_media && status.formal.card != null && status.formal.card.kind in ALLOWED_CARD_TYPES) {
+		if (!status.formal.has_media && status.formal.card != null && status.formal.card.kind in ALLOWED_CARD_TYPES) {
 			try {
 				prev_card = (Widgets.PreviewCard) status.formal.card.to_widget ();
 				prev_card.button.clicked.connect (open_card_url);


### PR DESCRIPTION
Following options are unpopular or a default value is clearly the preferred one. This PR will remove them.

If you use any of these, I'm open to leaving it in gsettings without a UI toggle so **speak now or forever hold your peace**

| Removed Option | Default | Comments |
| :---: | :---: | :---: |
| color scheme | following system theme | - |
| show preview card | true | - |
| scale emoji on hover | true | - |
| media viewer expand pictures | true | - |
| use blurhash | true | - |