### PR TITLE
feat(SidebarAccountRow): set subtitle lines to 2

### DIFF
--- a/data/ui/views/sidebar/account.ui
+++ b/data/ui/views/sidebar/account.ui
@@ -3,7 +3,7 @@
 	<template class="TubaViewsSidebarAccountRow" parent="AdwActionRow">
 		<property name="height_request">64</property>
 		<property name="title_lines">1</property>
-		<property name="subtitle_lines">1</property>
+		<property name="subtitle_lines">2</property>
 		<property name="activatable">1</property>
 		<property name="use-markup">0</property>
 


### PR DESCRIPTION
fix: #1153 

Not exactly what I was after, but since I can't set the ellipsization position and having 2 max sub lines looks better IMO as it hides less info.