### PR TITLE
feat(ScheduledStatuses): edit

### DIFF
--- a/src/Views/ScheduledStatuses.vala
+++ b/src/Views/ScheduledStatuses.vala
@@ -11,7 +11,10 @@ public class Tuba.Views.ScheduledStatuses : Views.Timeline {
 		var widget = base.on_create_model_widget (obj);
 		var widget_scheduled = widget as Widgets.ScheduledStatus;
 
-		if (widget_scheduled != null) widget_scheduled.deleted.connect (on_deleted_scheduled);
+		if (widget_scheduled != null) {
+			widget_scheduled.deleted.connect (on_deleted_scheduled);
+			widget_scheduled.refresh.connect (on_refresh);
+		}
 
 		return widget;
 	}

--- a/src/Widgets/ScheduledStatus.vala
+++ b/src/Widgets/ScheduledStatus.vala
@@ -1,5 +1,6 @@
 public class Tuba.Widgets.ScheduledStatus : Gtk.ListBoxRow {
 	public signal void deleted (string scheduled_status_id);
+	public signal void refresh ();
 	public signal void open ();
 
 	private bool _draft = false;
@@ -14,6 +15,7 @@ public class Tuba.Widgets.ScheduledStatus : Gtk.ListBoxRow {
 	}
 
 	Gtk.Button reschedule_button;
+	Gtk.Button edit_button;
 	Gtk.Box content_box;
 	Gtk.Label schedule_label;
 	construct {
@@ -37,6 +39,14 @@ public class Tuba.Widgets.ScheduledStatus : Gtk.ListBoxRow {
 		action_box.append (schedule_label);
 
 		var actions_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6);
+		edit_button = new Gtk.Button.from_icon_name ("document-edit-symbolic") {
+			css_classes = { "flat" },
+			tooltip_text = _("Edit"),
+			valign = Gtk.Align.CENTER
+		};
+		edit_button.clicked.connect (on_edit);
+		actions_box.append (edit_button);
+
 		reschedule_button = new Gtk.Button.from_icon_name ("tuba-clock-alt-symbolic") {
 			tooltip_text = _("Reschedule"),
 			css_classes = { "flat" }
@@ -73,6 +83,7 @@ public class Tuba.Widgets.ScheduledStatus : Gtk.ListBoxRow {
 		scheduled_at = scheduled_status.scheduled_at;
 		scheduled_id = scheduled_status.id;
 
+		GLib.DateTime now_load = new GLib.DateTime.now_local ();
 		API.Poll? poll = null;
 		if (scheduled_status.props.poll != null) {
 			poll = new API.Poll ("0") {
@@ -87,7 +98,7 @@ public class Tuba.Widgets.ScheduledStatus : Gtk.ListBoxRow {
 				});
 			}
 
-			poll.expires_at = new GLib.DateTime.now_local ().add_seconds (scheduled_status.props.poll.expires_in).format_iso8601 ();
+			poll.expires_at = now_load.add_seconds (scheduled_status.props.poll.expires_in).format_iso8601 ();
 		}
 
 		var status = new API.Status.empty () {
@@ -117,6 +128,10 @@ public class Tuba.Widgets.ScheduledStatus : Gtk.ListBoxRow {
 
 		// Re-parse the date into a MONTH DAY, YEAR (separator) HOUR:MINUTES
 		var date_parsed = new GLib.DateTime.from_iso8601 (scheduled_status.scheduled_at, null);
+
+		var delta = date_parsed.to_local ().difference (now_load);
+		edit_button.visible = delta >= TimeSpan.HOUR || delta / TimeSpan.MINUTE > 5;
+
 		date_parsed = date_parsed.to_timezone (new TimeZone.local ());
 		var date_local = _("%B %e, %Y");
 		// translators: Scheduled Post title, 'scheduled for: <date>'
@@ -197,5 +212,13 @@ public class Tuba.Widgets.ScheduledStatus : Gtk.ListBoxRow {
 
 	private void on_draft_posted (API.Status x) {
 		if (_draft) delete_status ();
+	}
+
+	private void on_edit () {
+		new Dialogs.Compose.from_scheduled (status_widget.status, scheduled_id, scheduled_at, on_edited);
+	}
+
+	private void on_edited (API.Status x) {
+		refresh ();
 	}
 }

--- a/src/Widgets/ScheduledStatus.vala
+++ b/src/Widgets/ScheduledStatus.vala
@@ -130,7 +130,7 @@ public class Tuba.Widgets.ScheduledStatus : Gtk.ListBoxRow {
 		var date_parsed = new GLib.DateTime.from_iso8601 (scheduled_status.scheduled_at, null);
 
 		var delta = date_parsed.to_local ().difference (now_load);
-		edit_button.visible = delta >= TimeSpan.HOUR || delta / TimeSpan.MINUTE > 5;
+		edit_button.visible = delta >= TimeSpan.HOUR;
 
 		date_parsed = date_parsed.to_timezone (new TimeZone.local ());
 		var date_local = _("%B %e, %Y");


### PR DESCRIPTION
fix: #1214 

As per my comment on that issue, the API does not allow us to directly edit them but hacking around that, we can delete and reschedule them.

It gets a bit messy with schedule timing however. Since the min is 5 mins, we *cannot* edit scheduled posts that are about to be posted, users first need to reschedule them to a future date and the edit button will appear.

It also leaves a period of error: If a post is to be posted in 6 minutes and the user clicks edit, if they spend 6 minutes in the composer, it will be posted. If they spend 2 minutes in the composer, it won't be able to edit it as the new schedule time will only be 4 minutes in the future.