### PR TITLE
feat(Composer): use the most private visibility when replying

### DIFF
--- a/src/API/Status.vala
+++ b/src/API/Status.vala
@@ -278,10 +278,11 @@ public class Tuba.API.Status : Entity, Widgetizable, SearchResult {
 		return action ("unbookmark");
 	}
 
-	public enum ReblogVisibility {
+	public enum Visibility {
 		PUBLIC,
 		UNLISTED,
-		PRIVATE;
+		PRIVATE,
+		DIRECT;
 
 		public string to_string () {
 			switch (this) {
@@ -291,26 +292,61 @@ public class Tuba.API.Status : Entity, Widgetizable, SearchResult {
 					return "unlisted";
 				case PRIVATE:
 					return "private";
+				case DIRECT:
+					return "direct";
 				default:
-					return "";
+					assert_not_reached ();
 			}
 		}
 
-		public static ReblogVisibility? from_string (string id) {
-			switch (id) {
+		public string to_title () {
+			switch (this) {
+				case PUBLIC:
+					return _("Public");
+				case UNLISTED:
+					// translators: Probably follow Mastodon's translation
+					return _("Unlisted");
+				case PRIVATE:
+					return _("Followers Only");
+				case DIRECT:
+					return _("Direct");
+				default:
+					assert_not_reached ();
+			}
+		}
+
+		public static Visibility? from_string (string id) {
+			switch (id.down ()) {
 				case "public":
 					return PUBLIC;
 				case "unlisted":
 					return UNLISTED;
 				case "private":
 					return PRIVATE;
+				case "direct":
+					return DIRECT;
 				default:
 					return null;
 			}
 		}
+
+		public int privacy_rate () {
+			switch (this) {
+				case PUBLIC:
+					return 0;
+				case UNLISTED:
+					return 1;
+				case PRIVATE:
+					return 2;
+				case DIRECT:
+					return 3;
+				default:
+					assert_not_reached ();
+			}
+		}
 	}
 
-	public Request reblog_req (ReblogVisibility? visibility = null) {
+	public Request reblog_req (Visibility? visibility = null) {
 		var req = action ("reblog");
 		if (visibility != null)
 			req.with_form_data ("visibility", visibility.to_string ());

--- a/src/Dialogs/Composer/Dialog.vala
+++ b/src/Dialogs/Composer/Dialog.vala
@@ -405,6 +405,12 @@ public class Tuba.Dialogs.Compose : Adw.Dialog {
 			language = to.language
 		};
 
+		var default_visibility = API.Status.Visibility.from_string (settings.default_post_visibility);
+		var to_visibility = API.Status.Visibility.from_string (to.visibility);
+		if (default_visibility != null && to_visibility != null && default_visibility.privacy_rate () > to_visibility.privacy_rate ()) {
+			template.visibility = settings.default_post_visibility;
+		}
+
 		Object (
 			status: new BasicStatus.from_status (template),
 			original_status: new BasicStatus.from_status (template),

--- a/src/Services/Accounts/Mastodon/Account.vala
+++ b/src/Services/Accounts/Mastodon/Account.vala
@@ -204,30 +204,29 @@ public class Tuba.Mastodon.Account : InstanceAccount {
 
 		// Populate possible visibility variants
 		set_visibility (new Visibility () {
-			id = "public",
-			name = _("Public"),
+			id = API.Status.Visibility.PUBLIC.to_string (),
+			name = API.Status.Visibility.PUBLIC.to_title (),
 			icon_name = "tuba-globe-symbolic",
 			small_icon_name = "tuba-globe-small-symbolic",
 			description = _("Post to public timelines")
 		});
 		set_visibility (new Visibility () {
-			id = "unlisted",
-			// translators: Probably follow Mastodon's translation
-			name = _("Unlisted"),
+			id = API.Status.Visibility.UNLISTED.to_string (),
+			name = API.Status.Visibility.UNLISTED.to_title (),
 			icon_name = "tuba-padlock2-open-symbolic",
 			small_icon_name = "tuba-padlock2-open-small-symbolic",
 			description = _("Don\'t post to public timelines")
 		});
 		set_visibility (new Visibility () {
-			id = "private",
-			name = _("Followers Only"),
+			id = API.Status.Visibility.PRIVATE.to_string (),
+			name = API.Status.Visibility.PRIVATE.to_title (),
 			icon_name = "tuba-padlock2-symbolic",
 			small_icon_name = "tuba-padlock2-small-symbolic",
 			description = _("Post to followers only")
 		});
 		set_visibility (new Visibility () {
-			id = "direct",
-			name = _("Direct"),
+			id = API.Status.Visibility.DIRECT.to_string (),
+			name = API.Status.Visibility.DIRECT.to_title (),
 			icon_name = "tuba-mail-unread-symbolic",
 			small_icon_name = "tuba-mail-small-symbolic",
 			description = _("Post to mentioned users only")

--- a/src/Widgets/Status/ActionsRow.vala
+++ b/src/Widgets/Status/ActionsRow.vala
@@ -240,11 +240,11 @@ public class Tuba.Widgets.ActionsRow : Gtk.Box {
 			};
 
 			Gtk.CheckButton? group = null; // hashmap is not ordered
-			Gee.HashMap<API.Status.ReblogVisibility, Gtk.CheckButton> check_buttons = new Gee.HashMap<API.Status.ReblogVisibility, Gtk.CheckButton> ();
+			Gee.HashMap<API.Status.Visibility, Gtk.CheckButton> check_buttons = new Gee.HashMap<API.Status.Visibility, Gtk.CheckButton> ();
 			for (int i = 0; i < accounts.active.visibility_list.n_items; i++) {
 				var visibility = (InstanceAccount.Visibility) accounts.active.visibility_list.get_item (i);
-				var reblog_visibility = API.Status.ReblogVisibility.from_string (visibility.id);
-				if (reblog_visibility == null) continue;
+				var reblog_visibility = API.Status.Visibility.from_string (visibility.id);
+				if (reblog_visibility == null || reblog_visibility == API.Status.Visibility.DIRECT) continue;
 
 				var checkbutton = new Gtk.CheckButton () {
 					css_classes = {"selection-mode"},
@@ -288,10 +288,10 @@ public class Tuba.Widgets.ActionsRow : Gtk.Box {
 				switch (res) {
 					case "yes":
 					case "quote":
-						API.Status.ReblogVisibility? reblog_visibility = null;
+						API.Status.Visibility? reblog_visibility = null;
 						check_buttons.foreach (e => {
 							if (((Gtk.CheckButton) e.value).active) {
-								reblog_visibility = (API.Status.ReblogVisibility) e.key;
+								reblog_visibility = (API.Status.Visibility) e.key;
 								return false;
 							}
 
@@ -335,7 +335,7 @@ public class Tuba.Widgets.ActionsRow : Gtk.Box {
 		}, false, status.formal.id);
 	}
 
-	private void commit_boost (Widgets.StatusActionButton status_btn, API.Status.ReblogVisibility? visibility = null) {
+	private void commit_boost (Widgets.StatusActionButton status_btn, API.Status.Visibility? visibility = null) {
 			status_btn.active = !status_btn.active;
 
 			string action;


### PR DESCRIPTION
fix: #1390 

Previously, when replying to a post, Tuba would use the same visibility for privacy reasons (if you reply to a followers-only post, your reply will use followers-only (pre-selected) etc).

But that failed to take into account that the user's default posting visibility might be even more private, aka

default user visibility: followers-only
replying-to post visibility: unlisted
pre-selected visibility: unlisted

which is less private than the user's default.

Now each option has a 'privacy rate', 0 to N, 0 being the least private. When it comes to replying, it will compare the two visibilities' privacy rate and the one with the bigger value will be the pre-selected visibility.

