### PR TITLE
feat(votebox): dont show results button if the poll has expired

### DIFF
--- a/data/ui/widgets/votebox.ui
+++ b/data/ui/widgets/votebox.ui
@@ -37,7 +37,6 @@
 				</child>
 				<child>
 					<object class="GtkButton" id="button_refresh">
-						<property name="visible" bind-source="button_vote" bind-property="visible" bind-flags="sync-create|invert-boolean" />
 						<property name="label" translatable="yes">Refresh</property>
 						<property name="valign">center</property>
 						<signal name="clicked" handler="on_refresh_poll" swapped="no" />

--- a/src/Widgets/VoteBox.vala
+++ b/src/Widgets/VoteBox.vala
@@ -79,7 +79,7 @@ public class Tuba.Widgets.VoteBox : Gtk.Box {
 		button_vote.sensitive = false;
 		button_vote.visible = !this.show_results && !poll.expired && !poll.voted;
 		button_results.visible = !poll.expired && !poll.voted;
-		button_refresh.visible = !poll.expired;
+		button_refresh.visible = !button_vote.visible && !poll.expired;
 
 		if (this.show_results) {
 			button_results.icon_name = "tuba-eye-not-looking-symbolic";

--- a/src/Widgets/VoteBox.vala
+++ b/src/Widgets/VoteBox.vala
@@ -79,6 +79,7 @@ public class Tuba.Widgets.VoteBox : Gtk.Box {
 		button_vote.sensitive = false;
 		button_vote.visible = !this.show_results && !poll.expired && !poll.voted;
 		button_results.visible = !poll.expired && !poll.voted;
+		button_refresh.visible = !poll.expired;
 
 		if (this.show_results) {
 			button_results.icon_name = "tuba-eye-not-looking-symbolic";


### PR DESCRIPTION
There's no point in refreshing an expired poll, remove the button if expired.