### PR TITLE
fix(Schedule): month from iso to GtkCalendar

### DIFF
--- a/src/Dialogs/Composer/Schedule.vala
+++ b/src/Dialogs/Composer/Schedule.vala
@@ -32,7 +32,7 @@ public class Tuba.Dialogs.Schedule : Adw.Dialog {
 			seconds_spin_button.value = (double) iso8601_datetime.get_second ();
 
 			calendar.year = iso8601_datetime.get_year ();
-			calendar.day = iso8601_datetime.get_month ();
+			calendar.month = iso8601_datetime.get_month () - 1;
 			calendar.day = iso8601_datetime.get_day_of_month ();
 		}
 


### PR DESCRIPTION
1. typo, calendar month never updated
2. DateTime's get_month is 1-12, representing each month, but GtkCalendar's month starts at 0, so we have to normalize it (aka -1)