### PR TITLE
feat(votebox): show results + refresh

### DIFF
--- a/data/ui/widgets/votebox.ui
+++ b/data/ui/widgets/votebox.ui
@@ -1,41 +1,57 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <requires lib="gtk" version="4.0"/>
-  <template class="TubaWidgetsVoteBox" parent="GtkBox">
-    <property name="margin_top">12</property>
-    <property name="orientation">vertical</property>
-    <child>
-      <object class="GtkListBox" id="poll_box">
-        <child>
-          <placeholder/>
-        </child>
-        <style>
-          <class name="boxed-list"/>
-          <class name="frame"/>
-          <class name="no-shadow"/>
-          <class name="uniform-border-color"/>
-        </style>
-      </object>
-    </child>
-    <child>
-      <object class="GtkBox">
-        <property name="margin_top">10</property>
-        <property name="spacing">12</property>
-        <child>
-          <object class="GtkButton" id="button_vote">
-            <property name="visible">0</property>
-            <property name="valign">center</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel" id="info_label">
-            <property name="wrap">1</property>
-            <property name="wrap-mode">word-char</property>
-            <property name="xalign">1</property>
-            <property name="hexpand">1</property>
-          </object>
-        </child>
-      </object>
-    </child>
-  </template>
+	<requires lib="gtk" version="4.0" />
+	<template class="TubaWidgetsVoteBox" parent="GtkBox">
+		<property name="margin_top">12</property>
+		<property name="orientation">vertical</property>
+		<child>
+			<object class="GtkListBox" id="poll_box">
+				<child>
+					<placeholder />
+				</child>
+				<style>
+					<class name="boxed-list" />
+					<class name="frame" />
+					<class name="no-shadow" />
+					<class name="uniform-border-color" />
+				</style>
+			</object>
+		</child>
+		<child>
+			<object class="GtkBox">
+				<property name="margin_top">10</property>
+				<property name="spacing">6</property>
+				<child>
+					<object class="GtkButton" id="button_results">
+						<property name="visible">0</property>
+						<property name="valign">center</property>
+						<signal name="clicked" handler="on_toggle_results" swapped="no" />
+					</object>
+				</child>
+				<child>
+					<object class="GtkButton" id="button_vote">
+						<property name="label" translatable="yes">Vote</property>
+						<property name="visible">0</property>
+						<property name="valign">center</property>
+					</object>
+				</child>
+				<child>
+					<object class="GtkButton" id="button_refresh">
+						<property name="visible" bind-source="button_vote" bind-property="visible" bind-flags="sync-create|invert-boolean" />
+						<property name="label" translatable="yes">Refresh</property>
+						<property name="valign">center</property>
+						<signal name="clicked" handler="on_refresh_poll" swapped="no" />
+					</object>
+				</child>
+				<child>
+					<object class="GtkLabel" id="info_label">
+						<property name="wrap">1</property>
+						<property name="wrap-mode">word-char</property>
+						<property name="xalign">1</property>
+						<property name="hexpand">1</property>
+					</object>
+				</child>
+			</object>
+		</child>
+	</template>
 </interface>

--- a/src/Widgets/VoteBox.vala
+++ b/src/Widgets/VoteBox.vala
@@ -2,15 +2,17 @@
 public class Tuba.Widgets.VoteBox : Gtk.Box {
 	[GtkChild] protected unowned Gtk.ListBox poll_box;
 	[GtkChild] protected unowned Gtk.Button button_vote;
+	[GtkChild] protected unowned Gtk.Button button_refresh;
+	[GtkChild] protected unowned Gtk.Button button_results;
 	[GtkChild] protected unowned Gtk.Label info_label;
 
 	public API.Poll? poll { get; set;}
 	protected Gee.ArrayList<string> selected_index = new Gee.ArrayList<string> ();
+	private bool show_results { get; set; default=false; }
 
 	public API.Translation? translation { get; set; default=null; }
 
 	construct {
-		button_vote.set_label (_("Vote"));
 		button_vote.clicked.connect (on_vote_button_clicked);
 		notify["poll"].connect (update);
 		button_vote.sensitive = false;
@@ -71,10 +73,22 @@ public class Tuba.Widgets.VoteBox : Gtk.Box {
 			entry = poll_box.get_first_child ();
 		}
 
-		// Reset button visibility
-		button_vote.visible = !poll.expired && !poll.voted;
+		selected_index.clear ();
 
-		if (poll.expired || poll.voted) {
+		// Reset button visibility
+		button_vote.sensitive = false;
+		button_vote.visible = !this.show_results && !poll.expired && !poll.voted;
+		button_results.visible = !poll.expired && !poll.voted;
+
+		if (this.show_results) {
+			button_results.icon_name = "tuba-eye-not-looking-symbolic";
+			button_results.tooltip_text = _("Hide Results");
+		} else {
+			button_results.icon_name = "tuba-eye-open-negative-filled-symbolic";
+			button_results.tooltip_text = _("Show Results");
+		}
+
+		if (poll.expired || poll.voted || this.show_results) {
 			foreach (API.PollOption p in poll.options) {
 				if (p.votes_count > winner_p) {
 					winner_p = p.votes_count;
@@ -91,7 +105,7 @@ public class Tuba.Widgets.VoteBox : Gtk.Box {
 			};
 
 			// If it is own poll
-			if (poll.expired || poll.voted) {
+			if (poll.expired || poll.voted || this.show_results) {
 				// If multiple, Checkbox else radioButton
 				var percentage = poll.votes_count > 0 ? ((double)p.votes_count / poll.votes_count) * 100 : 0.0;
 
@@ -146,7 +160,7 @@ public class Tuba.Widgets.VoteBox : Gtk.Box {
 					}
 				}
 
-				if (poll.expired || poll.voted) {
+				if (poll.expired || poll.voted || this.show_results) {
 					check_option.sensitive = false;
 				}
 
@@ -211,5 +225,39 @@ public class Tuba.Widgets.VoteBox : Gtk.Box {
 		}
 
 		button_vote.sensitive = selected_index.size > 0;
+	}
+
+	[GtkCallback] private void on_refresh_poll () {
+		if (poll == null) return;
+
+		button_refresh.sensitive = false;
+		new Request.GET (@"/api/v1/polls/$(poll.id)")
+			.with_account (accounts.active)
+			.then ((in_stream) => {
+				button_refresh.sensitive = true;
+
+				var parser = Network.get_parser_from_inputstream (in_stream);
+				var node = network.parse_node (parser);
+				var parsed_poll = API.Poll.from (node);
+
+				if (parsed_poll != null) {
+					poll = parsed_poll;
+					update ();
+				}
+			})
+			.on_error ((code, message) => {
+				warning (@"Couldn't refresh poll $(poll.id): $code $message");
+				button_refresh.sensitive = true;
+
+				app.toast (@"Couldn't refresh poll: $message");
+			})
+			.exec ();
+	}
+
+	[GtkCallback] private void on_toggle_results () {
+		if (poll == null) return;
+
+		this.show_results = !this.show_results;
+		update ();
 	}
 }


### PR DESCRIPTION
I kinda forgot about this oops

![Screenshot From 2024-10-13 19-21-56](https://github.com/user-attachments/assets/4dc2c0f1-96d3-4773-9baa-fd6395463672)
![Screenshot From 2024-10-13 19-22-03](https://github.com/user-attachments/assets/f0aa8e2c-33fa-48cd-bdfb-5ec2cc07fe88)

You can now see results without voting + you can refresh them