### PR TITLE
fix: get rid of weak / unowned from our side

### DIFF
--- a/src/Dialogs/Composer/Page.vala
+++ b/src/Dialogs/Composer/Page.vala
@@ -6,7 +6,7 @@ public class Tuba.ComposerPage : Gtk.Box {
 	public virtual bool can_publish { get; set; default = false; }
 	public virtual bool edit_mode { get; set; default = false; }
 
-	public weak Dialogs.Compose dialog;
+	public Dialogs.Compose dialog;
 	public Tuba.Dialogs.Compose.BasicStatus status;
 
 	Gtk.ScrolledWindow scroller;

--- a/src/Dialogs/MainWindow.vala
+++ b/src/Dialogs/MainWindow.vala
@@ -48,7 +48,7 @@ public class Tuba.Dialogs.MainWindow: Adw.ApplicationWindow, Saveable {
 		});
 	}
 
-	private weak Gtk.Widget? media_viewer_source_widget;
+	private Gtk.Widget? media_viewer_source_widget;
 	private void on_media_viewer_toggle () {
 		if (is_media_viewer_visible || media_viewer_source_widget == null) return;
 

--- a/src/Dialogs/Preferences.vala
+++ b/src/Dialogs/Preferences.vala
@@ -6,7 +6,7 @@ public class Tuba.Dialogs.Preferences : Adw.PreferencesDialog {
 
 	class FilterRow : Adw.ExpanderRow {
 		private API.Filters.Filter filter;
-		private weak Dialogs.Preferences win;
+		private Dialogs.Preferences win;
 		public signal void filter_deleted (FilterRow self);
 
 		~FilterRow () {

--- a/src/Services/Network/Request.vala
+++ b/src/Services/Network/Request.vala
@@ -25,7 +25,7 @@ public class Tuba.Request : GLib.Object {
 		}
 	}
 	public InputStream response_body { get; set; }
-	public weak InstanceAccount? account { get; set; default = null; }
+	public InstanceAccount? account { get; set; default = null; }
 	Network.SuccessCallback? cb;
 	Network.ErrorCallback? error_cb;
 	Gee.HashMap<string, string>? pars;

--- a/src/Views/Admin/Pages/Base.vala
+++ b/src/Views/Admin/Pages/Base.vala
@@ -5,7 +5,7 @@ public class Tuba.Views.Admin.Page.Base : Adw.NavigationPage {
 	private Adw.ToastOverlay toast_overlay;
 	protected Adw.HeaderBar headerbar;
 	protected Adw.ToolbarView toolbar_view;
-	public weak Dialogs.Admin.Window? admin_window { get; set; }
+	public Dialogs.Admin.Window? admin_window { get; set; }
 
 	~Base () {
 		debug (@"Destroying Admin Dialog page: $title");

--- a/src/Views/Thread.vala
+++ b/src/Views/Thread.vala
@@ -23,7 +23,7 @@ public class Tuba.Views.Thread : Views.ContentBase, AccountHolder {
 
 	protected InstanceAccount? account { get; set; }
 	public API.Status root_status { get; set; }
-	public weak Widgets.Status? root_status_widget { get; set; default=null; }
+	public Widgets.Status? root_status_widget { get; set; default=null; }
 
 	public Thread (API.Status status) {
 		Object (

--- a/src/Widgets/Account.vala
+++ b/src/Widgets/Account.vala
@@ -170,7 +170,7 @@ public class Tuba.Widgets.Account : Gtk.ListBoxRow {
 		);
 	}
 
-	private weak API.Account api_account { get; set; }
+	private API.Account api_account { get; set; }
 	private string account_id = "";
 	private ulong open_signal = -1;
 	public Account (API.Account account) {

--- a/src/Widgets/MarkupView.vala
+++ b/src/Widgets/MarkupView.vala
@@ -18,7 +18,7 @@ public class Tuba.Widgets.MarkupView : Gtk.Box {
 
 	public GLib.Regex? bold_text_regex { get; set; default = null; }
 	public Gee.HashMap<string, string>? instance_emojis { get; set; default = null; }
-	public weak Gee.ArrayList<API.Mention>? mentions { get; set; default = null; }
+	public Gee.ArrayList<API.Mention>? mentions { get; set; default = null; }
 	public bool has_quote { get; set; default=false; }
 	public bool extract_last_tags { get; set; default=false; }
 	public bool has_link { get; set; default=false; }

--- a/src/Widgets/RichLabel.vala
+++ b/src/Widgets/RichLabel.vala
@@ -1,7 +1,7 @@
 public class Tuba.Widgets.RichLabel : Adw.Bin {
 	Widgets.EmojiLabel widget;
 
-	public weak Gee.ArrayList<API.Mention>? mentions;
+	public Gee.ArrayList<API.Mention>? mentions;
 
 	public string label {
 		get { return widget.content; }


### PR DESCRIPTION
fix: #1347 

Okay this will fix pretty much all segfaults from our side but at the cost of stuff getting memory leaks, so this needs a thorough leak test on all affected objects.

Let's break it down because if I don't log this, I'll repeat it.

Vala's memory management is ref counting. Weak and Unowned are basically the same thing. Tuba uses weak/unowned in a few places where you'd think the objects would always exist regardless so it shouldn't matter and would save us the headache of memory leaking.

Examples include:
- Array of mention objects straight from the parent status to the content's richlabels. As long as the parent status exists, then they should also exist. Apparently not. #1347 
- Account object in avatars. Same as above, the parent status holds a reference to it so it should exist as long as that exists. NOT #1340

Now you might think "well, then check if they still exist". I do. Apparently a null check is not enough. A weak reference is not null if the object it references doesn't exist, it will happily pass those checks and then segfault.