### PR TITLE
fix(ci): split windows builds into portable and nsis

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -27,14 +27,18 @@ jobs:
           msystem: mingw64
           update: true
           install: git make zip wget unzip mingw-w64-x86_64-meson mingw-w64-x86_64-gcc mingw-w64-x86_64-vala mingw-w64-x86_64-libsoup3 mingw-w64-x86_64-libxml2 mingw-w64-x86_64-gtksourceview5 mingw-w64-x86_64-webp-pixbuf-loader mingw-w64-x86_64-libadwaita mingw-w64-x86_64-libgee mingw-w64-x86_64-json-glib mingw-w64-x86_64-libsecret mingw-w64-x86_64-desktop-file-utils mingw-w64-x86_64-imagemagick mingw-w64-x86_64-icu mingw-w64-x86_64-libspelling mingw-w64-x86_64-gstreamer mingw-w64-x86_64-gst-plugins-base mingw-w64-x86_64-gst-plugins-good mingw-w64-x86_64-nsis
-      - run: make windows windows_nsis release=1
+      - run: make windows release=1
         if: ${{ inputs.release }}
-      - run: make windows windows_nsis
+      - run: make windows
         if: ${{ !inputs.release }}
       - uses: actions/upload-artifact@v4
         with:
           name: tuba_windows_portable
           path: tuba_windows_portable/
+      - run: make windows_nsis release=1
+        if: ${{ inputs.release }}
+      - run: make windows_nsis
+        if: ${{ !inputs.release }}
       - uses: actions/upload-artifact@v4
         with:
           name: Tuba Setup.exe

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ __windows_copy_deps:
 	cp -r /mingw64/lib/gstreamer-1.0 $(PREFIX)/lib/gstreamer-1.0
 
 	cp -f /mingw64/share/gtksourceview-5/styles/Adwaita.xml /mingw64/share/gtksourceview-5/styles/Adwaita-dark.xml ${PREFIX}/share/gtksourceview-5/styles/
-	cp -f /mingw64/share/gtksourceview-5/language-specs/dtd.lang /mingw64/share/gtksourceview-5/language-specs/def.lang /mingw64/share/gtksourceview-5/language-specs/rust.lang /mingw64/share/gtksourceview-5/language-specs/language2.rng /mingw64/share/gtksourceview-5/language-specs/json.lang /mingw64/share/gtksourceview-5/language-specs/xml.lang /mingw64/share/gtksourceview-5/language-specs/markdown.lang /mingw64/share/gtksourceview-5/language-specs/html.lang ${PREFIX}/share/gtksourceview-5/language-specs/
+	cp -r /mingw64/share/gtksourceview-5/language-specs/ ${PREFIX}/share/gtksourceview-5/language-specs/
 
 	ldd $(PREFIX)/lib/gio/*/*.dll | grep '\/mingw.*\.dll' -o | xargs -I{} cp "{}" $(PREFIX)/bin
 	ldd $(PREFIX)/lib/gstreamer-1.0/*.dll | grep '\/mingw.*\.dll' -o | xargs -I{} cp "{}" $(PREFIX)/bin


### PR DESCRIPTION
last one

make windows and make windows_nsis are non-reversible. Once windows_nsis runs, portable has been tampered with and cannot or should not be uploaded