### PR TITLE
feat: draft posts

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -90,6 +90,7 @@ namespace Tuba {
 			{ "open-follow-requests", open_follow_requests },
 			{ "open-mutes-blocks", open_mutes_blocks },
 			{ "open-scheduled-posts", open_scheduled_posts },
+			{ "open-draft-posts", open_draft_posts },
 			{ "open-admin-dashboard", open_admin_dashboard }
 		};
 
@@ -533,6 +534,11 @@ namespace Tuba {
 
 		public void open_scheduled_posts () {
 			main_window.open_view (new Views.ScheduledStatuses ());
+			close_sidebar ();
+		}
+
+		public void open_draft_posts () {
+			main_window.open_view (new Views.DraftStatuses ());
 			close_sidebar ();
 		}
 

--- a/src/Dialogs/Composer/Dialog.vala
+++ b/src/Dialogs/Composer/Dialog.vala
@@ -152,6 +152,10 @@ public class Tuba.Dialogs.Compose : Adw.Dialog {
 
 			if (value) {
 				var menu_model = new GLib.Menu ();
+				// translators: 'Draft' is a verb
+				menu_model.append (_("Draft Post"), "composer.draft");
+
+				// translators: 'Schedule' is a verb
 				menu_model.append (_("Schedule Post"), "composer.schedule");
 
 				commit_button = new Adw.SplitButton () {
@@ -197,9 +201,13 @@ public class Tuba.Dialogs.Compose : Adw.Dialog {
 		var schedule_action = new SimpleAction ("schedule", null);
 		schedule_action.activate.connect (on_schedule_action_activated);
 
+		var draft_action = new SimpleAction ("draft", null);
+		draft_action.activate.connect (on_draft_action_activated);
+
 		var action_group = new GLib.SimpleActionGroup ();
 		action_group.add_action (paste_action);
 		action_group.add_action (schedule_action);
+		action_group.add_action (draft_action);
 
 		this.insert_action_group ("composer", action_group);
 		add_binding_action (Gdk.Key.V, Gdk.ModifierType.CONTROL_MASK, "composer.paste", null);
@@ -322,6 +330,18 @@ public class Tuba.Dialogs.Compose : Adw.Dialog {
 			quote_id: quote_id
 		);
 	}
+
+	public Compose.from_draft (API.Status status, owned SuccessCallback? t_cb = null) {
+		Object (
+			commit_button_has_menu: true,
+			status: new BasicStatus.from_status (status),
+			original_status: new BasicStatus.from_status (status),
+			button_class: "suggested-action"
+		);
+
+		this.cb = (owned) t_cb;
+	}
+
 
 	public Compose.redraft (API.Status status) {
 		Object (
@@ -521,6 +541,13 @@ public class Tuba.Dialogs.Compose : Adw.Dialog {
 		var schedule_dlg = new Dialogs.Schedule ();
 		schedule_dlg.schedule_picked.connect (on_schedule_picked);
 		schedule_dlg.present (this);
+	}
+
+	private void on_draft_action_activated () {
+		if (!commit_button.sensitive) return;
+
+		schedule_iso8601 = (new GLib.DateTime.now ()).add_years (3000).format_iso8601 ();
+		on_commit ();
 	}
 
 	private void on_schedule_picked (string iso8601) {

--- a/src/Views/DraftStatuses.vala
+++ b/src/Views/DraftStatuses.vala
@@ -1,0 +1,21 @@
+public class Tuba.Views.DraftStatuses : Views.ScheduledStatuses {
+	construct {
+		label = _("Draft Posts");
+		icon = "tuba-bookmarks-symbolic"; // TODO?
+		empty_state_title = _("No Draft Posts");
+	}
+
+	public override Gtk.Widget on_create_model_widget (Object obj) {
+		var widget = base.on_create_model_widget (obj);
+		var widget_scheduled = widget as Widgets.ScheduledStatus;
+
+		if (widget_scheduled != null) widget_scheduled.draft = true;
+
+		return widget;
+	}
+
+	public override bool should_hide (Entity entity) {
+		var scheduled_entity = entity as API.ScheduledStatus;
+		return scheduled_entity != null && new GLib.DateTime.from_iso8601 (scheduled_entity.scheduled_at, null).get_year () <= API.ScheduledStatus.DRAFT_YEAR;
+	}
+}

--- a/src/Views/Sidebar.vala
+++ b/src/Views/Sidebar.vala
@@ -62,6 +62,7 @@ public class Tuba.Views.Sidebar : Gtk.Widget, AccountHolder {
 		misc_submenu_model.append (_("Announcements"), "app.open-announcements");
 		misc_submenu_model.append (_("Follow Requests"), "app.open-follow-requests");
 		misc_submenu_model.append (_("Mutes & Blocks"), "app.open-mutes-blocks");
+		misc_submenu_model.append (_("Draft Posts"), "app.open-draft-posts");
 		misc_submenu_model.append (_("Scheduled Posts"), "app.open-scheduled-posts");
 
 		var admin_dahsboard_menu_item = new MenuItem (_("Admin Dashboard"), "app.open-admin-dashboard");

--- a/src/Views/meson.build
+++ b/src/Views/meson.build
@@ -5,6 +5,7 @@ sources += files(
     'Bookmarks.vala',
     'ContentBase.vala',
     'Conversations.vala',
+    'DraftStatuses.vala',
     'Explore.vala',
     'EditHistory.vala',
     'Favorites.vala',


### PR DESCRIPTION
After #1209, this was easy to do but keep in mind that this is not *my* implementation but rather my attempt at working together with other clients:

- There's no draft post api, so clients seem to be using scheduled posts, set to very far in the future (3000+ years)
- This is good because the server validates the draft, keep the attachments saved and syncs them between all clients
- But, it also means that the server has your drafts

