### PR TITLE
feat: set text domain codeset to utf8

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -220,6 +220,7 @@ namespace Tuba {
 
 			Intl.setlocale (LocaleCategory.ALL, "");
 			Intl.bindtextdomain (Build.GETTEXT_PACKAGE, Build.LOCALEDIR);
+			Intl.bind_textdomain_codeset (Build.GETTEXT_PACKAGE, "UTF-8");
 			Intl.textdomain (Build.GETTEXT_PACKAGE);
 
 			GLib.Environment.unset_variable ("GTK_THEME");


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/libspelling/-/issues/20