### PR TITLE
feat(SecretAccountStore): match name

### DIFF
--- a/src/Services/Accounts/SecretAccountStore.vala
+++ b/src/Services/Accounts/SecretAccountStore.vala
@@ -13,7 +13,7 @@ public class Tuba.SecretAccountStore : AccountStore {
 		schema_attributes["version"] = Secret.SchemaAttributeType.STRING;
 		schema = new Secret.Schema.newv (
 			Build.DOMAIN,
-			Secret.SchemaFlags.DONT_MATCH_NAME,
+			Secret.SchemaFlags.NONE,
 			schema_attributes
 		);
 


### PR DESCRIPTION
Okay, I'll put my foot down on this one.

To overcome some bugs found in some keyring implementations in some distros with some keyring backends, we would ignore the secret names.

That is really creating issues and is insecure. To put it simply, secrets look something like this data-wise:

```js
{
  app: dev.geopjr.Tuba,
  label: "Mastodon Account",
  attributes: { login: "@GeopJr@tech.lgbt", version: 1 },
  secret: { ... }
}
```

To hack around that issue, we would ignore the app name completely and instead match all secrets that have a `version` attribute. That means that if another app had a secret that had a `version` attribute, Tuba would attempt to load it.

This PR stops that behavior which might re-introduce that issue to affected setups.