### PR TITLE
fix(MainWindow): bind sidebar enable-gestures to `collapsed`

### DIFF
--- a/data/ui/dialogs/main.ui
+++ b/data/ui/dialogs/main.ui
@@ -20,6 +20,8 @@
 						</child>
 						<property name="child">
 							<object class="AdwOverlaySplitView" id="split_view">
+								<property name="enable-show-gesture" bind-source="split_view" bind-property="collapsed" bind-flags="sync-create" />
+								<property name="enable-hide-gesture" bind-source="split_view" bind-property="collapsed" bind-flags="sync-create" />
 								<property name="sidebar">
 									<object class="TubaViewsSidebar" id="sidebar" />
 								</property>


### PR DESCRIPTION
On touchscreen devices, it is possible to hide the sidebar when it is not collapsed by using a touchscreen swipe gesture. The sidebar becomes inaccessible as a result. The gestures should only be enabled when the sidebar is collapsed (an overlay), where it is expected to be shown and hidden with the sidebar button.