### PR TITLE
fix(MediaViewer): Make button-hide-timeout match gtk and clapper

### DIFF
--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -782,7 +782,7 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 		toggle_fs_revealer.set_reveal_child (true);
 
 		if (revealer_timeout > 0) GLib.Source.remove (revealer_timeout);
-		revealer_timeout = Timeout.add (5 * 1000, on_hide_media_buttons, Priority.LOW);
+		revealer_timeout = Timeout.add (3 * 1000, on_hide_media_buttons, Priority.LOW);
 	}
 
 	protected bool on_hide_media_buttons () {


### PR DESCRIPTION
Update the timeout to 3s which is used both by GtkVideo and ClapperGtkVideo.
Note that the later uses 5s for touch by default, but that could be adjusted via `set_fade_delay()`.

This makes the fullscreen button disappear together with other media controls and matches defaults of other players more closely, making the overall experience more consistant.