### PR TITLE
fix(AttachmentsPage): handle `application/octet-stream`

### DIFF
--- a/src/Dialogs/Composer/AttachmentsPage.vala
+++ b/src/Dialogs/Composer/AttachmentsPage.vala
@@ -356,6 +356,10 @@ public class Tuba.AttachmentsPage : ComposerPage {
 			&& accounts.active.instance_info.configuration.media_attachments != null
 			&& accounts.active.instance_info.configuration.media_attachments.supported_mime_types != null
 			&& accounts.active.instance_info.configuration.media_attachments.supported_mime_types.size > 0
+			&& !(
+				accounts.active.instance_info.configuration.media_attachments.supported_mime_types.size == 1
+				&& accounts.active.instance_info.configuration.media_attachments.supported_mime_types[0] == "application/octet-stream"
+			)
 		) {
 			supported_mimes = accounts.active.instance_info.configuration.media_attachments.supported_mime_types;
 		}


### PR DESCRIPTION
fix: #1311 

As discovered on the linked issue, Pleroma seems to set supported_mime_types to `application/octet-stream` in an attempt to communicate that everything is supported. However on Tuba, we either use whatever the instance returns or use the built-in list (which is from Mastodon).

That means that since Akkoma returns nothing, Tuba internally accepts everything mastodon does. But for Pleroma's case, when the user selects an `image/jpeg` file, Tuba will see that `image/jpeg` is not in the supported mime types the instance returned which is just `application/octet-stream` and tuba rejected it silently.

This PR makes it so if the only supported mime is `application/octet-stream` then it should be ignored and instead use the internal list.