### PR TITLE
feat(ProfileEdit): dynamically add rows

### DIFF
--- a/src/Dialogs/ProfileEdit.vala
+++ b/src/Dialogs/ProfileEdit.vala
@@ -169,6 +169,7 @@ public class Tuba.Dialogs.ProfileEdit : Adw.Dialog {
 
 	private API.Account profile { get; set; }
 	Gee.ArrayList<Field> fields = new Gee.ArrayList<Field> ();
+	Adw.ButtonRow? add_field_row = null;
 	int64 max_fields;
 	int64 max_key_length;
 	int64 max_value_length;
@@ -200,11 +201,23 @@ public class Tuba.Dialogs.ProfileEdit : Adw.Dialog {
 			}
 		}
 
-		var fields_left = int64.max (int64.min (max_fields - total_fields, 50), total_fields);
-		if (fields_left > 0) {
-			for (var i = 0; i < fields_left; i++) {
-				add_field (null, null);
-			}
+		if (max_fields > total_fields) {
+			add_field_row = new Adw.ButtonRow () {
+				start_icon_name = "tuba-plus-large-symbolic",
+				// translators: profile field, if unsure take a look at Mastodon https://github.com/mastodon/mastodon/blob/main/config/locales/ (under simple_form)
+				title = _("Add Field")
+			};
+			add_field_row.activated.connect (on_add_field_activated);
+			fields_box.add (add_field_row);
+		}
+	}
+
+	private void on_add_field_activated () {
+		add_field (null, null);
+
+		fields_box.remove (add_field_row);
+		if (max_fields > fields.size) {
+			fields_box.add (add_field_row);
 		}
 	}
 


### PR DESCRIPTION
fix: #1368 

As mentioned there, profile fields are now dynamic, if you can add more, there's a button to do so.