### PR TITLE
Avoid measuring labels width-for-height

### DIFF
--- a/data/ui/widgets/status.ui
+++ b/data/ui/widgets/status.ui
@@ -85,6 +85,7 @@
                       <object class="GtkButton" id="header_button">
                         <property name="visible">0</property>
                         <property name="halign">start</property>
+                        <property name="valign">center</property>
                         <child>
                           <object class="TubaWidgetsRichLabel" id="header_label">
                             <property name="use_markup">0</property>
@@ -299,6 +300,8 @@
                                             <property name="label">Spoiler Text Here</property>
                                             <property name="wrap">1</property>
                                             <property name="wrap-mode">word-char</property>
+                                            <property name="hexpand">1</property>
+                                            <property name="xalign">0</property>
                                           </object>
                                         </child>
                                       </object>


### PR DESCRIPTION
These were the remaining places in Tuba where labels were still being measured width-for-height (at least, on my timeline right now), and with these simple changes, we seem to get rid of them too. See the commit message.

There are likely some more small things here and there; for instance I saw a similarly start-aligned wrappable "By %s" button. That should be avoidable using the same valign=center trick.