### PR TITLE
fix(Host): use UriLauncher by default

### DIFF
--- a/src/Utils/Host.vala
+++ b/src/Utils/Host.vala
@@ -31,20 +31,15 @@ public class Tuba.Host {
 
 	private static void open_in_default_app (string uri) {
 		debug (@"Opening URI: $uri");
-		try {
-			var success = AppInfo.launch_default_for_uri (uri, null);
-			if (!success)
-				throw new Oopsie.USER ("launch_default_for_uri() failed");
-		} catch (Error e) {
-			var launcher = new Gtk.UriLauncher (uri);
-			launcher.launch.begin (app.active_window, null, (obj, res) => {
-				try {
-					launcher.launch.end (res);
-				} catch (Error e) {
-					warning (@"Error opening uri \"$uri\": $(e.message)");
-				}
-			});
-		}
+
+		var launcher = new Gtk.UriLauncher (uri);
+		launcher.launch.begin (app.active_window, null, (obj, res) => {
+			try {
+				launcher.launch.end (res);
+			} catch (Error e) {
+				warning (@"Error opening uri \"$uri\": $(e.message)");
+			}
+		});
 	}
 
 	public static void copy (string str) {


### PR DESCRIPTION
fix: #1210

On #1210, Łukasz reported and debugged an issue with the way we open uris in browser. We've been using `AppInfo.launch_default_for_uri` with `Gtk.UriLauncher` as a fallback. From what I gathered, the former uses dbus (and we didn't use its async variant, so Tuba froze when it failed), while the later the portal. This PR makes it so it only uses `Gtk.UriLauncher`.