### PR TITLE
feat(status): reaction posting

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -751,3 +751,7 @@ popover.mini-profile > contents {
 list.uniform-border-color row {
 	border-bottom-color: @borders;
 }
+
+.emoji-reaction-expander > box > list, .emoji-reaction-expander > box > list > row  {
+	border-radius: inherit;
+}

--- a/data/ui/widgets/announcement.ui
+++ b/data/ui/widgets/announcement.ui
@@ -27,7 +27,7 @@
           </object>
         </child>
         <child>
-          <object class="GtkBox">
+          <object class="GtkBox" id="mainbox">
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkBox">
@@ -138,17 +138,6 @@
                     <property name="hexpand">False</property>
                   </object>
                 </child>
-              </object>
-            </child>
-
-            <child>
-              <object class="GtkFlowBox" id="emoji_reactions">
-                <property name="margin-top">16</property>
-                <property name="visible">0</property>
-                <property name="column_spacing">6</property>
-                <property name="row_spacing">6</property>
-                <!-- Lower values leave space between items -->
-                <property name="max_children_per_line">100</property>
               </object>
             </child>
           </object>

--- a/src/API/EmojiReaction.vala
+++ b/src/API/EmojiReaction.vala
@@ -3,4 +3,17 @@ public class Tuba.API.EmojiReaction : Entity {
 	public string? url { get; set; default = null; }
 	public string? name { get; set; default = null; }
 	public bool me { get; set; default = false; }
+	public Gee.ArrayList<API.Account>? accounts { get; set; default = null; }
+	public Gee.ArrayList<string>? account_ids { get; set; default = null; }
+
+	public override Type deserialize_array_type (string prop) {
+		switch (prop) {
+			case "accounts":
+				return typeof (API.Account);
+			case "account-ids":
+				return Type.STRING;
+		}
+
+		return base.deserialize_array_type (prop);
+	}
 }

--- a/src/API/EmojiReaction.vala
+++ b/src/API/EmojiReaction.vala
@@ -1,4 +1,4 @@
-public class Tuba.API.EmojiReaction : Entity {
+public class Tuba.API.EmojiReaction : Entity, Widgetizable {
 	public int64 count { get; set; default = 0;}
 	public string? url { get; set; default = null; }
 	public string? name { get; set; default = null; }
@@ -15,5 +15,12 @@ public class Tuba.API.EmojiReaction : Entity {
 		}
 
 		return base.deserialize_array_type (prop);
+	}
+
+	public override Gtk.Widget to_widget () {
+		return new Widgets.EmojiReactionAccounts (this);
+	}
+
+	public override void open () {
 	}
 }

--- a/src/API/Instance.vala
+++ b/src/API/Instance.vala
@@ -186,6 +186,16 @@ public class Tuba.API.Instance : Entity {
 		}
 	}
 
+	public int64 compat_status_reactions_max {
+		get {
+			if (configuration != null && configuration.reactions != null) {
+				return configuration.reactions.max_reactions;
+			}
+
+			return 0;
+		}
+	}
+
 	public static API.Instance from (Json.Node node) throws Error {
 		return Entity.from_json (typeof (API.Instance), node) as API.Instance;
 	}

--- a/src/API/Notification.vala
+++ b/src/API/Notification.vala
@@ -62,6 +62,8 @@ public class Tuba.API.Notification : Entity, Widgetizable {
 	public string? kind { get; set; default = null; }
 	public string? created_at { get; set; default = null; }
 	public API.Status? status { get; set; default = null; }
+	public string? emoji { get; set; default = null; }
+	public string? emoji_url { get; set; default = null; }
 	public API.Admin.Report? report { get; set; default = null; }
 
 	// the docs claim that 'relationship_severance_event'
@@ -157,7 +159,7 @@ public class Tuba.API.Notification : Entity, Widgetizable {
 			kind_actor_name = _("%s (& %d others)").printf (account.display_name, others);
 		}
 
-		issuer.describe_kind (kind, out res_kind, kind_actor_name);
+		issuer.describe_kind (kind, out res_kind, kind_actor_name, emoji);
 		var toast = new GLib.Notification (res_kind.description);
 		if (status != null) {
 			var body = "";

--- a/src/Services/Accounts/InstanceAccount.vala
+++ b/src/Services/Accounts/InstanceAccount.vala
@@ -20,6 +20,7 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 	public const string KIND_ADMIN_REPORT = "admin.report";
 	public const string KIND_ADMIN_SIGNUP = "admin.sign_up";
 	public const string KIND_STATUS = "status";
+	public const string KIND_PLEROMA_REACTION = "pleroma:emoji_reaction";
 
 	public string uuid { get; set; }
 	public bool admin_mode { get; set; default=false; }
@@ -220,7 +221,8 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 		string? kind,
 		out Kind result,
 		string? actor_name = null,
-		string? callback_url = null
+		string? callback_url = null,
+		string? other_data = null
 	) {
 		switch (kind) {
 			case KIND_MENTION:
@@ -345,6 +347,25 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 					// translators: the variable is a string user name,
 					//				this is used for per-account notifications
 					_("%s just posted").printf (actor_name),
+				};
+				break;
+			case KIND_PLEROMA_REACTION:
+				string body;
+				if (other_data == null) {
+					// translators: the variable is a string user name,
+					//				this is used for notifications
+					body = _("%s reacted to your post").printf (actor_name);
+				} else {
+					// translators: the first variable is a string user name,
+					//				the second variable is an emoji,
+					//				this is used for notifications
+					body = _("%s reacted to your post with %s").printf (actor_name, other_data);
+				}
+
+				result = {
+					"tuba-smile-symbolic",
+					body,
+					callback_url
 				};
 				break;
 			default:

--- a/src/Services/Accounts/InstanceAccount.vala
+++ b/src/Services/Accounts/InstanceAccount.vala
@@ -21,6 +21,7 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 	public const string KIND_ADMIN_SIGNUP = "admin.sign_up";
 	public const string KIND_STATUS = "status";
 	public const string KIND_PLEROMA_REACTION = "pleroma:emoji_reaction";
+	public const string KIND_REACTION = "reaction";
 
 	public string uuid { get; set; }
 	public bool admin_mode { get; set; default=false; }
@@ -350,6 +351,7 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 				};
 				break;
 			case KIND_PLEROMA_REACTION:
+			case KIND_REACTION:
 				string body;
 				if (other_data == null) {
 					// translators: the variable is a string user name,

--- a/src/Views/StatusStats.vala
+++ b/src/Views/StatusStats.vala
@@ -1,12 +1,13 @@
 public class Tuba.Views.StatusStats : Views.TabbedBase {
 	Views.ContentBase favorited;
 	Views.ContentBase boosted;
+	Views.ContentBase reacted;
 
 	construct {
 		label = _("Post Stats");
 	}
 
-	public StatusStats (string status_id) {
+	public StatusStats (string status_id, bool has_reactors = false) {
 		favorited = add_timeline_tab (
 			// translators: title for a list of people that favorited a post
 			_("Favorited By"),
@@ -26,5 +27,17 @@ public class Tuba.Views.StatusStats : Views.TabbedBase {
 			_("No Boosts"),
 			"tuba-heart-broken-symbolic"
 		);
+
+		if (has_reactors && accounts.active.instance_info != null && accounts.active.instance_info.pleroma != null) {
+			reacted = add_timeline_tab (
+				// translators: title for a list of people that have reacted to a post
+				_("Reactions"),
+				"tuba-smile-symbolic",
+				@"/api/v1/pleroma/statuses/$(status_id)/reactions",
+				typeof (API.EmojiReaction),
+				_("No Reactions"),
+				"tuba-heart-broken-symbolic"
+			);
+		}
 	}
 }

--- a/src/Widgets/Announcement.vala
+++ b/src/Widgets/Announcement.vala
@@ -1,79 +1,5 @@
 [GtkTemplate (ui = "/dev/geopjr/Tuba/ui/widgets/announcement.ui")]
 public class Tuba.Widgets.Announcement : Gtk.ListBoxRow {
-	public class ReactButton : Gtk.Button {
-		private Gtk.Label reactions_label;
-		public string shortcode { get; private set; }
-		public signal void reaction_toggled ();
-
-		private bool _has_reacted = false;
-		public bool has_reacted {
-			get {
-				return _has_reacted;
-			}
-			set {
-				_has_reacted = value;
-				update_reacted (value);
-			}
-		}
-
-		private int64 _reactions = 0;
-		public int64 reactions {
-			get {
-				return _reactions;
-			}
-			set {
-				_reactions = value;
-				reactions_label.label = value.to_string ();
-			}
-		}
-
-		public ReactButton (API.EmojiReaction reaction) {
-			this.set_accessible_role (Gtk.AccessibleRole.TOGGLE_BUTTON);
-
-			// translators: the variable is the emoji or its name if it's custom
-			tooltip_text = _("React with %s").printf (reaction.name);
-			shortcode = reaction.name;
-
-			var badge = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6);
-			if (reaction.url != null) {
-				badge.append (new Widgets.Emoji (reaction.url));
-			} else {
-				badge.append (new Gtk.Label (reaction.name));
-			}
-
-			reactions_label = new Gtk.Label (null);
-			reactions = reaction.count;
-
-			badge.append (reactions_label);
-			this.child = badge;
-
-			_has_reacted = reaction.me;
-			if (reaction.me == true) {
-				this.add_css_class ("accent");
-				this.update_state (Gtk.AccessibleState.PRESSED, Gtk.AccessibleTristate.TRUE, -1);
-			}
-
-			this.clicked.connect (on_clicked);
-		}
-
-		public void update_reacted (bool reacted = true) {
-			if (reacted) {
-				this.add_css_class ("accent");
-				reactions = reactions + 1;
-				this.update_state (Gtk.AccessibleState.PRESSED, Gtk.AccessibleTristate.TRUE, -1);
-			} else {
-				this.remove_css_class ("accent");
-				reactions = reactions - 1;
-				this.update_state (Gtk.AccessibleState.PRESSED, Gtk.AccessibleTristate.FALSE, -1);
-			}
-			_has_reacted = reacted;
-		}
-
-		private void on_clicked () {
-			reaction_toggled ();
-		}
-	}
-
 	private API.Announcement announcement { get; private set; }
 	public signal void open ();
 
@@ -156,10 +82,9 @@ public class Tuba.Widgets.Announcement : Gtk.ListBoxRow {
 			foreach (API.EmojiReaction p in value) {
 				if (p.count <= 0) return;
 
-				var badge_button = new ReactButton (p);
+				var badge_button = new Widgets.ReactButton (p);
 				badge_button.reaction_toggled.connect (on_reaction_toggled);
 
-				//  emoji_reactions.append(badge_button); // GTK >= 4.5
 				emoji_reactions.insert (
 					new Gtk.FlowBoxChild () {
 						child = badge_button,
@@ -237,7 +162,7 @@ public class Tuba.Widgets.Announcement : Gtk.ListBoxRow {
 		avatar.custom_image = data;
 	}
 
-	private void on_reaction_toggled (ReactButton btn) {
+	private void on_reaction_toggled (Widgets.ReactButton btn) {
 		var endpoint = @"/api/v1/announcements/$(announcement.id)/reactions/$(btn.shortcode)";
 		var req = btn.has_reacted ? new Request.DELETE (endpoint) : new Request.PUT (endpoint);
 

--- a/src/Widgets/EmojiReactionAccounts.vala
+++ b/src/Widgets/EmojiReactionAccounts.vala
@@ -1,0 +1,81 @@
+public class Tuba.Widgets.EmojiReactionAccounts : Adw.ExpanderRow {
+	public class AccountRow : Gtk.ListBoxRow {
+		API.Account account;
+		Adw.Avatar avi;
+
+		public AccountRow (API.Account account) {
+			this.activatable = false;
+			this.account = account;
+			var main_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 12) {
+				vexpand = true,
+				margin_bottom = 12,
+				margin_end = 12,
+				margin_start = 12,
+				margin_top = 12
+			};
+			avi = new Adw.Avatar (36, null, true);
+			avi.name = account.display_name;
+			main_box.prepend (avi);
+
+			var info_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 6) {
+				hexpand = true
+			};
+			var title_label = new Widgets.EmojiLabel () {
+				use_markup = false
+			};
+			title_label.instance_emojis = account.emojis_map;
+			title_label.content = account.display_name;
+			info_box.prepend (title_label);
+			info_box.append (new Gtk.Label (account.full_handle) {
+				hexpand = true,
+				xalign = 0.0f,
+				wrap = true,
+				wrap_mode = Pango.WrapMode.WORD_CHAR,
+				use_markup = false,
+				css_classes = {"dim-label"}
+			});
+			main_box.append (info_box);
+
+			var open_button = new Gtk.Button.with_label (_("Open")) {
+				valign = Gtk.Align.CENTER
+			};
+			open_button.clicked.connect (open);
+			main_box.append (open_button);
+			this.child = main_box;
+
+			Tuba.Helper.Image.request_paintable (account.avatar, null, false, on_avi_cache_response);
+		}
+
+		void open () {
+			this.account.open ();
+		}
+
+		void on_avi_cache_response (Gdk.Paintable? data) {
+			avi.custom_image = data;
+		}
+	}
+
+	public EmojiReactionAccounts (API.EmojiReaction reaction) {
+		this.add_css_class ("emoji-reaction-expander");
+		this.title = GLib.ngettext (
+			// translators: the variable is the amount of emoji reactions,
+			//				this is the singular version, '1 Reaction'
+			_("%d Reaction").printf (reaction.accounts.size),
+
+			// translators: the variable is the amount of emoji reactions,
+			//				this is the plural version, '4 Reactions'
+			_("%d Reactions").printf (reaction.accounts.size),
+			(ulong) reaction.accounts.size
+		);
+
+		if (reaction.url != null) {
+			this.add_prefix (new Widgets.Emoji (reaction.url));
+		} else {
+			this.add_prefix (new Gtk.Label (reaction.name));
+		}
+
+		foreach (var account in reaction.accounts) {
+			this.add_row (new AccountRow (account));
+		}
+	}
+}

--- a/src/Widgets/Notification.vala
+++ b/src/Widgets/Notification.vala
@@ -41,6 +41,7 @@ public class Tuba.Widgets.Notification : Widgets.Status {
 			case InstanceAccount.KIND_FAVOURITE:
 			case InstanceAccount.KIND_REBLOG:
 			case InstanceAccount.KIND_PLEROMA_REACTION:
+			case InstanceAccount.KIND_REACTION:
 				this.add_css_class ("can-be-dimmed");
 				break;
 		}

--- a/src/Widgets/Notification.vala
+++ b/src/Widgets/Notification.vala
@@ -8,7 +8,23 @@ public class Tuba.Widgets.Notification : Widgets.Status {
 		else
 			status = new API.Status.from_account (obj.account);
 
+		if (obj.emoji_url != null) {
+			API.Emoji custom_reaction = new API.Emoji () {
+				shortcode = obj.emoji.slice (1, -1),
+				url = obj.emoji_url
+			};
+
+			if (obj.account.emojis != null) {
+				obj.account.emojis.add (custom_reaction);
+			} else {
+				var arr = new Gee.ArrayList<API.Emoji> ();
+				arr.add (custom_reaction);
+				obj.account.emojis = arr;
+			}
+		}
+
 		Object (
+			other_data: obj.emoji,
 			notification: obj,
 			kind_instigator: obj.account,
 			kind: obj.kind,
@@ -24,6 +40,7 @@ public class Tuba.Widgets.Notification : Widgets.Status {
 				break;
 			case InstanceAccount.KIND_FAVOURITE:
 			case InstanceAccount.KIND_REBLOG:
+			case InstanceAccount.KIND_PLEROMA_REACTION:
 				this.add_css_class ("can-be-dimmed");
 				break;
 		}

--- a/src/Widgets/ReactButton.vala
+++ b/src/Widgets/ReactButton.vala
@@ -50,7 +50,6 @@ public class Tuba.Widgets.ReactButton : Gtk.Button {
 
 	public void update_reaction (API.EmojiReaction reaction) {
 		if (reaction.count == 0) removed ();
-
 		update_button_props (reaction.me);
 		this.reactions = reaction.count;
 	}

--- a/src/Widgets/ReactButton.vala
+++ b/src/Widgets/ReactButton.vala
@@ -1,0 +1,76 @@
+public class Tuba.Widgets.ReactButton : Gtk.Button {
+	private Gtk.Label reactions_label;
+	public string shortcode { get; private set; }
+	public signal void reaction_toggled ();
+	public signal void removed ();
+
+	private bool _has_reacted = false;
+	public bool has_reacted {
+		get {
+			return _has_reacted;
+		}
+		set {
+			_has_reacted = value;
+			update_reacted (value);
+		}
+	}
+
+	private int64 _reactions = 0;
+	public int64 reactions {
+		get {
+			return _reactions;
+		}
+		set {
+			_reactions = value;
+			reactions_label.label = value.to_string ();
+		}
+	}
+
+	public ReactButton (API.EmojiReaction reaction) {
+		this.set_accessible_role (Gtk.AccessibleRole.TOGGLE_BUTTON);
+
+		// translators: the variable is the emoji or its name if it's custom
+		tooltip_text = _("React with %s").printf (reaction.name);
+		shortcode = reaction.name;
+
+		var badge = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6);
+		if (reaction.url != null) {
+			badge.append (new Widgets.Emoji (reaction.url));
+		} else {
+			badge.append (new Gtk.Label (reaction.name));
+		}
+
+		reactions_label = new Gtk.Label (null);
+		reactions = reaction.count;
+
+		badge.append (reactions_label);
+		this.child = badge;
+
+		_has_reacted = reaction.me;
+		if (reaction.me == true) {
+			this.add_css_class ("accent");
+			this.update_state (Gtk.AccessibleState.PRESSED, Gtk.AccessibleTristate.TRUE, -1);
+		}
+
+		this.clicked.connect (on_clicked);
+	}
+
+	public void update_reacted (bool reacted = true) {
+		if (reacted) {
+			this.add_css_class ("accent");
+			reactions = reactions + 1;
+			this.update_state (Gtk.AccessibleState.PRESSED, Gtk.AccessibleTristate.TRUE, -1);
+		} else {
+			this.remove_css_class ("accent");
+			reactions = reactions - 1;
+			this.update_state (Gtk.AccessibleState.PRESSED, Gtk.AccessibleTristate.FALSE, -1);
+		}
+		_has_reacted = reacted;
+
+		if (reactions == 0) removed ();
+	}
+
+	private void on_clicked () {
+		reaction_toggled ();
+	}
+}

--- a/src/Widgets/ReactButton.vala
+++ b/src/Widgets/ReactButton.vala
@@ -41,33 +41,40 @@ public class Tuba.Widgets.ReactButton : Gtk.Button {
 		}
 
 		reactions_label = new Gtk.Label (null);
-		reactions = reaction.count;
-
 		badge.append (reactions_label);
 		this.child = badge;
 
-		_has_reacted = reaction.me;
-		if (reaction.me == true) {
-			this.add_css_class ("accent");
-			this.update_state (Gtk.AccessibleState.PRESSED, Gtk.AccessibleTristate.TRUE, -1);
-		}
-
+		update_reaction (reaction);
 		this.clicked.connect (on_clicked);
+	}
+
+	public void update_reaction (API.EmojiReaction reaction) {
+		if (reaction.count == 0) removed ();
+
+		update_button_props (reaction.me);
+		this.reactions = reaction.count;
 	}
 
 	public void update_reacted (bool reacted = true) {
 		if (reacted) {
-			this.add_css_class ("accent");
 			reactions = reactions + 1;
+		} else {
+			reactions = reactions - 1;
+		}
+
+		if (reactions == 0) removed ();
+		update_button_props (reacted);
+	}
+
+	private void update_button_props (bool reacted) {
+		if (reacted) {
+			this.add_css_class ("accent");
 			this.update_state (Gtk.AccessibleState.PRESSED, Gtk.AccessibleTristate.TRUE, -1);
 		} else {
 			this.remove_css_class ("accent");
-			reactions = reactions - 1;
 			this.update_state (Gtk.AccessibleState.PRESSED, Gtk.AccessibleTristate.FALSE, -1);
 		}
 		_has_reacted = reacted;
-
-		if (reactions == 0) removed ();
 	}
 
 	private void on_clicked () {

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -196,7 +196,18 @@
 
 	private bool has_stats { get { return status.formal.reblogs_count != 0 || status.formal.favourites_count != 0; } }
 	private void show_view_stats_action () {
-		stats_simple_action.set_enabled (has_stats);
+		stats_simple_action.set_enabled (has_stats || has_reactions ());
+	}
+
+	private bool has_reactions () {
+		bool res = false;
+
+		var reactions = status.formal.compat_status_reactions;
+		if (reactions != null && reactions.size > 0) {
+			res = reactions[0].account_ids != null && reactions[0].account_ids.size > 0;
+		}
+
+		return res;
 	}
 
 	public Status (API.Status status) {
@@ -369,7 +380,7 @@
 	}
 
 	private void view_stats () {
-		app.main_window.open_view (new Views.StatusStats (status.formal.id));
+		app.main_window.open_view (new Views.StatusStats (status.formal.id, has_reactions ()));
 	}
 
 	private void on_edit (API.Status x) {

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -27,6 +27,7 @@
 	public bool enable_thread_lines { get; set; default = false; }
 	public API.Translation? translation { get; private set; default = null; }
 	private Adw.Bin? emoji_reactions { get; set; default = null; }
+	protected string? other_data { get; set; default = null; }
 
 	private bool _can_be_opened = true;
 	public bool can_be_opened {
@@ -608,7 +609,8 @@
 			this.kind,
 			out res_kind,
 			actor_name,
-			this.kind_instigator.url
+			this.kind_instigator.url,
+			this.other_data
 		);
 
 		if (header_button_activate > 0) header_button.disconnect (header_button_activate);

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -26,6 +26,7 @@
 	private Gtk.Button? quoted_status_btn { get; set; default = null; }
 	public bool enable_thread_lines { get; set; default = false; }
 	public API.Translation? translation { get; private set; default = null; }
+	private Adw.Bin? emoji_reactions { get; set; default = null; }
 
 	private bool _can_be_opened = true;
 	public bool can_be_opened {
@@ -144,18 +145,6 @@
 	private SimpleAction show_original_simple_action;
 	private SimpleAction mute_conversation_action;
 	private SimpleAction unmute_conversation_action;
-
-	protected Adw.Bin emoji_reactions;
-	public Gee.ArrayList<API.EmojiReaction>? reactions {
-		get { return status.formal.compat_status_reactions; }
-		set {
-			if (emoji_reactions != null) content_column.remove (emoji_reactions);
-			if (value == null) return;
-
-			emoji_reactions = new ReactionsRow (value);
-			content_column.insert_child_after (emoji_reactions, spoiler_stack);
-		}
-	}
 
 	void settings_updated () {
 		Tuba.toggle_css (this, settings.larger_font_size, "ttl-status-font-large");
@@ -947,6 +936,12 @@
 			}
 		}
 
+		if (emoji_reactions != null) content_column.remove (emoji_reactions);
+		if (status.formal.compat_status_reactions != null) {
+			emoji_reactions = new ReactionsRow (status.formal.id, status.formal.compat_status_reactions);
+			content_column.insert_child_after (emoji_reactions, spoiler_stack);
+		}
+
 		spoiler_label.label = this.spoiler_text;
 		spoiler_label_rev.label = this.spoiler_text_revealed;
 
@@ -981,8 +976,6 @@
 		// translators: Tooltip text for avatars in posts.
 		//				The variable is a string user handle.
 		name_button.tooltip_text = avatar.tooltip_text = _("Open %s's Profile").printf (status.formal.account.handle);
-
-		reactions = status.formal.compat_status_reactions;
 
 		name_label.instance_emojis = status.formal.account.emojis_map;
 		name_label.label = title_text;

--- a/src/Widgets/Status/ReactionsRow.vala
+++ b/src/Widgets/Status/ReactionsRow.vala
@@ -8,6 +8,14 @@ public class Tuba.Widgets.ReactionsRow : Adw.Bin {
 		set {
 			emoji_button.sensitive = value;
 			if (custom_emoji_button != null) custom_emoji_button.sensitive = value;
+
+			react_btn_list.foreach (e => {
+				if (!((Widgets.ReactButton) e.value).has_reacted) {
+					((Widgets.ReactButton) e.value).sensitive = value;
+				}
+
+				return true;
+			});
 		}
 	}
 

--- a/src/Widgets/Status/ReactionsRow.vala
+++ b/src/Widgets/Status/ReactionsRow.vala
@@ -1,50 +1,146 @@
-// TODO: Move reaction logic from Accouncement.vala
-
 public class Tuba.Widgets.ReactionsRow : Adw.Bin {
-	Gtk.FlowBox reaction_box = new Gtk.FlowBox () {
-		column_spacing = 6,
-		row_spacing = 6,
-		// Lower values leave space between items
-		max_children_per_line = 100
-	};
+	Gtk.FlowBox reaction_box;
+	Gee.HashMap<string, Widgets.ReactButton> react_btn_list;
 
 	construct {
+		react_btn_list = new Gee.HashMap<string, Widgets.ReactButton>();
+		reaction_box = new Gtk.FlowBox () {
+			column_spacing = 6,
+			row_spacing = 6,
+			// Lower values leave space between items
+			max_children_per_line = 100
+		};
+
 		this.child = reaction_box;
+
+		var emoji_picker = new Gtk.EmojiChooser ();
+		var emoji_button = new Gtk.MenuButton () {
+			icon_name = "tuba-smile-symbolic",
+			popover = emoji_picker,
+			tooltip_text = _("Emoji Picker")
+		};
+		reaction_box.append (emoji_button);
+		emoji_picker.emoji_picked.connect (on_emoji_picked);
+
+		if (accounts.active.instance_emojis != null && accounts.active.instance_emojis.size > 0) {
+			var custom_emoji_picker = new Widgets.CustomEmojiChooser ();
+			var custom_emoji_button = new Gtk.MenuButton () {
+				icon_name = "tuba-cat-symbolic",
+				popover = custom_emoji_picker,
+				tooltip_text = _("Custom Emoji Picker")
+			};
+
+			reaction_box.append (custom_emoji_button);
+			custom_emoji_picker.emoji_picked.connect (on_custom_emoji_picked);
+		}
 	}
 
-	public ReactionsRow (Gee.ArrayList<API.EmojiReaction> reactions) {
-		foreach (API.EmojiReaction p in reactions) {
-			if (p.count <= 0) continue;
 
-			var badge_button = new Gtk.Button () {
-				// translators: the variable is the emoji or its name if it's custom
-				tooltip_text = _("React with %s").printf (p.name)
-			};
-			badge_button.set_accessible_role (Gtk.AccessibleRole.TOGGLE_BUTTON);
-			badge_button.update_state (Gtk.AccessibleState.PRESSED, Gtk.AccessibleTristate.FALSE, -1);
+	private Gee.ArrayList<API.EmojiReaction>? reactions {
+		set {
+			if (value == null) return;
 
-			var badge = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6);
+			react_btn_list.foreach (e => {
+				reaction_box.remove ((Widgets.ReactButton) e.value);
 
-			if (p.url != null) {
-				badge.append (new Widgets.Emoji (p.url));
-			} else {
-				badge.append (new Gtk.Label (p.name));
-			}
-
-			badge.append (new Gtk.Label (p.count.to_string ()));
-			badge_button.child = badge;
-
-			if (p.me == true) {
-				badge_button.add_css_class ("accent");
-				badge_button.update_state (Gtk.AccessibleState.PRESSED, Gtk.AccessibleTristate.TRUE, -1);
-			}
-
-			reaction_box.append (new Gtk.FlowBoxChild () {
-				child = badge_button,
-				focusable = false
+				return true;
 			});
-		}
+			react_btn_list.clear ();
 
-		reaction_box.visible = reactions.size > 0;
+
+			for (int j = 0; j < value.size; j++) {
+				API.EmojiReaction p = value.get (j);
+				if (p.count <= 0) return;
+
+				var badge_button = new Widgets.ReactButton (p);
+				badge_button.reaction_toggled.connect (on_reaction_toggled);
+				badge_button.removed.connect (on_remove);
+
+				reaction_box.insert (
+					new Gtk.FlowBoxChild () {
+						child = badge_button,
+						focusable = false
+					},
+					j
+				);
+
+				react_btn_list.set (p.name, badge_button);
+			}
+		}
+	}
+
+	string status_id;
+	public ReactionsRow (string status_id, Gee.ArrayList<API.EmojiReaction> reactions) {
+		this.status_id = status_id;
+		this.reactions = reactions;
+	}
+
+	private void on_reaction_toggled (ReactButton btn) {
+		btn.sensitive = false;
+		reaction_request (btn.shortcode, btn.has_reacted)
+			.with_account (accounts.active)
+			.then (() => {
+				btn.update_reacted (!btn.has_reacted);
+				btn.sensitive = true;
+			})
+			.on_error ((code, message) => {
+				warning (@"Error while reacting to $status_id with $(btn.shortcode): $code $message");
+				btn.sensitive = true;
+
+				app.toast ("%s: %s".printf (_("Error"), message));
+			})
+			.exec ();
+	}
+
+	private void react_with_shortcode (string shortcode) {
+		if (react_btn_list.has_key (shortcode)) {
+			on_reaction_toggled (react_btn_list.get (shortcode));
+		} else {
+			reaction_request (shortcode, false)
+				.with_account (accounts.active)
+				.then ((in_stream) => {
+					if (accounts.active.instance_info.pleroma != null) {
+						var parser = Network.get_parser_from_inputstream (in_stream);
+						var node = network.parse_node (parser);
+						var status = API.Status.from (node);
+						if (status.formal.compat_status_reactions != null) {
+							this.reactions = status.formal.compat_status_reactions;
+						}
+					}
+				})
+				.on_error ((code, message) => {
+					warning (@"Error while reacting to $status_id with $(shortcode): $code $message");
+					app.toast ("%s: %s".printf (_("Error"), message));
+				})
+				.exec ();
+		}
+	}
+
+	private Request reaction_request (string shortcode, bool has_reacted) {
+		if (accounts.active.instance_info.pleroma != null) {
+			string endpoint = @"/api/v1/pleroma/statuses/$status_id/reactions/$(Uri.escape_string(shortcode))";
+			return has_reacted ? new Request.DELETE (endpoint) : new Request.PUT (endpoint);
+		} else {
+			string action = "react";
+			if (has_reacted) {
+				action = "unreact";
+			}
+
+			string endpoint = @"/api/v1/statuses/$status_id/$action/$(Uri.escape_string(shortcode))";
+			return new Request.POST (endpoint);
+		}
+	}
+
+	private void on_remove (ReactButton btn) {
+		reaction_box.remove (btn);
+		react_btn_list.unset (btn.shortcode);
+	}
+
+	private void on_emoji_picked (string emoji) {
+		react_with_shortcode (emoji);
+	}
+
+	private void on_custom_emoji_picked (string emoji_shortcode) {
+		react_with_shortcode (emoji_shortcode.slice (1, -2));
 	}
 }

--- a/src/Widgets/meson.build
+++ b/src/Widgets/meson.build
@@ -8,6 +8,7 @@ sources += files(
     'CustomEmojiChooser.vala',
     'Emoji.vala',
     'EmojiLabel.vala',
+    'EmojiReactionAccounts.vala',
     'FocusPicker.vala',
     'FocusPicture.vala',
     'LabelWithWidgets.vala',

--- a/src/Widgets/meson.build
+++ b/src/Widgets/meson.build
@@ -19,6 +19,7 @@ sources += files(
     'PreviewCardInternal.vala',
     'PreviewCardExplore.vala',
     'ProfileCover.vala',
+    'ReactButton.vala',
     'RelationshipButton.vala',
     'RichLabel.vala',
     'ScaleRevealer.vala',


### PR DESCRIPTION
fix: #44 

![image](https://github.com/user-attachments/assets/614c2635-922e-4a17-b764-a7d0af4adef5)

Not that fond of the chooser buttons

TODO:
- [x] Chooser UX
- [x] Convert announcement rows to reactionrows
- [x] Support the glitch pr (I really don't like the API, yes it makes sense to be like that for statuses, but the announcement reactions already had a well established API, now all clients have to support two different APIs for the same backend for essentially the same thing :shrug:)
- [x] Reaction limits
- [ ] Maybe its time to start saving detected features with the account, as there's probably a race condition between instance info and reaction limits
- [x] List reactors on right click (popover, listbox, accountrow?)