### PR TITLE
fix(CompletionProvider): remove prefix from searching

### DIFF
--- a/src/Dialogs/Composer/Completion/HandleProvider.vala
+++ b/src/Dialogs/Composer/Completion/HandleProvider.vala
@@ -17,7 +17,7 @@ public class Tuba.HandleProvider: Tuba.CompletionProvider {
 	}
 
 	public override async ListModel suggest (string word, Cancellable? cancellable) throws Error {
-		var req = API.Account.search (word);
+		var req = API.Account.search (word.substring (1));
 		yield req.await ();
 
 		var results = new GLib.ListStore (typeof (Object));

--- a/src/Dialogs/Composer/Completion/HashtagProvider.vala
+++ b/src/Dialogs/Composer/Completion/HashtagProvider.vala
@@ -17,7 +17,7 @@ public class Tuba.HashtagProvider: Tuba.CompletionProvider {
 	}
 
 	public override async ListModel suggest (string word, Cancellable? cancellable) throws Error {
-		var req = API.Tag.search (word);
+		var req = API.Tag.search (word.substring (1));
 		yield req.await ();
 
 		var suggestions = new GLib.ListStore (typeof (Object));


### PR DESCRIPTION
fix: #1167

During #1003 (iirc), we improved capturing, which started including the prefix in the captured word. That makes the search apis search for `@[username]`, `#[hashtag]`. While Mastodon seems to be okay with it, other backends might not normalize it (like removing the prefix if it doesn't match their internal structures).

This PR removes the prefix in the handle and hashtag providers when searching.
