### PR TITLE
fix(ProfileEdit): bind with parent source

### DIFF
--- a/data/ui/dialogs/profile_edit.ui
+++ b/data/ui/dialogs/profile_edit.ui
@@ -128,7 +128,6 @@
                             <property name="title" translatable="yes">Bio</property>
                             <child type="action">
                               <object class="GtkMenuButton" id="cepbtn">
-                                <property name="sensitive" bind-source="bio_row" bind-property="expanded" bind-flags="sync-create"/>
                                 <style>
                                   <class name="circular"/>
                                 </style>

--- a/src/Dialogs/ProfileEdit.vala
+++ b/src/Dialogs/ProfileEdit.vala
@@ -97,6 +97,7 @@ public class Tuba.Dialogs.ProfileEdit : Adw.Dialog {
 
 		if (accounts.active.instance_emojis != null && accounts.active.instance_emojis.size > 0) {
 			cepbtn.visible = true;
+			bio_row.bind_property ("expanded", cepbtn, "sensitive", GLib.BindingFlags.SYNC_CREATE);
 		}
 	}
 


### PR DESCRIPTION
fix: #1168

According to the log attached on that issue, it has to do with the property binding in the ui file :shrug: 

Unknown why I cannot reproduce it, maybe aarch64 only?
