### PR TITLE
feat(Search): limit query bolding to regular sized results

### DIFF
--- a/src/Views/Search.vala
+++ b/src/Views/Search.vala
@@ -182,6 +182,8 @@ public class Tuba.Views.Search : Views.TabbedBase {
 
 	GLib.Regex? search_query_regex = null;
 	private void generate_regex () {
+		if (this.query.length >= 45) return;
+
 		try {
 			search_query_regex = new Regex (
 				// "this is a test." => /(\bthis\b|\bis\b|\ba\b|\btest\.\b)/

--- a/src/Widgets/MarkupView.vala
+++ b/src/Widgets/MarkupView.vala
@@ -414,7 +414,7 @@ public class Tuba.Widgets.MarkupView : Gtk.Box {
 	}
 
 	private static string bold_needle (owned string source, GLib.Regex? bold_text_regex) {
-		if (bold_text_regex == null) return source;
+		if (bold_text_regex == null || source.length >= 2000) return source;
 
 		try {
 			source = bold_text_regex.replace (source, source.length, 0, "<b>\\0</b>");


### PR DESCRIPTION
Result bolding is cool and all but some posts and queries can be too long and we should probably limit it a bit for the sake of regex and markdown parsing on huge posts and queries 