### PR TITLE
fix(lww): label measuring when pango wrap is word_char

### DIFF
--- a/src/Widgets/LabelWithWidgets.vala
+++ b/src/Widgets/LabelWithWidgets.vala
@@ -70,7 +70,7 @@ public class Tuba.Widgets.LabelWithWidgets : Gtk.Widget, Gtk.Buildable, Gtk.Acce
 	construct {
 		label = new Gtk.Label ("") {
 			wrap = true,
-			wrap_mode = Pango.WrapMode.WORD_CHAR,
+			wrap_mode = Pango.WrapMode.WORD,
 			xalign = 0.0f,
 			valign = Gtk.Align.START,
 			use_markup = false,
@@ -246,7 +246,7 @@ public class Tuba.Widgets.LabelWithWidgets : Gtk.Widget, Gtk.Buildable, Gtk.Acce
 
 		if (old_label != new_label) {
 			label.wrap = true;
-			label.wrap_mode = Pango.WrapMode.WORD_CHAR;
+			label.wrap_mode = Pango.WrapMode.WORD;
 
 			_text = new_label;
 			label.label = _text;


### PR DESCRIPTION
fix: #914 

TODO: maybe set it to word only when inside markupview?