### PR TITLE
feat: do not force GL by default

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -229,7 +229,6 @@ namespace Tuba {
 					GLib.Environment.set_variable ("SECRET_FILE_TEST_PASSWORD", @"$(GLib.Environment.get_user_name ())$(Build.DOMAIN)", false);
 			#endif
 
-			GLib.Environment.set_variable ("GSK_RENDERER", "gl", false);
 			if (GLib.Environment.get_variable ("GSK_RENDERER") == "gl") {
 				GLib.Environment.set_variable ("GDK_DEBUG", "gl-no-fractional", false);
 			}


### PR DESCRIPTION
fix: #197 

When ngl was the default, some users noticed a significant performance regression. So we set the default to be GL (while respecting `GSK_RENDERER`).

On 47, Vulkan became the default renderer and the performance should be much better than ngl.

Both ngl and Vulkan fix many artifacts (like curcular avatars becoming square while scrolling sometimes) and the #197 issue from what I gathered.