### PR TITLE
feat(SecretAccountStore): remove UUID fallback

### DIFF
--- a/src/Services/Accounts/AccountStore.vala
+++ b/src/Services/Accounts/AccountStore.vala
@@ -34,15 +34,15 @@ public abstract class Tuba.AccountStore : GLib.Object {
 
 	public abstract void load () throws GLib.Error;
 	public abstract void save () throws GLib.Error;
-	public void safe_save () {
-		try {
-			save ();
-		} catch (GLib.Error e) {
-			warning (e.message);
-			var dlg = app.inform (_("Error"), e.message);
-			dlg.present (app.main_window);
-		}
-	}
+	//  public void safe_save () {
+	//  	try {
+	//  		save ();
+	//  	} catch (GLib.Error e) {
+	//  		warning (e.message);
+	//  		var dlg = app.inform (_("Error"), e.message);
+	//  		dlg.present (app.main_window);
+	//  	}
+	//  }
 
 	public virtual void add (InstanceAccount account) throws GLib.Error {
 		debug (@"Adding new account: $(account.handle)");


### PR DESCRIPTION
When UUIDs in secrets were added (for anonymity reasons), Tuba added some fallbacks to convert old accounts to the new ones. It's been over 1-2 years since, it's safe to say we can remove the fallback. This doesn't affect you unless you are updating from version 0.2 or something.