### PR TITLE
feat: ListBox => ListView

### DIFF
--- a/build-aux/dev.geopjr.Tuba.Stack.json
+++ b/build-aux/dev.geopjr.Tuba.Stack.json
@@ -1,0 +1,115 @@
+{
+	"app-id": "dev.geopjr.Tuba",
+	"runtime": "org.gnome.Platform",
+	"runtime-version": "master",
+	"sdk": "org.gnome.Sdk",
+	"command": "dev.geopjr.Tuba",
+	"finish-args": [
+		"--device=dri",
+		"--share=ipc",
+		"--share=network",
+		"--socket=fallback-x11",
+		"--socket=wayland",
+		"--socket=pulseaudio"
+	],
+	"cleanup": [
+		"/include",
+		"/lib/pkgconfig",
+		"/man",
+		"/share/doc",
+		"/share/gtk-doc",
+		"/share/man",
+		"/share/pkgconfig",
+		"/share/vala",
+		"*.la",
+		"*.a"
+	],
+	"modules": [
+		{
+			"name": "libsass",
+			"buildsystem": "meson",
+			"cleanup": [
+				"*"
+			],
+			"sources": [
+				{
+					"type": "git",
+					"url": "https://github.com/lazka/libsass.git",
+					"commit": "302397c0c8ae2d7ab02f45ea461c2c3d768f248e"
+				}
+			]
+		},
+		{
+			"name": "sassc",
+			"buildsystem": "meson",
+			"cleanup": [
+				"*"
+			],
+			"sources": [
+				{
+					"type": "git",
+					"url": "https://github.com/lazka/sassc.git",
+					"commit": "82803377c33247265d779af034eceb5949e78354"
+				}
+			]
+		},
+		{
+			"name": "gtk",
+			"buildsystem": "meson",
+			"config-opts": [
+				"-Dbuildtype=release",
+				"-Dprint-cups=disabled",
+				"-Dbuild-demos=false",
+				"-Dbuild-testsuite=false",
+				"-Dbuild-examples=false",
+				"-Dbuild-tests=false"
+			],
+			"cleanup": [
+				"/bin/gtk*"
+			],
+			"sources": [
+				{
+					"type": "git",
+					"url": "https://gitlab.gnome.org/GNOME/gtk.git",
+					"tag": "4.17.2"
+				},
+				{
+					"type": "patch",
+					"path": "listview_lower_min_recycler.patch"
+				}
+			]
+		},
+		{
+			"name": "libspelling",
+			"buildsystem": "meson",
+			"config-opts": [
+				"-Ddocs=false"
+			],
+			"sources": [
+				{
+					"type": "git",
+					"url": "https://gitlab.gnome.org/GNOME/libspelling.git",
+					"tag": "0.4.5"
+				}
+			]
+		},
+		{
+			"name": "tuba",
+			"builddir": true,
+			"buildsystem": "meson",
+			"config-opts": [
+				"-Ddevel=true",
+				"--libdir=lib"
+			],
+			"sources": [
+				{
+					"type": "dir",
+					"path": "../"
+				}
+			]
+		}
+	],
+	"build-options": {
+		"env": {}
+	}
+}

--- a/build-aux/listview_lower_min_recycler.patch
+++ b/build-aux/listview_lower_min_recycler.patch
@@ -1,0 +1,14 @@
+diff --git a/gtk/gtklistview.c b/gtk/gtklistview.c
+--- gtk/gtklistview.c
++++ gtk/gtklistview.c
+@@ -33,9 +33,9 @@
+ /* Maximum number of list items created by the listview.
+  * For debugging, you can set this to G_MAXUINT to ensure
+  * there's always a list item for every row.
+  */
+-#define GTK_LIST_VIEW_MAX_LIST_ITEMS 200
++#define GTK_LIST_VIEW_MAX_LIST_ITEMS 20
+
+ /* Extra items to keep above + below every tracker */
+ #define GTK_LIST_VIEW_EXTRA_ITEMS 2
+

--- a/data/style.css
+++ b/data/style.css
@@ -208,8 +208,7 @@ headerbar.flat.no-title .title {
 }
 
 .small .ttl-profile-cover>.content {
-	border-bottom-left-radius: 0px;
-	border-bottom-right-radius: 0px;
+	border-radius: 0px;
 }
 
 .ttl-box-no-shadow>revealer>box {
@@ -523,67 +522,70 @@ video > overlay > revealer > controls, .audio-controls {
 	box-shadow: none;
 }
 
-/* .ttl-view .content row:first-child { */
-.ttl-view .fake-content row:first-child {
+.ttl-view .contentbase row:first-child {
+/* .ttl-view .fake-content row:first-child { */
 	margin-top: 0px;
 }
 
-/* .ttl-view .content row:last-child { */
-.ttl-view .fake-content row:last-child {
+.ttl-view .contentbase row:last-child {
+/* .ttl-view .fake-content row:last-child { */
 	margin-bottom: 0px;
 }
 
-/* .ttl-view:not(.large-view) .content .card { */
-.ttl-view:not(.large-view) .fake-content .card,
-.ttl-view:not(.large-view) .fake-content .toggle-group-17 {
+.ttl-view:not(.large-view) .contentbase .card,
+.ttl-view:not(.large-view) .contentbase .toggle-group-17 {
+/* .ttl-view:not(.large-view) .fake-content .card,
+.ttl-view:not(.large-view) .fake-content .toggle-group-17 { */
 	border-left: none;
 	border-right: none;
 	border-radius: 0px;
 }
 
-/* .ttl-view:not(.large-view) .content { */
-.ttl-view:not(.large-view) .fake-content {
+.ttl-view:not(.large-view) .contentbase {
+/* .ttl-view:not(.large-view) .fake-content { */
 	padding: 0px;
 }
 
-/* .ttl-view .content row:not(.ttl-post) { */
-.ttl-view .fake-content row:not(.ttl-post):not(.toggle-group-17) {
+.ttl-view .contentbase row:not(.ttl-post):not(.toggle-group-17) {
+/* .ttl-view .fake-content row:not(.ttl-post):not(.toggle-group-17) { */
 	padding: 0px;
 }
 
-.card-spacing {
+/* .card-spacing {
 	background-color: var(--card-bg-color);
-}
+} */
 
-.ttl-profile-cover > .content {
+.ttl-profile-cover > .contentbase {
 	background: none;
 }
 
-/* .ttl-view .content { */
-.ttl-view .fake-content {
+.ttl-view .contentbase {
+/* .ttl-view .fake-content { */
 	transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
-.ttl-view.large-view .fake-content:first-child {
+.ttl-view.large-view .contentbase:first-child {
+/* .ttl-view.large-view .fake-content:first-child { */
 	padding-top: 32px;
 }
 
-.ttl-view.large-view .fake-content:last-child {
+.ttl-view.large-view .contentbase:last-child {
+/* .ttl-view.large-view .fake-content:last-child { */
 	padding-bottom: 32px;
 }
 
-/* .ttl-view:not(.large-view) .content .card { */
-.ttl-view:not(.large-view) .fake-content .card {
+.ttl-view:not(.large-view) .contentbase .card {
+/* .ttl-view:not(.large-view) .fake-content .card { */
 	border-bottom: 1px var(--border-color) solid;
 }
 
-/* .ttl-view:not(.large-view) .content .card:first-child { */
-.ttl-view:not(.large-view) .fake-content .card:first-child {
+.ttl-view:not(.large-view) .contentbase .card:first-child {
+/* .ttl-view:not(.large-view) .fake-content .card:first-child { */
 	border-top: 1px var(--border-color) solid;
 }
 
-/* .ttl-view:not(.large-view) .content .card { */
-.ttl-view:not(.large-view) .fake-content .card {
+.ttl-view:not(.large-view) .contentbase .card {
+/* .ttl-view:not(.large-view) .fake-content .card { */
 	box-shadow: none;
 }
 
@@ -599,8 +601,8 @@ video > overlay > revealer > controls, .audio-controls {
 	border-radius: 12px;
 }
 
-/* .ttl-view:not(.large-view) .content .card.card-spacing { */
-.ttl-view:not(.large-view) .fake-content .card.card-spacing {
+.ttl-view:not(.large-view) .contentbase .card-spacing:not(.keep-margin) {
+/* .ttl-view:not(.large-view) .fake-content .card.card-spacing { */
 	margin: 0px;
 }
 
@@ -612,7 +614,7 @@ video > overlay > revealer > controls, .audio-controls {
 	padding: 3px 14px;
 }
 
-.ttl-view.large-view .fake-content {
+.ttl-view.large-view .contentbase {
 	padding-left: 0;
 	padding-right: 0;
 	margin-left: 18px;

--- a/data/ui/views/base.ui
+++ b/data/ui/views/base.ui
@@ -159,8 +159,8 @@
                         <property name="vexpand">1</property>
                         <property name="hscrollbar_policy">never</property>
                         <property name="child">
-                          <!-- <object class="AdwClampScrollable" id="content_box"> -->
-                          <object class="AdwClamp" id="content_box">
+                          <object class="AdwClampScrollable" id="content_box">
+                          <!-- <object class="AdwClamp" id="content_box"> -->
                             <property name="vexpand">1</property>
                             <property name="visible">True</property>
                             <property name="maximum_size">670</property>

--- a/data/ui/views/profile_header.ui
+++ b/data/ui/views/profile_header.ui
@@ -7,6 +7,7 @@
 			<object class="GtkListBox" id="info">
 				<property name="selection_mode">none</property>
 				<property name="activate_on_single_click">0</property>
+				<property name="overflow">hidden</property>
 				<style>
 					<class name="content" />
 					<class name="uniform-border-color" />

--- a/data/ui/widgets/status.ui
+++ b/data/ui/widgets/status.ui
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk" version="4.0" />
-  <!-- <template class="TubaWidgetsStatus" parent="AdwBin"> -->
-  <template class="TubaWidgetsStatus" parent="GtkListBoxRow">
+  <template class="TubaWidgetsStatus" parent="AdwBin">
+  <!-- <template class="TubaWidgetsStatus" parent="GtkListBoxRow"> -->
     <accessibility>
       <relation name="described-by">content</relation>
     </accessibility>

--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@ project(
     ],
 )
 
-# add_project_arguments(['--define=USE_LISTVIEW'], language: 'vala')
+add_project_arguments(['--define=USE_LISTVIEW'], language: 'vala')
 
 # https://gitlab.gnome.org/GNOME/vala/-/issues/1413#note_1707480
 if meson.get_compiler ('c').get_id () == 'clang'

--- a/src/Dialogs/Admin/Report.vala
+++ b/src/Dialogs/Admin/Report.vala
@@ -285,7 +285,9 @@ public class Tuba.Dialogs.Admin.Report : Dialogs.Admin.Base {
 				widget.add_css_class ("card-spacing");
 				widget.actions.visible = false;
 				widget.menu_button.visible = false;
-				widget.activatable = false;
+				#if !USE_LISTVIEW
+					widget.activatable = false;
+				#endif
 				widget.filter_stack.can_focus = false;
 				widget.filter_stack.can_target = false;
 				widget.filter_stack.focusable = false;

--- a/src/Dialogs/AnnualReport.vala
+++ b/src/Dialogs/AnnualReport.vala
@@ -18,7 +18,9 @@ public class Tuba.Dialogs.AnnualReport : Adw.Dialog {
 				var widg = status.to_widget () as Widgets.Status;
 				widg.actions.visible = false;
 				widg.menu_button.visible = false;
-				widg.activatable = false;
+				#if !USE_LISTVIEW
+					widg.activatable = false;
+				#endif
 				widg.filter_stack.can_focus = false;
 				widg.filter_stack.can_target = false;
 				widg.filter_stack.focusable = false;

--- a/src/Services/Network/Streamable.vala
+++ b/src/Services/Network/Streamable.vala
@@ -1,4 +1,4 @@
-public abstract interface Tuba.Streamable : Object {
+public interface Tuba.Streamable : Object {
 
 	public struct Event {
 		public string type;

--- a/src/Views/Admin/Timelines/PaginationTimeline.vala
+++ b/src/Views/Admin/Timelines/PaginationTimeline.vala
@@ -41,7 +41,7 @@ public class Tuba.Views.Admin.Timeline.PaginationTimeline : Gtk.Box {
 
 		content = new Gtk.ListBox () {
 			selection_mode = Gtk.SelectionMode.NONE,
-			css_classes = { "fake-content", "background" }
+			css_classes = { "content", "background" }
 		};
 		content.row_activated.connect (on_content_item_activated);
 

--- a/src/Views/ContentBase.vala
+++ b/src/Views/ContentBase.vala
@@ -4,8 +4,8 @@ public class Tuba.Views.ContentBase : Views.Base {
 		protected Gtk.ListView content;
 	#else
 		protected Gtk.ListBox content;
-		protected signal void reached_close_to_top ();
 	#endif
+	protected signal void reached_close_to_top ();
 	public GLib.ListStore model;
 	private bool bottom_reached_locked = false;
 
@@ -21,17 +21,17 @@ public class Tuba.Views.ContentBase : Views.Base {
 			signallistitemfactory.bind.connect (bind_listitem_cb);
 
 			content = new Gtk.ListView (new Gtk.NoSelection (model), signallistitemfactory) {
-				css_classes = { "content", "background" },
+				css_classes = { "contentbase", "content", "background" },
 				single_click_activate = true
 			};
 
 			content.activate.connect (on_content_item_activated);
+			model.items_changed.connect (on_content_changed);
 		#else
 			model.items_changed.connect (on_content_changed);
-
 			content = new Gtk.ListBox () {
 				selection_mode = Gtk.SelectionMode.NONE,
-				css_classes = { "fake-content", "background" }
+				css_classes = { "content", "background" }
 			};
 
 			content.row_activated.connect (on_content_item_activated);
@@ -61,9 +61,7 @@ public class Tuba.Views.ContentBase : Views.Base {
 			&& scrolled.vadjustment.value + scrolled.vadjustment.page_size + 100 < scrolled.vadjustment.upper
 		);
 
-		#if !USE_LISTVIEW
-			if (is_close_to_top) reached_close_to_top ();
-		#endif
+		if (is_close_to_top) reached_close_to_top ();
 	}
 
 	protected void set_scroll_to_top_reveal_child (bool reveal) {
@@ -129,7 +127,6 @@ public class Tuba.Views.ContentBase : Views.Base {
 		if (obj_widgetable == null)
 			Process.exit (0);
 		try {
-
 			#if !USE_LISTVIEW
 				Gtk.Widget widget = obj_widgetable.to_widget ();
 				widget.add_css_class ("card");

--- a/src/Views/NotificationRequests.vala
+++ b/src/Views/NotificationRequests.vala
@@ -44,7 +44,13 @@ public class Tuba.Views.NotificationRequests : Views.Timeline {
 			.exec ();
 	}
 
-	public override void on_content_item_activated (Gtk.ListBoxRow row) {
-		((Widgets.NotificationRequest) row).open ();
-	}
+	#if USE_LISTVIEW
+		public override void on_content_item_activated (uint pos) {
+			((Widgetizable) ((ListModel) content.model).get_item (pos)).open ();
+		}
+	#else
+		public override void on_content_item_activated (Gtk.ListBoxRow row) {
+			((Widgets.NotificationRequest) row).open ();
+		}
+	#endif
 }

--- a/src/Widgets/AccountSuggestions.vala
+++ b/src/Widgets/AccountSuggestions.vala
@@ -1,4 +1,4 @@
-public class Tuba.Widgets.AccountSuggestions : Gtk.ListBoxRow {
+public class Tuba.Widgets.AccountSuggestions : Adw.Bin {
 	public class AccountSuggestion : Gtk.Box {
 		Widgets.RelationshipButton rsbtn;
 		API.Account acc;
@@ -62,7 +62,9 @@ public class Tuba.Widgets.AccountSuggestions : Gtk.ListBoxRow {
 	Gtk.Button next_button;
 	construct {
 		this.visible = false;
-		this.activatable = false;
+		#if !USE_LISTVIEW
+			this.activatable = false;
+		#endif
 
 		account_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
 		scrolled_window = new Gtk.ScrolledWindow () {

--- a/src/Widgets/Conversation.vala
+++ b/src/Widgets/Conversation.vala
@@ -4,7 +4,7 @@ public class Tuba.Widgets.Conversation : Widgets.Status {
 
 	public Conversation (API.Conversation entity) {
 		Object (conversation: entity, status: entity.last_status, change_background_on_direct: false);
-		init_menu_button ();
+
 		conversation.bind_property (
 			"unread",
 			this.visibility_indicator,

--- a/src/Widgets/ScheduledStatus.vala
+++ b/src/Widgets/ScheduledStatus.vala
@@ -118,7 +118,9 @@ public class Tuba.Widgets.ScheduledStatus : Gtk.ListBoxRow {
 
 		var widg = new Widgets.Status (status);
 		widg.can_be_opened = false;
-		widg.activatable = false;
+		#if !USE_LISTVIEW
+			widg.activatable = false;
+		#endif
 		widg.actions.visible = false;
 		widg.menu_button.visible = false;
 		widg.date_label.visible = false;

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -14,10 +14,10 @@
 
 			_bound_status = value;
 			if (_bound_status != null) {
-				bind ();
+				bind.begin ();
 			}
 			if (context_menu == null) {
-				create_actions ();
+				create_actions.begin ();
 			}
 		}
 	}
@@ -74,9 +74,11 @@
 		set {
 			if (value != _kind) {
 				_kind = value;
-				change_kind ();
-				if (status != null)
-					aria_describe_status ();
+				change_kind.begin ((obj, res) => {
+					change_kind.end (res);
+					if (status != null)
+						aria_describe_status ();
+				});
 			}
 		}
 	}
@@ -240,8 +242,6 @@
 				kind = InstanceAccount.KIND_REPLY;
 			}
 		}
-
-		init_menu_button ();
 	}
 	~Status () {
 		debug ("Destroying Status widget");
@@ -251,17 +251,8 @@
 		}
 	}
 
-	protected void init_menu_button () {
-		if (context_menu == null) {
-			create_actions ();
-		}
-
-		menu_button.popover = context_menu;
-		menu_button.visible = true;
-	}
-
-	protected void create_actions () {
-		create_context_menu ();
+	protected async void create_actions () {
+		yield create_context_menu ();
 
 		mute_conversation_action = new SimpleAction ("mute-conversation", null);
 		mute_conversation_action.activate.connect (toggle_mute_conversation);
@@ -303,7 +294,7 @@
 	}
 
 	private GLib.MenuItem pin_menu_item;
-	protected void create_context_menu () {
+	protected async void create_context_menu () {
 		var menu_model = new GLib.Menu ();
 		menu_model.append (_("Open in Browser"), "status.open-in-browser");
 		menu_model.append (_("Copy URL"), "status.copy-url");
@@ -368,7 +359,14 @@
 			menu_model.append (_("Report"), "status.report");
 		}
 
-		context_menu = new Gtk.PopoverMenu.from_model (menu_model);
+		GLib.Idle.add (() => {
+			context_menu = new Gtk.PopoverMenu.from_model (menu_model);
+			menu_button.popover = context_menu;
+			menu_button.visible = true;
+			create_context_menu.callback ();
+			return GLib.Source.REMOVE;
+		});
+		yield;
 	}
 
 	private void copy_url () {
@@ -429,7 +427,7 @@
 
 	public void on_edit (API.Status x) {
 		this.status.patch (x);
-		bind ();
+		bind.begin ();
 	}
 
 	public signal void pin_changed ();
@@ -530,7 +528,7 @@
 	private void translate () {
 		if (translation != null) {
 			translation = null;
-			bind ();
+			bind.begin ();
 
 			translate_simple_action.set_enabled (true);
 			show_original_simple_action.set_enabled (false);
@@ -548,7 +546,7 @@
 						content = akkotrans.text,
 						detected_source_language = akkotrans.detected_language
 					};
-					bind ();
+					bind.begin ();
 
 					translate_simple_action.set_enabled (false);
 					show_original_simple_action.set_enabled (true);
@@ -569,7 +567,7 @@
 				var parser = Network.get_parser_from_inputstream (in_stream);
 				var node = network.parse_node (parser);
 				translation = API.Translation.from (node);
-				bind ();
+				bind.begin ();
 
 				translate_simple_action.set_enabled (false);
 				show_original_simple_action.set_enabled (true);
@@ -670,7 +668,7 @@
 		InstanceAccount.KIND_REMOTE_REBLOG,
 		InstanceAccount.KIND_FAVOURITE
 	};
-	protected virtual void change_kind () {
+	protected async virtual void change_kind () {
 		Tuba.InstanceAccount.Kind res_kind;
 
 		string actor_name = this.kind_instigator.display_name;
@@ -968,7 +966,7 @@
 	ulong[] formal_handler_ids = {};
 	ulong[] this_handler_ids = {};
 	Binding[] bindings = {};
-	protected virtual void bind () {
+	protected async virtual void bind () {
 		soft_unbind ();
 
 		if (this.status.formal.filtered != null && this.status.formal.filtered.size > 0) {


### PR DESCRIPTION
Guess I'm really not meant to take a break from Tuba...

Anyway, ListView is the 1.0.0 blocker. This is yet another retry. Memory wise, it works. No matter how many posts you scroll down it will always be < 200 MB.

But that's because it patches GTK to limit it to 20 items recycler. We need to make our own one.

Main loop blocking wise, I did yet another round of profiling, the main things I can see is actions and binding. Obviously this still uses our messy binding and I don't think we will ever get over it, but we can at least try and do our best to optimize it. Moving away from GtkBuilder for status widgets might also help slightly. If we know that a timeline will only have a certain type of widgets we could attempt to optimize it further.