### PR TITLE
Let BlurHash to be transliterated for non Latin scripts.

### DIFF
--- a/data/ui/dialogs/preferences.ui
+++ b/data/ui/dialogs/preferences.ui
@@ -76,7 +76,7 @@
 						</child>
 						<child>
 							<object class="AdwSwitchRow" id="use_blurhash">
-								<property name="title" translatable="no">BlurHash</property>
+								<property name="title" translatable="yes">BlurHash</property>
 								<property name="subtitle" translatable="yes">Show a blurred version of the media until they fully load</property>
 							</object>
 						</child>


### PR DESCRIPTION
in many non-Latin scripts e.g. Persian, words like `BlurHash` should be transliterated or they can not be read, understood or identified at all.