### PR TITLE
feat(lww): remove hacks

### DIFF
--- a/src/Widgets/LabelWithWidgets.vala
+++ b/src/Widgets/LabelWithWidgets.vala
@@ -54,17 +54,6 @@ public class Tuba.Widgets.LabelWithWidgets : Gtk.Widget, Gtk.Buildable, Gtk.Acce
 		}
 	}
 
-	private bool _fix_overflow_hack = false;
-	public bool fix_overflow_hack {
-		get {
-			return _fix_overflow_hack;
-		}
-		set {
-			_fix_overflow_hack = value;
-			update_label ();
-		}
-	}
-
 	protected const string OBJECT_REPLACEMENT_CHARACTER = "\xEF\xBF\xBC";
 
 	construct {
@@ -79,9 +68,13 @@ public class Tuba.Widgets.LabelWithWidgets : Gtk.Widget, Gtk.Buildable, Gtk.Acce
 		};
 
 		label.set_parent (this);
-
-		label.activate_link.connect ((url) => activate_link (url));
+		label.activate_link.connect (on_activate_link);
 	}
+
+	private bool on_activate_link (string url) {
+		return activate_link (url);
+	}
+
 	~LabelWithWidgets () {
 		label.unparent ();
 		foreach (var child in widgets) {
@@ -245,16 +238,7 @@ public class Tuba.Widgets.LabelWithWidgets : Gtk.Widget, Gtk.Buildable, Gtk.Acce
 		var old_label = label.label;
 		var new_label = _text.replace (placeholder, OBJECT_REPLACEMENT_CHARACTER);
 
-		if (_fix_overflow_hack) {
-			label.lines = int.max (100, widgets.length);
-			label.ellipsize = Pango.EllipsizeMode.END;
-			label.width_chars = 1;
-		}
-
 		if (old_label != new_label) {
-			label.wrap = true;
-			label.wrap_mode = Pango.WrapMode.WORD_CHAR;
-
 			_text = new_label;
 			label.label = _text;
 			_label_text = label.get_text ();

--- a/src/Widgets/MarkupView.vala
+++ b/src/Widgets/MarkupView.vala
@@ -128,7 +128,6 @@ public class Tuba.Widgets.MarkupView : Gtk.Box {
 				vexpand = true,
 				large_emojis = settings.enlarge_custom_emojis,
 				use_markup = true,
-				fix_overflow_hack = true,
 				yalign = 0f,
 				//  focusable_label = true
 			};
@@ -280,7 +279,6 @@ public class Tuba.Widgets.MarkupView : Gtk.Box {
 						visible = true,
 						css_classes = { "ttl-code", "monospace" },
 						use_markup = true,
-						fix_overflow_hack = true,
 						//  focusable_label = true
 						// markup = MarkupPolicy.DISALLOW
 					};
@@ -308,7 +306,6 @@ public class Tuba.Widgets.MarkupView : Gtk.Box {
 					visible = true,
 					css_classes = { "ttl-code", "italic" },
 					use_markup = true,
-					fix_overflow_hack = true,
 					//  focusable_label = true
 					// markup = MarkupPolicy.DISALLOW
 				};

--- a/src/Widgets/RichLabel.vala
+++ b/src/Widgets/RichLabel.vala
@@ -78,16 +78,6 @@ public class Tuba.Widgets.RichLabel : Adw.Bin {
 		get { return widget.accessible_text; }
 	}
 
-	// #756
-	public bool fix_overflow_hack {
-		get {
-			return widget.fix_overflow_hack;
-		}
-		set {
-			widget.fix_overflow_hack = value;
-		}
-	}
-
 	public string get_text () {
 		return widget.label_text;
 	}


### PR DESCRIPTION
GNOME 48 is out and one of the important fixes on the GTK side are the labels, thanks to Sergey!

This means that we can finally get rid of the LWW hacks.

fix: #756
fix: #67
fix: #914 
fix: #1219 

and probably others