### PR TITLE
feat(NAD): close on ESC when possible

### DIFF
--- a/src/Dialogs/NewAccount.vala
+++ b/src/Dialogs/NewAccount.vala
@@ -55,6 +55,8 @@ public class Tuba.Dialogs.NewAccount: Adw.Window {
 
 		if (!can_access_settings) {
 			app.toast.connect (add_toast);
+		} else {
+			add_binding_action (Gdk.Key.Escape, 0, "window.close", null);
 		}
 
 		manual_auth_label.activate_link.connect (on_manual_auth);
@@ -297,7 +299,6 @@ public class Tuba.Dialogs.NewAccount: Adw.Window {
 			this.title = _("Settings");
 			this.content_width = 460;
 			this.content_height = 220;
-			this.can_close = false;
 
 			var cancel_button = new Gtk.Button.with_label (_("Cancel"));
 			cancel_button.clicked.connect (on_cancel);


### PR DESCRIPTION
fix: #1212

The new account dialog (nad), is still not an adw.dialog, because it can be used both as a standalone window (when there's no accounts) or a modal (when adding another account).

This PR makes it so it can be closed with ESC when it's not standalone. Plus sets the extra settings dialog to be able to be closed.