### PR TITLE
feat(Status): warn before copying link to a private post

### DIFF
--- a/data/dev.geopjr.Tuba.gschema.xml
+++ b/data/dev.geopjr.Tuba.gschema.xml
@@ -85,6 +85,9 @@
 		<key name="reply-to-old-post-reminder" type="b">
 			<default>true</default>
 		</key>
+    <key name="copy-private-link-reminder" type="b">
+			<default>true</default>
+		</key>
 		<key name="spellchecker-enabled" type="b">
 			<default>true</default>
 		</key>

--- a/data/ui/dialogs/preferences.ui
+++ b/data/ui/dialogs/preferences.ui
@@ -165,6 +165,11 @@
 							</object>
 						</child>
 						<child>
+							<object class="AdwSwitchRow" id="copy_private_link_reminder">
+								<property name="title" translatable="yes">Warn before copying a link to a private post</property>
+							</object>
+						</child>
+						<child>
 							<object class="AdwEntryRow" id="proxy_entry">
 								<property name="show-apply-button">0</property>
 								<!-- translators: probably leave it as is. It's a networking term that might not translate nicely without losing its meaning -->

--- a/src/Dialogs/Preferences.vala
+++ b/src/Dialogs/Preferences.vala
@@ -129,6 +129,7 @@ public class Tuba.Dialogs.Preferences : Adw.PreferencesDialog {
 	[GtkChild] unowned Adw.SwitchRow advanced_boost_dialog;
 	[GtkChild] unowned Adw.SwitchRow darken_images_on_dark_mode;
 	[GtkChild] unowned Adw.SwitchRow reply_to_old_post_reminder;
+	[GtkChild] unowned Adw.SwitchRow copy_private_link_reminder;
 	[GtkChild] unowned Adw.EntryRow proxy_entry;
 	[GtkChild] unowned Adw.SwitchRow dim_trivial_notifications;
 
@@ -301,6 +302,7 @@ public class Tuba.Dialogs.Preferences : Adw.PreferencesDialog {
 		settings.bind ("advanced-boost-dialog", advanced_boost_dialog, "active", SettingsBindFlags.DEFAULT);
 		settings.bind ("darken-images-on-dark-mode", darken_images_on_dark_mode, "active", SettingsBindFlags.DEFAULT);
 		settings.bind ("reply-to-old-post-reminder", reply_to_old_post_reminder, "active", SettingsBindFlags.DEFAULT);
+		settings.bind ("copy-private-link-reminder", copy_private_link_reminder, "active", SettingsBindFlags.DEFAULT);
 		settings.bind ("dim-trivial-notifications", dim_trivial_notifications, "active", SettingsBindFlags.DEFAULT);
 		settings.bind ("analytics", analytics_switch, "active", SettingsBindFlags.DEFAULT);
 		settings.bind ("update-contributors", update_contributors, "active", SettingsBindFlags.DEFAULT);

--- a/src/Services/Settings.vala
+++ b/src/Services/Settings.vala
@@ -122,6 +122,7 @@ public class Tuba.Settings : GLib.Settings {
 	public bool group_push_notifications { get; set; }
 	public bool advanced_boost_dialog { get; set; }
 	public bool reply_to_old_post_reminder { get; set; }
+	public bool copy_private_link_reminder { get; set; }
 	public bool spellchecker_enabled { get; set; }
 	public bool darken_images_on_dark_mode { get; set; }
 	public double media_viewer_last_used_volume { get; set; }
@@ -154,6 +155,7 @@ public class Tuba.Settings : GLib.Settings {
 		"group-push-notifications",
 		"advanced-boost-dialog",
 		"reply-to-old-post-reminder",
+		"copy-private-link-reminder",
 		"spellchecker-enabled",
 		"darken-images-on-dark-mode",
 		"media-viewer-last-used-volume",

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -372,12 +372,12 @@
 		if (status.formal.url != null && settings.copy_private_link_reminder && (status.formal.visibility == "direct" || status.formal.visibility == "private")) {
 			string body;
 			if (status.formal.visibility == "direct") {
-				body = _("Only mentioned users will be able to view it.");
+				body = _("Only mentioned people will be able to view it.");
 			} else if (status.formal.account.is_self ()) {
-				body = _("Only people that follow you will be able to view it.");
+				body = _("Only mentioned people and your followers will be able to view it.");
 			} else {
 				// translators: dialog subtitle shown when copying a link to a private post, the variable is a handle
-				body = _("Only people that follow %s will be able to view it.").printf (status.formal.account.full_handle);
+				body = _("Only mentioned people and people that follow %s will be able to view it.").printf (status.formal.account.full_handle);
 			}
 
 			app.question.begin (


### PR DESCRIPTION
I saw David post about bluesky warning you before copying a the link of a post that wont be visible to everyone, so I thought I could apply it here too.

When attempting to copy a link of a post that's either direct or private, it will show you a dialog. You can either choose to not be reminded again or copy anyway. The dialog lets you know who can see the post (mentioned people, people that follow you, people that follow the author)