### PR TITLE
fix(ProfileEdit): limit profile fields

### DIFF
--- a/src/Dialogs/ProfileEdit.vala
+++ b/src/Dialogs/ProfileEdit.vala
@@ -200,7 +200,7 @@ public class Tuba.Dialogs.ProfileEdit : Adw.Dialog {
 			}
 		}
 
-		var fields_left = int.max (int.min (max_fields - total_fields, 50), total_fields);
+		var fields_left = int64.max (int64.min (max_fields - total_fields, 50), total_fields);
 		if (fields_left > 0) {
 			for (var i = 0; i < fields_left; i++) {
 				add_field (null, null);

--- a/src/Dialogs/ProfileEdit.vala
+++ b/src/Dialogs/ProfileEdit.vala
@@ -200,7 +200,7 @@ public class Tuba.Dialogs.ProfileEdit : Adw.Dialog {
 			}
 		}
 
-		var fields_left = max_fields - total_fields;
+		var fields_left = int.max (int.min (max_fields - total_fields, 50), total_fields);
 		if (fields_left > 0) {
 			for (var i = 0; i < fields_left; i++) {
 				add_field (null, null);


### PR DESCRIPTION
fix: #1368 

Iceshrimp.NET doesn't have a limit yet (2147483647) on profile fields and Tuba's current design tries to create the max amount of fields that a profile can have, causing it to freeze when trying to create that many rows.

This PR makes it so it either creates them all if there are less than 50 available or none if there are more than 50.

This is a temporary solution until I re-do the UX so you can 'add' rows instead.