### PR TITLE
fix(visualizer): dont destroy on unmap

### DIFF
--- a/src/Widgets/AudioPlayer/Player.vala
+++ b/src/Widgets/AudioPlayer/Player.vala
@@ -58,6 +58,7 @@ public class Tuba.Widgets.Audio.Player : Adw.Bin {
 		player.ended.connect (on_ended);
 
 		this.child = overlay;
+		this.destroy.connect (on_destroy);
 	}
 
 	private void on_ended () {
@@ -130,10 +131,11 @@ public class Tuba.Widgets.Audio.Player : Adw.Bin {
 		on_reveal_media_buttons ();
 	}
 
-	public override void unmap () {
-		if (revealer_timeout > 0) GLib.Source.remove (revealer_timeout);
-
-		base.unmap ();
+	private void on_destroy () {
+		if (revealer_timeout > 0) {
+			GLib.Source.remove (revealer_timeout);
+			revealer_timeout = 0;
+		}
 		player.destroy ();
 	}
 

--- a/src/Widgets/AudioPlayer/Stream.vala
+++ b/src/Widgets/AudioPlayer/Stream.vala
@@ -144,11 +144,20 @@ public class Tuba.Widgets.Audio.Stream : GLib.Object {
 	// Without disconnecting everything
 	// it leaks.
 	public void destroy () {
-		if (timeout_id > 0) GLib.Source.remove (timeout_id);
-		bus.remove_watch ();
-		bus = null;
-		this.state = Gst.State.NULL;
-		pipeline = null;
+		if (timeout_id > 0) {
+			GLib.Source.remove (timeout_id);
+			timeout_id = 0;
+		}
+
+		if (bus != null) {
+			bus.remove_watch ();
+			bus = null;
+		}
+
+		if (pipeline != null) {
+			this.state = Gst.State.NULL;
+			pipeline = null;
+		}
 	}
 
 	~Stream () {


### PR DESCRIPTION
unmap is not the 'pre-destroy' stage. Instead connect to the destroy signal since the mediaviewer calls it anyway.

Destroy may be called multiple times, so check if the other objects are available.