### PR TITLE
feat: remove accounts that get muted/blocked from home

### DIFF
--- a/src/API/Relationship.vala
+++ b/src/API/Relationship.vala
@@ -94,7 +94,7 @@ public class Tuba.API.Relationship : Entity {
 				invalidate (node);
 				debug (@"Performed \"$operation\" on Relationship $id");
 
-				if (operation == "mute" || operation == "block") app.remove_user_id (id);
+				if (operation == "mute" || operation == "block" || operation == "unfollow") app.remove_user_id (id);
 			});
 
 		if (modify_params != null) {

--- a/src/API/Relationship.vala
+++ b/src/API/Relationship.vala
@@ -93,6 +93,8 @@ public class Tuba.API.Relationship : Entity {
 				var node = network.parse_node (parser);
 				invalidate (node);
 				debug (@"Performed \"$operation\" on Relationship $id");
+
+				if (operation == "mute" || operation == "block") app.remove_user_id (id);
 			});
 
 		if (modify_params != null) {

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -47,6 +47,7 @@ namespace Tuba {
 
 		public signal void refresh ();
 		public signal void relationship_invalidated (API.Relationship new_relationship);
+		public signal void remove_user_id (string user_id);
 		public signal void toast (string title, uint timeout = 5);
 
 		#if DEV_MODE

--- a/src/Views/Home.vala
+++ b/src/Views/Home.vala
@@ -54,6 +54,8 @@ public class Tuba.Views.Home : Views.Timeline {
 				| BindingFlags.BIDIRECTIONAL
 			#endif
 		);
+
+		app.remove_user_id.connect (on_remove_user);
 	}
 
 	void toggle_scroll_to_top_margin () {

--- a/src/Views/Timeline.vala
+++ b/src/Views/Timeline.vala
@@ -376,4 +376,15 @@ public class Tuba.Views.Timeline : AccountHolder, Streamable, Views.ContentBase 
 			warning (@"Error getting String from json: $(e.message)");
 		}
 	}
+
+	public virtual void on_remove_user (string user_id) {
+		if (accepts != typeof (API.Status)) return;
+
+		for (uint i = 0; i < model.get_n_items (); i++) {
+			var status_obj = (API.Status) model.get_item (i);
+			if (status_obj.formal.account.id == user_id) {
+				model.remove (i);
+			}
+		}
+	}
 }


### PR DESCRIPTION
I remember Jeff mentioning this at some point, but when you mute/block an account current loaded posts from them are not removed until refreshed. This PR does that, however, I only enabled it for 'Home'. I don't know if they should be removed from convos/notifications and the other timelines are probably not open that long to require listening to this signal.

edit: found it
fix: #233