### PR TITLE
fix: float to string being locale dependent

### DIFF
--- a/src/Dialogs/Composer/AttachmentsPage.vala
+++ b/src/Dialogs/Composer/AttachmentsPage.vala
@@ -484,7 +484,10 @@ public class Tuba.AttachmentsPage : ComposerPage {
 
 			string? focus = null;
 			if (attachment.meta != null && attachment.meta.focus != null) {
-				focus = "%.2f,%.2f".printf (page_attachment.pos_x, page_attachment.pos_y);
+				focus = "%s,%s".printf (
+					Units.float_to_2_point_string (page_attachment.pos_x),
+					Units.float_to_2_point_string (page_attachment.pos_y)
+				);
 			}
 
 			status.add_media (attachment.id, attachment.description, focus);

--- a/src/Dialogs/Composer/AttachmentsPageAttachment.vala
+++ b/src/Dialogs/Composer/AttachmentsPageAttachment.vala
@@ -445,7 +445,10 @@ public class Tuba.AttachmentsPageAttachment : Widgets.Attachment.Item {
 			builder.add_string_value (alt_text);
 
 			builder.set_member_name ("focus");
-			builder.add_string_value ("%.2f,%.2f".printf (pos_x, pos_y));
+			builder.add_string_value ("%s,%s".printf (
+				Units.float_to_2_point_string (pos_x),
+				Units.float_to_2_point_string (pos_y)
+			));
 
 			builder.end_object ();
 

--- a/src/Dialogs/Composer/Dialog.vala
+++ b/src/Dialogs/Composer/Dialog.vala
@@ -76,7 +76,10 @@ public class Tuba.Dialogs.Compose : Adw.Dialog {
 					string focus = "0.00,0.00";
 
 					if (t_attachment.meta != null && t_attachment.meta.focus != null) {
-						focus = "%.2f,%.2f".printf (t_attachment.meta.focus.x, t_attachment.meta.focus.y);
+						focus = "%s,%s".printf (
+							Units.float_to_2_point_string (t_attachment.meta.focus.x),
+							Units.float_to_2_point_string (t_attachment.meta.focus.y)
+						);
 					}
 
 					add_media (t_attachment.id, t_attachment.description, focus);

--- a/src/Utils/Units.vala
+++ b/src/Utils/Units.vala
@@ -73,4 +73,8 @@ public class Tuba.Units {
 
 		return "♾️";
 	}
+
+	public static string float_to_2_point_string (float unit) {
+		return ((double) unit).format (new char[double.DTOSTR_BUF_SIZE], "%.2f");
+	}
 }


### PR DESCRIPTION
fix: #1327 

I can't believe this is the best way to do this but it seems to be true.

Looks like `g_ascii_formatd` is the only one forcing dots as the decimal separators. `double#to_string` calls that internally but it includes 17 dec places while we only need 2. So we will cast the float to double and then call format on it with a 2 place decimal.