### PR TITLE
revert: "feat: scroll to top on Home (#1251)"

### DIFF
--- a/data/gtk/help-overlay.ui
+++ b/data/gtk/help-overlay.ui
@@ -75,12 +75,6 @@
 								<property name="action-name">app.scroll-page-down</property>
 							</object>
 						</child>
-						<child>
-							<object class="GtkShortcutsShortcut">
-								<property name="title" translatable="yes">Scroll to Top</property>
-								<property name="action-name">app.scroll-page-to-top</property>
-							</object>
-						</child>
 					</object>
 				</child>
 				<child>

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -78,7 +78,6 @@ namespace Tuba {
 			{ "back-home", back_home_activated },
 			{ "scroll-page-down", scroll_view_page_down },
 			{ "scroll-page-up", scroll_view_page_up },
-			{ "scroll-page-to-top", scroll_view_page_to_top },
 			{ "goto-notifications", goto_notifications },
 			{ "open-status-url", open_status_url, "s" },
 			{ "answer-follow-request", answer_follow_request, "(ssb)" },
@@ -328,7 +327,6 @@ namespace Tuba {
 			set_accels_for_action ("app.back-home", {"<Alt>Home"});
 			set_accels_for_action ("app.scroll-page-down", {"Page_Down"});
 			set_accels_for_action ("app.scroll-page-up", {"Page_Up"});
-			set_accels_for_action ("app.scroll-page-to-top", {"Home"});
 			add_action_entries (APP_ENTRIES, this);
 
 			if (settings.monitor_network)
@@ -497,10 +495,6 @@ namespace Tuba {
 
 		void back_home_activated () {
 			main_window.go_back_to_start ();
-		}
-
-		void scroll_view_page_to_top () {
-			main_window.scroll_view_to_top ();
 		}
 
 		void scroll_view_page_down () {

--- a/src/Dialogs/MainWindow.vala
+++ b/src/Dialogs/MainWindow.vala
@@ -230,13 +230,6 @@ public class Tuba.Dialogs.MainWindow: Adw.ApplicationWindow, Saveable {
 		}
 	}
 
-	public void scroll_view_to_top () {
-		var c_view = navigation_view.visible_page.child as Views.Base;
-		if (c_view != null) {
-			c_view.on_scroll_to_top ();
-		}
-	}
-
 	// public override bool delete_event (Gdk.EventAny event) {
 	// 	window = null;
 	// 	return app.on_window_closed ();

--- a/src/Views/Base.vala
+++ b/src/Views/Base.vala
@@ -153,7 +153,7 @@ public class Tuba.Views.Base : Adw.BreakpointBin {
 		header.show_start_title_buttons = !header.show_start_title_buttons;
 	}
 
-	public virtual void on_scroll_to_top () {
+	private void on_scroll_to_top () {
 		scrolled.scroll_child (Gtk.ScrollType.START, false);
 	}
 

--- a/src/Views/TabbedBase.vala
+++ b/src/Views/TabbedBase.vala
@@ -154,12 +154,6 @@ public class Tuba.Views.TabbedBase : Views.Base {
 		base_status = null;
 	}
 
-	public override void on_scroll_to_top () {
-		var c_scrolled = stack.visible_child as Views.Base;
-		if (c_scrolled != null)
-			c_scrolled.on_scroll_to_top ();
-	}
-
 	public override void scroll_page (bool up = false) {
 		var c_scrolled = stack.visible_child as Views.Base;
 		if (c_scrolled != null)


### PR DESCRIPTION
This reverts commit 7f8c8d333cc96d18024e5b9b1afb5b0c7836e864.

revert: #1251
fix: #1258 

Global action + AdwDialogs = bad. I quickly tried setting it as a view action or a shortcut, same results. No time to debug this rn we are too close to a release