### PR TITLE
feat(Widgets): VoteRow

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -448,16 +448,6 @@ video > overlay > revealer > controls, .audio-controls {
 	transform: scale(2);
 }
 
-@keyframes loadbg {
-	0% { background-size: 0%; }
-	95% { background-size: 105%; }
-	100% { background-size: 100%; }
-}
-
-.ttl-poll-voted {
-	animation: loadbg 0.5s ease;
-}
-
 .ttl-poll-row:first-child {
 	border-top-left-radius: 12px;
 	border-top-right-radius: 12px;

--- a/data/ui/widgets/votebox.ui
+++ b/data/ui/widgets/votebox.ui
@@ -6,6 +6,8 @@
 		<property name="orientation">vertical</property>
 		<child>
 			<object class="GtkListBox" id="poll_box">
+				<property name="overflow">hidden</property>
+				<property name="selection-mode">none</property>
 				<child>
 					<placeholder />
 				</child>

--- a/src/API/Poll.vala
+++ b/src/API/Poll.vala
@@ -7,6 +7,21 @@ public class Tuba.API.Poll : Entity, Widgetizable {
 	public bool voted { get; set; default = true;}
 	public Gee.ArrayList<int> own_votes { get; set; default = null; }
 	public Gee.ArrayList<PollOption>? options { get; set; default = null; }
+	public Gee.ArrayList<API.Emoji>? emojis { get; set; default = null; }
+
+	public Gee.HashMap<string, string>? gen_emojis_map () {
+		Gee.HashMap<string, string>? res = null;
+		if (emojis != null && emojis.size > 0) {
+			res = new Gee.HashMap<string, string> ();
+
+			emojis.@foreach (e => {
+				res.set (e.shortcode, e.url);
+				return true;
+			});
+		}
+
+		return res;
+	}
 
 	public Poll (string _id) {
 		id = _id;
@@ -16,6 +31,8 @@ public class Tuba.API.Poll : Entity, Widgetizable {
 		switch (prop) {
 			case "options":
 				return typeof (API.PollOption);
+			case "emojis":
+				return typeof (API.Emoji);
 			case "own-votes":
 				return Type.INT;
 		}

--- a/src/Widgets/VoteBox.vala
+++ b/src/Widgets/VoteBox.vala
@@ -52,7 +52,11 @@ public class Tuba.Widgets.VoteBox : Gtk.Box {
 		API.Poll.vote (accounts.active, poll.options, selected_index, poll.id)
 			.then ((in_stream) => {
 				var parser = Network.get_parser_from_inputstream (in_stream);
+
+				freeze_notify ();
 				poll = API.Poll.from (network.parse_node (parser));
+				thaw_notify ();
+				update_rows ();
 
 				button.sensitive = true;
 			})

--- a/src/Widgets/VoteBox.vala
+++ b/src/Widgets/VoteBox.vala
@@ -24,6 +24,25 @@ public class Tuba.Widgets.VoteBox : Gtk.Box {
 		button_vote.clicked.connect (on_vote_button_clicked);
 		notify["poll"].connect (update);
 		button_vote.sensitive = false;
+
+		poll_box.row_activated.connect (on_listboxrow_activated);
+
+		Gtk.GestureClick click_gesture = new Gtk.GestureClick () {
+			button = Gdk.BUTTON_PRIMARY
+		};
+		click_gesture.pressed.connect (on_clicked);
+		poll_box.add_controller (click_gesture);
+	}
+
+	private void on_clicked (Gtk.GestureClick gesture, int n_press, double x, double y) {
+		gesture.set_state (Gtk.EventSequenceState.CLAIMED);
+	}
+
+	private void on_listboxrow_activated (Gtk.ListBoxRow row) {
+		var vote_row = row as Widgets.VoteRow;
+		if (vote_row == null || !vote_row.check_button.visible) return;
+
+		vote_row.check_button.active = !vote_row.check_button.active;
 	}
 
 	private void on_vote_button_clicked (Gtk.Button button) {
@@ -40,10 +59,6 @@ public class Tuba.Widgets.VoteBox : Gtk.Box {
 				button.sensitive = true;
 			})
 			.exec ();
-	}
-
-	public string generate_css_style (int percentage) {
-		return @".ttl-poll-$(percentage).ttl-poll-winner { background: linear-gradient(to right, alpha(@accent_bg_color, .5) $(percentage)%, transparent 0%) no-repeat; } .ttl-poll-$(percentage) { background: linear-gradient(to right, alpha(@view_fg_color, .1) $(percentage)%, transparent 0%) no-repeat; }"; // vala-lint=line-length
 	}
 
 	void update_translations () {
@@ -67,11 +82,10 @@ public class Tuba.Widgets.VoteBox : Gtk.Box {
 		}
 	}
 
+	Widgets.VoteRow[] vote_rows = {};
 	void update () {
-		update_translations ();
-
+		vote_rows = {};
 		var row_number = 0;
-		int64 winner_p = 0;
 		Widgets.VoteCheckButton group_radio_option = null;
 
 		// Clear all existing entries
@@ -80,129 +94,31 @@ public class Tuba.Widgets.VoteBox : Gtk.Box {
 			poll_box.remove (entry);
 			entry = poll_box.get_first_child ();
 		}
-
 		selected_index.clear ();
 
-		// Reset button visibility
-		button_vote.sensitive = false;
-		button_vote.visible = !this.show_results && !poll.expired && !poll.voted;
-		button_results.visible = !poll.expired && !poll.voted;
-		button_refresh.visible = !button_vote.visible && !poll.expired;
-
-		if (this.show_results) {
-			button_results.icon_name = "tuba-eye-not-looking-symbolic";
-			// translators: tooltip of poll button that hides the current vote results
-			button_results.tooltip_text = _("Hide Results");
-		} else {
-			button_results.icon_name = "tuba-eye-open-negative-filled-symbolic";
-			// translators: tooltip of poll button that shows the current vote results
-			button_results.tooltip_text = _("Show Results");
-		}
-
-		if (poll.expired || poll.voted || this.show_results) {
-			foreach (API.PollOption p in poll.options) {
-				if (p.votes_count > winner_p) {
-					winner_p = p.votes_count;
-				}
-			}
-		}
-
+		var emojis_map = poll.gen_emojis_map ();
 		// Create the entries of poll
 		foreach (API.PollOption p in poll.options) {
-			var row = new Adw.ActionRow () {
-				css_classes = { "ttl-poll-row" },
-				use_markup = false,
-				title = p.tuba_translated_title == null ? p.title : p.tuba_translated_title
+			var row = new Widgets.VoteRow (p.title) {
+				delayed_animation = true,
+				instance_emojis = emojis_map
 			};
 
-			// If it is own poll
-			if (poll.expired || poll.voted || this.show_results) {
-				// If multiple, Checkbox else radioButton
-				var percentage = poll.votes_count > 0 ? ((double)p.votes_count / poll.votes_count) * 100 : 0.0;
-
-				var provider = new Gtk.CssProvider ();
-				provider.load_from_string (generate_css_style ((int) percentage));
-
-				row.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-				row.add_css_class (@"ttl-poll-$((int) percentage)");
-				row.add_css_class ("ttl-poll-voted");
-
-				if (p.votes_count == winner_p) {
-					row.add_css_class ("ttl-poll-winner");
+			if (!poll.multiple) {
+				if (row_number == 0) {
+					group_radio_option = row.check_button;
+				} else {
+					row.check_button.set_group (group_radio_option);
 				}
-
-				if (poll.own_votes != null) {
-					foreach (int own_vote in poll.own_votes) {
-						if (own_vote == row_number) {
-							row.add_suffix (new Gtk.Image.from_icon_name ("tuba-check-round-outline-symbolic") {
-								tooltip_text = _("Voted")
-							});
-						}
-					}
-				}
-
-				row.subtitle = "%.1f%%".printf (percentage);
-				poll_box.append (row);
-			} else {
-				var check_option = new Widgets.VoteCheckButton ();
-
-				if (!poll.multiple) {
-					if (row_number == 0) {
-						group_radio_option=check_option;
-					} else {
-						check_option.set_group (group_radio_option);
-					}
-				}
-
-				check_option.poll_title = p.title;
-				check_option.toggled.connect (on_check_option_toggeled);
-
-				if (poll.own_votes != null) {
-					foreach (int own_vote in poll.own_votes) {
-						if (own_vote == row_number) {
-							check_option.active = true;
-							row.add_suffix (new Gtk.Image.from_icon_name ("tuba-check-round-outline-symbolic") {
-								tooltip_text = _("Voted")
-							});
-
-							if (!selected_index.contains (p.title)) {
-								selected_index.add (p.title);
-							}
-						}
-					}
-				}
-
-				if (poll.expired || poll.voted || this.show_results) {
-					check_option.sensitive = false;
-				}
-
-				row.add_prefix (check_option);
-				row.activatable_widget = check_option;
-
-				poll_box.append (row);
 			}
+			row.check_button.toggled.connect (on_check_option_toggled);
 
+			vote_rows += row;
+			poll_box.append (row);
 			row_number++;
 		}
 
-		string voted_string = Tuba.Units.shorten (poll.votes_count);
-		string voted_numerical_string = GLib.ngettext (
-			// translators: the variable is the amount of people that voted
-			"%s voted", "%s voted",
-			(ulong) poll.votes_count
-		).printf (voted_string);
-		if (poll.expires_at != null) {
-			info_label.label = "%s · %s".printf (
-				voted_numerical_string,
-				poll.expired
-					? DateTime.humanize_ago (poll.expires_at)
-					: DateTime.humanize_left (poll.expires_at)
-			);
-		} else {
-			info_label.label = voted_numerical_string;
-		}
-
-		update_aria ();
+		update_rows ();
 	}
 
 	private void update_aria () {
@@ -233,11 +149,14 @@ public class Tuba.Widgets.VoteBox : Gtk.Box {
 		);
 	}
 
-	private void on_check_option_toggeled (Gtk.CheckButton radio) {
+	private void on_check_option_toggled (Gtk.CheckButton radio) {
 		var radio_votebutton = radio as Widgets.VoteCheckButton;
-		if (selected_index.contains (radio_votebutton.poll_title)) {
+
+		bool contained = selected_index.contains (radio_votebutton.poll_title);
+		bool active = radio_votebutton.active;
+		if (contained && !active) {
 			selected_index.remove (radio_votebutton.poll_title);
-		} else {
+		} else if (!contained && active) {
 			selected_index.add (radio_votebutton.poll_title);
 		}
 
@@ -260,7 +179,7 @@ public class Tuba.Widgets.VoteBox : Gtk.Box {
 
 				if (parsed_poll != null) {
 					poll = parsed_poll;
-					update ();
+					update_rows ();
 				}
 			})
 			.on_error ((code, message) => {
@@ -276,6 +195,97 @@ public class Tuba.Widgets.VoteBox : Gtk.Box {
 		if (poll == null) return;
 
 		this.show_results = !this.show_results;
-		update ();
+		update_rows ();
+	}
+
+	private void update_rows () {
+		update_translations ();
+
+		// Reset button visibility
+		button_vote.sensitive = selected_index.size > 0;
+		button_vote.visible = !this.show_results && !poll.expired && !poll.voted;
+		button_results.visible = !poll.expired && !poll.voted;
+		button_refresh.visible = !button_vote.visible && !poll.expired;
+
+		if (this.show_results) {
+			button_results.icon_name = "tuba-eye-not-looking-symbolic";
+			// translators: tooltip of poll button that hides the current vote results
+			button_results.tooltip_text = _("Hide Results");
+		} else {
+			button_results.icon_name = "tuba-eye-open-negative-filled-symbolic";
+			// translators: tooltip of poll button that shows the current vote results
+			button_results.tooltip_text = _("Show Results");
+		}
+
+		int64 winner_p = 0;
+		if (poll.expired || poll.voted || this.show_results) {
+			foreach (API.PollOption p in poll.options) {
+				if (p.votes_count > winner_p) {
+					winner_p = p.votes_count;
+				}
+			}
+		}
+
+		if (vote_rows.length <= poll.options.size) {
+			for (int i = 0; i < vote_rows.length; i++) {
+				var row = vote_rows[i];
+				var p = poll.options.get (i);
+
+				row.title = p.tuba_translated_title == null ? p.title : p.tuba_translated_title;
+				row.voted = false;
+				row.winner = false;
+				row.show_results = false;
+				row.check_button.active = selected_index.contains (row.check_button.poll_title);
+
+				// If it is own poll
+				if (poll.expired || poll.voted || this.show_results) {
+					var percentage = poll.votes_count > 0 ? ((double)p.votes_count / poll.votes_count) * 100 : 0.0;
+
+					row.percentage = percentage;
+					row.winner = p.votes_count == winner_p;
+
+					if (poll.own_votes != null) {
+						foreach (int own_vote in poll.own_votes) {
+							if (own_vote == i) {
+								row.voted = true;
+								break;
+							}
+						}
+					}
+
+					row.show_results = true;
+				} else {
+					if (poll.own_votes != null) {
+						foreach (int own_vote in poll.own_votes) {
+							if (own_vote == i) {
+								row.check_button.active = true;
+								row.voted = true;
+							}
+						}
+					}
+				}
+
+				row.play_animation ();
+			}
+		}
+
+		string voted_string = Tuba.Units.shorten (poll.votes_count);
+		string voted_numerical_string = GLib.ngettext (
+			// translators: the variable is the amount of people that voted
+			"%s voted", "%s voted",
+			(ulong) poll.votes_count
+		).printf (voted_string);
+		if (poll.expires_at != null) {
+			info_label.label = "%s · %s".printf (
+				voted_numerical_string,
+				poll.expired
+					? DateTime.humanize_ago (poll.expires_at)
+					: DateTime.humanize_left (poll.expires_at)
+			);
+		} else {
+			info_label.label = voted_numerical_string;
+		}
+
+		update_aria ();
 	}
 }

--- a/src/Widgets/VoteBox.vala
+++ b/src/Widgets/VoteBox.vala
@@ -47,6 +47,8 @@ public class Tuba.Widgets.VoteBox : Gtk.Box {
 
 	private void on_vote_button_clicked (Gtk.Button button) {
 		button.sensitive = false;
+		update_selected_index ();
+
 		API.Poll.vote (accounts.active, poll.options, selected_index, poll.id)
 			.then ((in_stream) => {
 				var parser = Network.get_parser_from_inputstream (in_stream);
@@ -150,14 +152,26 @@ public class Tuba.Widgets.VoteBox : Gtk.Box {
 	}
 
 	private void on_check_option_toggled (Gtk.CheckButton radio) {
-		var radio_votebutton = radio as Widgets.VoteCheckButton;
+		bool can_vote = false;
+		foreach (var row in vote_rows) {
+			if (row.check_button.active) {
+				can_vote = true;
+				break;
+			}
+		}
 
-		bool contained = selected_index.contains (radio_votebutton.poll_title);
-		bool active = radio_votebutton.active;
-		if (contained && !active) {
-			selected_index.remove (radio_votebutton.poll_title);
-		} else if (!contained && active) {
-			selected_index.add (radio_votebutton.poll_title);
+		button_vote.sensitive = can_vote;
+	}
+
+	private void update_selected_index () {
+		foreach (var row in vote_rows) {
+			bool contained = selected_index.contains (row.check_button.poll_title);
+			bool active = row.check_button.active;
+			if (contained && !active) {
+				selected_index.remove (row.check_button.poll_title);
+			} else if (!contained && active) {
+				selected_index.add (row.check_button.poll_title);
+			}
 		}
 
 		button_vote.sensitive = selected_index.size > 0;
@@ -287,5 +301,6 @@ public class Tuba.Widgets.VoteBox : Gtk.Box {
 		}
 
 		update_aria ();
+		update_selected_index ();
 	}
 }

--- a/src/Widgets/VoteRow.vala
+++ b/src/Widgets/VoteRow.vala
@@ -1,0 +1,206 @@
+public class Tuba.Widgets.VoteRow : Gtk.ListBoxRow {
+	const uint ANIMATION_DURATION = 500;
+
+	Adw.SpringAnimation animation;
+	Widgets.EmojiLabel title_label;
+	Gtk.Label subtitle_label;
+	Gtk.Box main_box;
+	Gtk.Image voted_icon;
+
+	public Widgets.VoteCheckButton check_button { get; private set; }
+	public bool delayed_animation { get; set; default = false; }
+
+	private bool _winner = false;
+	public bool winner {
+		get { return _winner; }
+		set {
+			if (_winner != value) {
+				_winner = value;
+				this.queue_draw ();
+			}
+		}
+	}
+
+	private double _percentage = -1;
+	public double percentage {
+		get { return _percentage; }
+		set {
+			if (value != _percentage) {
+				double before = _percentage / 100;
+
+				_percentage = value;
+				this.subtitle_label.label = "%.1f%%".printf (percentage);
+
+				animate (double.min (before, 0));
+			}
+		}
+	}
+
+	public Gee.HashMap<string, string>? instance_emojis {
+		set {
+			this.title_label.instance_emojis = value;
+			if (this.title != "") this.title_label.content = this.title;
+		}
+	}
+
+	private string _title = "";
+	public string title {
+		get { return _title; }
+		set {
+			if (value != _title) {
+				_title = value;
+				this.title_label.content = value;
+			}
+		}
+	}
+
+	private bool _voted = false;
+	public bool voted {
+		get { return _voted; }
+		set {
+			if (_voted != value) {
+				_voted = value;
+				this.voted_icon.visible = value;
+				this.show_results = true;
+			}
+		}
+	}
+
+	private bool _show_results = false;
+	public bool show_results {
+		get { return _show_results; }
+		set {
+			if (_show_results != value) {
+				_show_results = value;
+				this.check_button.visible = !value;
+				this.subtitle_label.visible = value && this.subtitle_label.label != "";
+				this.voted_icon.visible = this.voted;
+				this.activatable = !value;
+
+				animate (0);
+			}
+		}
+	}
+
+	private Gdk.RGBA _background_color = {
+		120 / 255.0f,
+		174 / 255.0f,
+		237 / 255.0f,
+		0.5f
+	};
+	private Gdk.RGBA background_color {
+		get { return _background_color; }
+		set {
+			value.alpha = 0.5f;
+			_background_color = value;
+			if (this.winner) this.queue_draw ();
+		}
+	}
+
+	private void animation_target_cb (double value) {
+		this.queue_draw ();
+	}
+
+	private void animate (double from, double to = this.percentage / 100) {
+		animation.value_from = from;
+		animation.value_to = to;
+
+		if (!delayed_animation) play_animation ();
+	}
+
+	public void play_animation () {
+		this.animation.play ();
+	}
+
+	private void update_accent_color () {
+		background_color = Adw.StyleManager.get_default ().get_accent_color_rgba ();
+	}
+
+	construct {
+		this.add_css_class ("ttl-poll-row");
+		this.activatable = true;
+		this.vexpand = true;
+
+		check_button = new Widgets.VoteCheckButton ();
+		var target = new Adw.CallbackAnimationTarget (animation_target_cb);
+		animation = new Adw.SpringAnimation (this, 0.0, 1.0, new Adw.SpringParams (0.65, 0.4, 110.0), target);
+
+		var default_sm = Adw.StyleManager.get_default ();
+		if (default_sm.system_supports_accent_colors) {
+			default_sm.notify["accent-color-rgba"].connect (update_accent_color);
+			_background_color = default_sm.get_accent_color_rgba ();
+			_background_color.alpha = 0.5f;
+		}
+
+		this.title_label = new Widgets.EmojiLabel () {
+			use_markup = false,
+			xalign = 0.0f,
+			vexpand = true,
+			valign = Gtk.Align.CENTER
+		};
+		this.subtitle_label = new Gtk.Label ("") {
+			visible = false,
+			xalign = 0.0f,
+			css_classes = {"dim-label"}
+		};
+		this.voted_icon = new Gtk.Image.from_icon_name ("tuba-check-round-outline-symbolic") {
+			tooltip_text = "Voted",
+			vexpand = true,
+			valign = Gtk.Align.CENTER,
+			visible = false
+		};
+
+		var title_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0) {
+			hexpand = true,
+			margin_top = 6,
+			margin_bottom = 6
+		};
+		title_box.append (title_label);
+		title_box.append (subtitle_label);
+
+		this.main_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 12) {
+			margin_top = 2,
+			margin_bottom = 2,
+			margin_start = 14,
+			margin_end = 14,
+			height_request = 50
+		};
+		this.main_box.append (check_button);
+		this.main_box.append (title_box);
+		this.main_box.append (voted_icon);
+
+		this.child = main_box;
+	}
+
+	public VoteRow (string poll_title) {
+		this.check_button.poll_title = poll_title;
+	}
+
+	public override void snapshot (Gtk.Snapshot snapshot) {
+		if (!show_results) {
+			base.snapshot (snapshot);
+			return;
+		}
+
+		int width = this.get_width ();
+		Graphene.Rect bar = Graphene.Rect () {
+			origin = Graphene.Point () {
+				x = 0.0f,
+				y = 0.0f
+			},
+			size = Graphene.Size () {
+				height = (float) this.get_height (),
+				width = (float) width * (float) this.animation.value
+			}
+		};
+
+		if (this.winner) {
+			snapshot.append_color (this.background_color, bar);
+		} else {
+			var color = this.get_color ();
+			color.alpha = 0.2f;
+			snapshot.append_color (color, bar);
+		}
+		base.snapshot (snapshot);
+	}
+}

--- a/src/Widgets/meson.build
+++ b/src/Widgets/meson.build
@@ -32,6 +32,7 @@ sources += files(
     'StatusActionButton.vala',
     'VoteBox.vala',
     'VoteCheckButton.vala',
+    'VoteRow.vala',
     'Widgetizable.vala',
 )
 


### PR DESCRIPTION
fix: #1264

This took way longer than it should have, but I had to replace the action rows with a custom widget as to replace the title label with LWW.

Since I had full control over it, I went ahead and actually designed a useful API for it, so now VoteBox won't destroy all rows and re-build them on updates. Instead it will update the already made rows.

This assumes that no new poll entries can be added or removed during small updates (translations, show results, voting - does not include post editing, those get updated as expected).

But this big refactor might have introduced bugs in terms of voting and updating so any testing would be appreciated :), specifically daily-use testing and not just making test polls since fedizens use polls in many different ways that test polls will never cover.