### PR TITLE
fix(TabbedBase): headerbar stack width due to homogeneous

### DIFF
--- a/src/Views/TabbedBase.vala
+++ b/src/Views/TabbedBase.vala
@@ -67,7 +67,9 @@ public class Tuba.Views.TabbedBase : Views.Base {
 	}
 
 	public override void build_header () {
-		title_stack = new Gtk.Stack ();
+		title_stack = new Gtk.Stack () {
+			hhomogeneous = false
+		};
 		header.title_widget = title_stack;
 
 		switcher = new Adw.ViewSwitcher () { policy = Adw.ViewSwitcherPolicy.WIDE };


### PR DESCRIPTION
default is hhomogeneous true
tabbed bases have view switchers that can make the width much larger
hhomogeneous makes the stack width as big as the biggest child, even if it's not visible

fix: #1183 