### PR TITLE
feat: TagExtractor

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -645,6 +645,10 @@ video > overlay > revealer > controls, .audio-controls {
 	border-radius: 9999px;
 }
 
+.hashtag-bar-hashtag {
+	padding: 4px 11px;
+}
+
 .preview_card:not(.explore), .preview_card:not(.explore) image:not(.attachment-overlay-icon) {
 	background-color: alpha(currentColor, 0.0625);
 }

--- a/data/ui/widgets/status.ui
+++ b/data/ui/widgets/status.ui
@@ -321,6 +321,7 @@
                                       <object class="TubaWidgetsMarkupView" id="content">
                                         <property name="visible">True</property>
                                         <property name="hexpand">False</property>
+                                        <property name="extract-last-tags">True</property>
                                       </object>
                                     </child>
                                   </object>

--- a/src/Utils/TagExtractor.vala
+++ b/src/Utils/TagExtractor.vala
@@ -1,0 +1,54 @@
+public class Tuba.TagExtractor {
+	public struct Tag {
+		public string tag;
+		public string link;
+	}
+
+	public struct Result {
+		public string? input_without_tags;
+		public Tag[]? extracted_tags;
+	}
+
+	static GLib.Regex pango_uri_regex;
+	static construct {
+		try {
+			pango_uri_regex = new GLib.Regex ("<a href='(?<href>http[^']+)'>#(?<tag>[^<]+)<\\/a>", GLib.RegexCompileFlags.OPTIMIZE | GLib.RegexCompileFlags.CASELESS);
+		} catch (GLib.RegexError e) {
+			critical (e.message);
+		}
+	}
+
+	public static Result from_string (string input) {
+		new TagExtractor ();
+		Result res = { null, null };
+
+		int last_paragraph_begin = input.last_index_of ("\n\n");
+		if (last_paragraph_begin == -1) return res;
+
+		string last_paragraph = input.slice (last_paragraph_begin, input.length);
+		if (last_paragraph.strip ().last_index_of_char ('\n') > -1) return res;
+
+		try {
+			Tag[]? extracted_tags = null;
+			string cleaned_up_paragraph = pango_uri_regex.replace_eval (last_paragraph, last_paragraph.length, 0, 0, (match_info, data) => {
+				data.append ("");
+
+				if (extracted_tags == null) extracted_tags = {};
+				extracted_tags += Tag () {
+					tag = match_info.fetch_named ("tag"),
+					link = match_info.fetch_named ("href")
+				};
+
+				return false;
+			}).strip ();
+			if (cleaned_up_paragraph != "") return res;
+
+			res.extracted_tags = extracted_tags;
+			res.input_without_tags = input.slice (0, last_paragraph_begin);
+		} catch (GLib.RegexError e) {
+			critical (e.message);
+		}
+
+		return res;
+	}
+}

--- a/src/Utils/TagExtractor.vala
+++ b/src/Utils/TagExtractor.vala
@@ -1,4 +1,6 @@
 public class Tuba.TagExtractor {
+	public const int MAX_TAGS_ALLOWED = 20;
+
 	public struct Tag {
 		public string tag;
 		public string link;
@@ -41,7 +43,7 @@ public class Tuba.TagExtractor {
 
 				return false;
 			}).strip ();
-			if (cleaned_up_paragraph != "") return res;
+			if (cleaned_up_paragraph != "" || extracted_tags.length > MAX_TAGS_ALLOWED) return res;
 
 			res.extracted_tags = extracted_tags;
 			res.input_without_tags = input.slice (0, last_paragraph_begin);

--- a/src/Utils/meson.build
+++ b/src/Utils/meson.build
@@ -7,6 +7,7 @@ sources += files(
     'Html.vala',
     'Locale.vala',
     'ShareHandler.vala',
+    'TagExtractor.vala',
     'Tracking.vala',
     'Units.vala',
     'WebApHandler.vala',

--- a/src/Widgets/HashtagBar.vala
+++ b/src/Widgets/HashtagBar.vala
@@ -1,0 +1,70 @@
+public class Tuba.Widgets.HashtagBar : Adw.Bin {
+	const int MAX_VISIBLE_TAGS = 3;
+
+	public class HashtagButton : Gtk.Button {
+		construct {
+			this.clicked.connect (on_clicked);
+			this.css_classes = { "profile-role-border-radius", "hashtag-bar-hashtag" };
+		}
+
+		string tag;
+		public HashtagButton (TagExtractor.Tag hashtag) {
+			tag = hashtag.tag;
+			this.label = @"#$tag";
+		}
+
+		private void on_clicked () {
+			app.main_window.open_view (new Views.Hashtag (tag, null, Uri.escape_string (tag)));
+		}
+	}
+
+	Gtk.FlowBox flowbox;
+	Gtk.Button show_more;
+	construct {
+		flowbox = new Gtk.FlowBox () {
+			selection_mode = Gtk.SelectionMode.NONE,
+			column_spacing = 6,
+			row_spacing = 6,
+			max_children_per_line = 100
+		};
+
+		this.child = flowbox;
+	}
+
+	public HashtagBar (TagExtractor.Tag[] tags) {
+		for (int i = 0; i < tags.length; i++) {
+			flowbox.append (
+				new Gtk.FlowBoxChild () {
+					child = new HashtagButton (tags [i]),
+					visible = i < MAX_VISIBLE_TAGS,
+					focusable = false
+				}
+			);
+		}
+
+		if (tags.length > MAX_VISIBLE_TAGS) {
+			show_more = new Gtk.Button.with_label (_("Show %d More").printf (tags.length - MAX_VISIBLE_TAGS)) {
+				css_classes = { "flat", "profile-role-border-radius", "hashtag-bar-hashtag" }
+			};
+			show_more.clicked.connect (on_clicked);
+
+			flowbox.append (new Gtk.FlowBoxChild () {
+				child = show_more,
+				focusable = false
+			});
+		}
+	}
+
+	private void on_clicked () {
+		flowbox.remove (show_more);
+
+		int i = MAX_VISIBLE_TAGS;
+		var child = flowbox.get_child_at_index (i);
+		while (child != null) {
+			child.visible = true;
+
+			i = i + 1;
+			child = flowbox.get_child_at_index (i);
+		}
+	}
+}

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -887,6 +887,7 @@
 		}
 	}
 
+	private Widgets.HashtagBar hashtag_bar;
 	protected Widgets.PreviewCard prev_card;
 	private Widgets.Attachment.Box attachments;
 	private Gtk.Label translation_label;
@@ -1059,6 +1060,12 @@
 				prev_card.button.clicked.connect (open_card_url);
 				content_box.append (prev_card);
 			} catch {}
+		}
+
+		if (hashtag_bar != null) content_box.remove (prev_card);
+		if (this.content.get_extracted_tags () != null && this.content.get_extracted_tags ().length > 0) {
+			hashtag_bar = new Widgets.HashtagBar (this.content.get_extracted_tags ());
+			content_box.append (hashtag_bar);
 		}
 
 		show_view_stats_action ();

--- a/src/Widgets/meson.build
+++ b/src/Widgets/meson.build
@@ -10,6 +10,7 @@ sources += files(
     'EmojiLabel.vala',
     'FocusPicker.vala',
     'FocusPicture.vala',
+    'HashtagBar.vala',
     'LabelWithWidgets.vala',
     'ListBoxRowWrapper.vala',
     'MarkupView.vala',

--- a/tests/TagExtractor.test.vala
+++ b/tests/TagExtractor.test.vala
@@ -4,6 +4,17 @@ struct TestExtract {
 }
 
 TestExtract[] get_extractions () {
+	string max_limit_test_tag = "<a href='https://gnome.org/tags/test'>#test</a>";
+	Tuba.TagExtractor.Tag max_limit_test_tag_struct = {"test", "https://gnome.org/tags/test"};
+	string max_limit_test_source = "Testing the tag limit\n\n";
+	Tuba.TagExtractor.Tag[] max_limit_test_tags = {};
+
+	for (int i = 0; i < Tuba.TagExtractor.MAX_TAGS_ALLOWED; i++) {
+		max_limit_test_source += max_limit_test_tag;
+		max_limit_test_tags += max_limit_test_tag_struct;
+	}
+
+
 	return {
 		{
 			"I am a <a href='https://gnome.org/'>pango</a> markup label\n\n<a href='https://gnome.org/tags/opensource'>#opensource</a> <a href='https://gnome.org/tags/cookies'>#cookies</a> <a href='https://gnome.org/tags/frogs'>#frogs</a> <a href='https://gnome.org/tags/sunny'>#sunny</a>",
@@ -49,6 +60,17 @@ TestExtract[] get_extractions () {
 				"Same as before but no tags", null
 			}
 		},
+		{
+			max_limit_test_source,
+			{
+				"Testing the tag limit",
+				max_limit_test_tags
+			}
+		},
+		{
+			@"Same as before but plus 1. $max_limit_test_source$max_limit_test_tag",
+			null
+		}
 	};
 }
 

--- a/tests/TagExtractor.test.vala
+++ b/tests/TagExtractor.test.vala
@@ -1,0 +1,82 @@
+struct TestExtract {
+	public string source;
+	public Tuba.TagExtractor.Result? extracted;
+}
+
+TestExtract[] get_extractions () {
+	return {
+		{
+			"I am a <a href='https://gnome.org/'>pango</a> markup label\n\n<a href='https://gnome.org/tags/opensource'>#opensource</a> <a href='https://gnome.org/tags/cookies'>#cookies</a> <a href='https://gnome.org/tags/frogs'>#frogs</a> <a href='https://gnome.org/tags/sunny'>#sunny</a>",
+			{
+				"I am a <a href='https://gnome.org/'>pango</a> markup label", {
+					{"opensource", "https://gnome.org/tags/opensource"},
+					{"cookies", "https://gnome.org/tags/cookies"},
+					{"frogs", "https://gnome.org/tags/frogs"},
+					{"sunny", "https://gnome.org/tags/sunny"}
+				}
+			}
+		},
+		{
+			"Same as before but no spaces between tags\n\n<a href='https://gnome.org/tags/opensource'>#opensource</a><a href='https://gnome.org/tags/cookies'>#cookies</a><a href='https://gnome.org/tags/frogs'>#frogs</a><a href='https://gnome.org/tags/sunny'>#sunny</a>",
+			{
+				"Same as before but no spaces between tags", {
+					{"opensource", "https://gnome.org/tags/opensource"},
+					{"cookies", "https://gnome.org/tags/cookies"},
+					{"frogs", "https://gnome.org/tags/frogs"},
+					{"sunny", "https://gnome.org/tags/sunny"}
+				}
+			}
+		},
+		{
+			"Same as before but there's a newline in the middle\n\n<a href='https://gnome.org/tags/opensource'>#opensource</a><a href='https://gnome.org/tags/cookies'>#cookies</a>\n<a href='https://gnome.org/tags/frogs'>#frogs</a><a href='https://gnome.org/tags/sunny'>#sunny</a>",
+			null
+		},
+		{
+			"Same as before but there's non-hashtag text in the middle\n\n<a href='https://gnome.org/tags/opensource'>#opensource</a><a href='https://gnome.org/tags/cookies'>#cookies</a> hello? <a href='https://gnome.org/tags/frogs'>#frogs</a><a href='https://gnome.org/tags/sunny'>#sunny</a>",
+			null
+		},
+		{
+			"Same as before but there's a hashtag without #\n\n<a href='https://gnome.org/tags/opensource'>#opensource</a><a href='https://gnome.org/tags/cookies'>#cookies</a> hello? <a href='https://gnome.org/tags/frogs'>frogs</a><a href='https://gnome.org/tags/sunny'>#sunny</a>",
+			null
+		},
+		{
+			"Same as before but single newline\n<a href='https://gnome.org/tags/opensource'>#opensource</a><a href='https://gnome.org/tags/cookies'>#cookies</a><a href='https://gnome.org/tags/frogs'>#frogs</a><a href='https://gnome.org/tags/sunny'>#sunny</a>",
+			null
+		},
+		{
+			"Same as before but no tags\n\n",
+			{
+				"Same as before but no tags", null
+			}
+		},
+	};
+}
+
+public void test_extractor () {
+	foreach (var test_extract in get_extractions ()) {
+		var extraction = Tuba.TagExtractor.from_string (test_extract.source);
+		if (test_extract.extracted == null) {
+			assert_true (extraction.input_without_tags == null);
+			assert_true (extraction.extracted_tags == null);
+		} else {
+			assert_cmpstr (test_extract.extracted.input_without_tags, CompareOperator.EQ, extraction.input_without_tags);
+			if (test_extract.extracted.extracted_tags == null) {
+				assert_true (extraction.extracted_tags == null);
+			} else {
+				assert_cmpint (test_extract.extracted.extracted_tags.length, CompareOperator.EQ, extraction.extracted_tags.length);
+
+				for (int i = 0; i < test_extract.extracted.extracted_tags.length; i++) {
+					assert_cmpstr (test_extract.extracted.extracted_tags[i].tag, CompareOperator.EQ, extraction.extracted_tags[i].tag);
+					assert_cmpstr (test_extract.extracted.extracted_tags[i].link, CompareOperator.EQ, extraction.extracted_tags[i].link);
+				}
+			}
+		}
+	}
+}
+
+public int main (string[] args) {
+	Test.init (ref args);
+
+	Test.add_func ("/test_extractor", test_extractor);
+	return Test.run ();
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -17,6 +17,9 @@ unit_tests = {
     'ShareHandler': files (
         meson.project_source_root() + '/src/Utils/ShareHandler.vala'
     ),
+    'TagExtractor': files (
+        meson.project_source_root() + '/src/Utils/TagExtractor.vala'
+    ),
     'Tracking': files (
         meson.project_source_root() + '/src/Utils/Tracking.vala'
     ),


### PR DESCRIPTION
fix: #880 

I tried out different ways to do this and honestly this is probably the best.

- Extracting while parsing the HTML

The way libxml2 traverses through a doc is unpredictable (aka, when it reaches an anchor, you can't exactly get the content, you have to go through it and usually the `#` character and the hashtag name are in different elements). That makes it impossible to detect that an anchor is a hashtag quickly and before parsing and appending it. Same thing for detecting if the last paragraph only has hashtags.

The structure also depends on the backend.

- Extracting them afterwards by parsing the pango markup

While we now have a predictable structure, the same issue as above is still present. It becomes too difficult to reliably detect if the last paragraph is only made of hashtag anchors.

- Current solution

Regex. (Anchors are predictable as it's being ran on the converted HTML)



https://github.com/user-attachments/assets/6bb4f161-a3f0-4757-89d5-cb5b6c672e18


