### PR TITLE
feat(structure): move utils under the Utils namespace

### DIFF
--- a/data/gtk/dropdown/language.ui
+++ b/data/gtk/dropdown/language.ui
@@ -7,7 +7,7 @@
           <object class="GtkLabel">
             <property name="xalign">0</property>
             <binding name="label">
-              <lookup name="name" type="TubaLocalesLocale">
+              <lookup name="name" type="TubaUtilsLocalesLocale">
                 <lookup name="item">GtkListItem</lookup>
               </lookup>
             </binding>
@@ -17,7 +17,7 @@
           <object class="GtkLabel">
             <property name="xalign">0</property>
             <binding name="label">
-              <lookup name="en_name" type="TubaLocalesLocale">
+              <lookup name="en_name" type="TubaUtilsLocalesLocale">
                 <lookup name="item">GtkListItem</lookup>
               </lookup>
             </binding>

--- a/data/gtk/dropdown/language_title.ui
+++ b/data/gtk/dropdown/language_title.ui
@@ -12,7 +12,7 @@
         <child> -->
           <object class="GtkLabel">
             <binding name="label">
-              <lookup name="locale" type="TubaLocalesLocale">
+              <lookup name="locale" type="TubaUtilsLocalesLocale">
                 <lookup name="item">GtkListItem</lookup>
               </lookup>
             </binding>

--- a/data/ui/dialogs/preferences.ui
+++ b/data/ui/dialogs/preferences.ui
@@ -127,7 +127,7 @@
 								<property name="title" translatable="yes">Default Post Language</property>
 
 								<property name="expression">
-									<lookup type="TubaLocalesLocale" name="name" />
+									<lookup type="TubaUtilsLocalesLocale" name="name" />
 								</property>
 							</object>
 						</child>

--- a/meson.build
+++ b/meson.build
@@ -63,6 +63,7 @@ add_project_arguments(['--vapidir=' + meson.project_source_root() / 'vapi'], lan
 add_project_arguments (
   '-DGETTEXT_PACKAGE="@0@"'.format(meson.project_name()),
   '-DG_LOG_DOMAIN="Tuba"',
+  '-w',
   language: 'c'
 )
 

--- a/src/API/Admin/Report.vala
+++ b/src/API/Admin/Report.vala
@@ -78,7 +78,7 @@ public class Tuba.API.Admin.Report : Entity, BasicWidgetizable {
 			? "%s\n".printf (_("You've received a report"))
 
 			// translators: report notification with date, "You've received a report on: <date>"
-			: "%s: <b>%s</b>\n".printf (_("You've received a report on"), DateTime.format_full (created_at));
+			: "%s: <b>%s</b>\n".printf (_("You've received a report on"), Utils.DateTime.format_full (created_at));
 
 		return @"$msg$t_reason$t_comment";
 	}

--- a/src/API/Notification.vala
+++ b/src/API/Notification.vala
@@ -61,11 +61,11 @@ public class Tuba.API.Notification : Entity, Widgetizable {
 	public override void open () {
 		switch (kind) {
 			case InstanceAccount.KIND_SEVERED_RELATIONSHIPS:
-				Host.open_url.begin (@"$(accounts.active.instance)/severed_relationships");
+				Utils.Host.open_url.begin (@"$(accounts.active.instance)/severed_relationships");
 				break;
 			case InstanceAccount.KIND_MODERATION_WARNING:
 				string dispute_id = this.moderation_warning == null ? "" : this.moderation_warning.id;
-				Host.open_url.begin (@"$(accounts.active.instance)/disputes/strikes/$dispute_id");
+				Utils.Host.open_url.begin (@"$(accounts.active.instance)/disputes/strikes/$dispute_id");
 				break;
 			case InstanceAccount.KIND_ADMIN_REPORT:
 				if (report != null) {
@@ -74,7 +74,7 @@ public class Tuba.API.Notification : Entity, Widgetizable {
 						admin_window.present ();
 						admin_window.open_reports ();
 					} else {
-						Host.open_url.begin (@"$(accounts.active.instance)/admin/reports/$(report.id)");
+						Utils.Host.open_url.begin (@"$(accounts.active.instance)/admin/reports/$(report.id)");
 					}
 				}
 				break;
@@ -190,7 +190,7 @@ public class Tuba.API.Notification : Entity, Widgetizable {
 		var toast = new GLib.Notification (res_kind.description);
 		if (status != null) {
 			var body = "";
-			body += HtmlUtils.remove_tags (status.content);
+			body += Utils.Htmlx.remove_tags (status.content);
 			toast.set_body (body);
 		}
 

--- a/src/API/Status/PreviewCard.vala
+++ b/src/API/Status/PreviewCard.vala
@@ -250,6 +250,6 @@ public class Tuba.API.PreviewCard : Entity, Widgetizable {
 			}
 		#endif
 
-		Host.open_url.begin (url);
+		Utils.Host.open_url.begin (url);
 	}
 }

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -37,7 +37,7 @@ namespace Tuba {
 		public bool is_mobile { get; set; default=false; }
 		public bool is_online { get; private set; default=true; }
 
-		public Locales app_locales { get; construct set; }
+		public Utils.Locales app_locales { get; construct set; }
 
 		// These are used for the GTK Inspector
 		public Settings app_settings { get {return Tuba.settings; } }
@@ -152,7 +152,7 @@ namespace Tuba {
 		public void handle_web_ap (Uri uri) {
 			if (accounts.active == null) return;
 
-			accounts.active.resolve.begin (WebApHandler.from_uri (uri), (obj, res) => {
+			accounts.active.resolve.begin (Utils.WebApHandler.from_uri (uri), (obj, res) => {
 				try {
 					accounts.active.resolve.end (res).open ();
 				} catch (Error e) {
@@ -163,7 +163,7 @@ namespace Tuba {
 			});
 		}
 
-		private ShareHandler.ShareResult? to_share = null;
+		private Utils.ShareHandler.ShareResult? to_share = null;
 		public void handle_share () {
 			if (to_share == null || accounts.active == null || accounts.active.instance_info == null) return;
 
@@ -182,7 +182,7 @@ namespace Tuba {
 			application_id = Build.DOMAIN;
 			flags = ApplicationFlags.HANDLES_OPEN;
 
-			app_locales = new Tuba.Locales ();
+			app_locales = new Utils.Locales ();
 		}
 
 		public static int main (string[] args) {
@@ -408,7 +408,7 @@ namespace Tuba {
 						case "tuba":
 							if (add_account_window == null) {
 								if (uri.get_host ().down () == "share") {
-									to_share = ShareHandler.from_uri (uri);
+									to_share = Utils.ShareHandler.from_uri (uri);
 									handle_share ();
 
 									break;
@@ -653,7 +653,7 @@ namespace Tuba {
 			dialog.present (main_window);
 
 			GLib.Idle.add (() => {
-				var style = Tuba.Celebrate.get_celebration_css_class (new GLib.DateTime.now ());
+				var style = Utils.Celebrate.get_celebration_css_class (new GLib.DateTime.now ());
 				if (style != "")
 					dialog.add_css_class (style);
 				return GLib.Source.REMOVE;

--- a/src/Dialogs/AnnualReport.vala
+++ b/src/Dialogs/AnnualReport.vala
@@ -211,7 +211,7 @@ public class Tuba.Dialogs.AnnualReport : Adw.Dialog {
 				total_new_followings += stats.following;
 			}
 
-			string shortened_value = Units.shorten (total_new_posts);
+			string shortened_value = Utils.Units.shorten (total_new_posts);
 			posts_box.append (new Gtk.Label (shortened_value) {
 				css_classes = {"title-1"},
 				wrap = true,
@@ -392,7 +392,7 @@ public class Tuba.Dialogs.AnnualReport : Adw.Dialog {
 					wrap_mode = Pango.WrapMode.WORD_CHAR
 				});
 
-				followers_box.append (new Gtk.Label (Units.shorten (total_new_followers)) {
+				followers_box.append (new Gtk.Label (Utils.Units.shorten (total_new_followers)) {
 					css_classes = {"title-1"},
 					wrap = true,
 					wrap_mode = Pango.WrapMode.WORD_CHAR
@@ -417,7 +417,7 @@ public class Tuba.Dialogs.AnnualReport : Adw.Dialog {
 					wrap_mode = Pango.WrapMode.WORD_CHAR
 				});
 
-				follows_box.append (new Gtk.Label (Units.shorten (total_new_followings)) {
+				follows_box.append (new Gtk.Label (Utils.Units.shorten (total_new_followings)) {
 					css_classes = {"title-1"},
 					wrap = true,
 					wrap_mode = Pango.WrapMode.WORD_CHAR

--- a/src/Dialogs/Composer/AttachmentsPage.vala
+++ b/src/Dialogs/Composer/AttachmentsPage.vala
@@ -485,8 +485,8 @@ public class Tuba.AttachmentsPage : ComposerPage {
 			string? focus = null;
 			if (attachment.meta != null && attachment.meta.focus != null) {
 				focus = "%s,%s".printf (
-					Units.float_to_2_point_string (page_attachment.pos_x),
-					Units.float_to_2_point_string (page_attachment.pos_y)
+					Utils.Units.float_to_2_point_string (page_attachment.pos_x),
+					Utils.Units.float_to_2_point_string (page_attachment.pos_y)
 				);
 			}
 

--- a/src/Dialogs/Composer/AttachmentsPageAttachment.vala
+++ b/src/Dialogs/Composer/AttachmentsPageAttachment.vala
@@ -423,7 +423,7 @@ public class Tuba.AttachmentsPageAttachment : Widgets.Attachment.Item {
 
 	protected override void on_click () {
 		if (attachment_file != null) {
-			Host.open_url.begin (attachment_file.get_path ());
+			Utils.Host.open_url.begin (attachment_file.get_path ());
 		} else if (entity != null) {
 			base.on_click ();
 		}
@@ -451,8 +451,8 @@ public class Tuba.AttachmentsPageAttachment : Widgets.Attachment.Item {
 
 			builder.set_member_name ("focus");
 			builder.add_string_value ("%s,%s".printf (
-				Units.float_to_2_point_string (pos_x),
-				Units.float_to_2_point_string (pos_y)
+				Utils.Units.float_to_2_point_string (pos_x),
+				Utils.Units.float_to_2_point_string (pos_y)
 			));
 
 			builder.end_object ();

--- a/src/Dialogs/Composer/Dialog.vala
+++ b/src/Dialogs/Composer/Dialog.vala
@@ -77,8 +77,8 @@ public class Tuba.Dialogs.Compose : Adw.Dialog {
 
 					if (t_attachment.meta != null && t_attachment.meta.focus != null) {
 						focus = "%s,%s".printf (
-							Units.float_to_2_point_string (t_attachment.meta.focus.x),
-							Units.float_to_2_point_string (t_attachment.meta.focus.y)
+							Utils.Units.float_to_2_point_string (t_attachment.meta.focus.x),
+							Utils.Units.float_to_2_point_string (t_attachment.meta.focus.y)
 						);
 					}
 
@@ -378,7 +378,7 @@ public class Tuba.Dialogs.Compose : Adw.Dialog {
 		};
 
 		if (source == null) {
-			template.content = HtmlUtils.remove_tags (t_status.content);
+			template.content = Utils.Htmlx.remove_tags (t_status.content);
 		} else {
 			template.content = source.text;
 			template.spoiler_text = source.spoiler_text;

--- a/src/Dialogs/Composer/EditorPage.vala
+++ b/src/Dialogs/Composer/EditorPage.vala
@@ -18,24 +18,24 @@ public class Tuba.EditorPage : ComposerPage {
 		string locale_icu = "en";
 		if (
 			language_button != null
-			&& ((Tuba.Locales.Locale) language_button.selected_item) != null
-			&& ((Tuba.Locales.Locale) language_button.selected_item).locale != null
+			&& ((Utils.Locales.Locale) language_button.selected_item) != null
+			&& ((Utils.Locales.Locale) language_button.selected_item).locale != null
 		) {
-			locale_icu = ((Tuba.Locales.Locale) language_button.selected_item).locale;
+			locale_icu = ((Utils.Locales.Locale) language_button.selected_item).locale;
 		}
 
 		if (cw_button != null && cw_button.active)
-				res -= Counting.chars (cw_entry.text, locale_icu);
+				res -= Utils.Counting.chars (cw_entry.text, locale_icu);
 
-		string replaced_urls = Tracking.cleanup_content_with_uris (
+		string replaced_urls = Utils.Tracking.cleanup_content_with_uris (
 			editor.buffer.text,
-			Tracking.extract_uris (editor.buffer.text),
-			Tracking.CleanupType.SPECIFIC_LENGTH,
+			Utils.Tracking.extract_uris (editor.buffer.text),
+			Utils.Tracking.CleanupType.SPECIFIC_LENGTH,
 			accounts.active.instance_info.compat_status_characters_reserved_per_url
 		);
-		string replaced_mentions = Counting.replace_mentions (replaced_urls);
+		string replaced_mentions = Utils.Counting.replace_mentions (replaced_urls);
 
-		res -= Counting.chars (replaced_mentions, locale_icu);
+		res -= Utils.Counting.chars (replaced_mentions, locale_icu);
 
 		remaining_chars = res;
 	}
@@ -104,10 +104,10 @@ public class Tuba.EditorPage : ComposerPage {
 
 	protected void on_paste (Gdk.Clipboard clp) {
 		if (!settings.strip_tracking) return;
-		var clean_buffer = Tracking.cleanup_content_with_uris (
+		var clean_buffer = Utils.Tracking.cleanup_content_with_uris (
 			editor.buffer.text,
-			Tracking.extract_uris (editor.buffer.text),
-			Tracking.CleanupType.STRIP_TRACKING
+			Utils.Tracking.extract_uris (editor.buffer.text),
+			Utils.Tracking.CleanupType.STRIP_TRACKING
 		);
 		if (clean_buffer == editor.buffer.text) return;
 
@@ -146,7 +146,7 @@ public class Tuba.EditorPage : ComposerPage {
 			status.visibility = instance_visibility.id;
 
 		if (language_button != null && language_button.selected_item != null) {
-			status.language = ((Tuba.Locales.Locale) language_button.selected_item).locale;
+			status.language = ((Utils.Locales.Locale) language_button.selected_item).locale;
 		}
 
 		if (content_type_button != null && content_type_button.selected_item != null) {
@@ -435,7 +435,7 @@ public class Tuba.EditorPage : ComposerPage {
 
 	protected void install_languages (string? locale_iso) {
 		language_button = new Gtk.DropDown (app.app_locales.list_store, null) {
-			expression = new Gtk.PropertyExpression (typeof (Tuba.Locales.Locale), null, "name"),
+			expression = new Gtk.PropertyExpression (typeof (Utils.Locales.Locale), null, "name"),
 			factory = new Gtk.BuilderListItemFactory.from_resource (null, @"$(Build.RESOURCES)gtk/dropdown/language_title.ui"),
 			list_factory = new Gtk.BuilderListItemFactory.from_resource (null, @"$(Build.RESOURCES)gtk/dropdown/language.ui"),
 			tooltip_text = _("Post Language"),
@@ -450,8 +450,8 @@ public class Tuba.EditorPage : ComposerPage {
 			uint default_lang_index;
 			if (
 				app.app_locales.list_store.find_with_equal_func (
-					new Tuba.Locales.Locale (locale_iso, null, null),
-					Tuba.Locales.Locale.compare,
+					new Utils.Locales.Locale (locale_iso, null, null),
+					Utils.Locales.Locale.compare,
 					out default_lang_index
 				)
 			) {
@@ -464,7 +464,7 @@ public class Tuba.EditorPage : ComposerPage {
 
 	#if LIBSPELLING
 		private void on_langauge_changed () {
-			var locale_obj = language_button.selected_item as Tuba.Locales.Locale;
+			var locale_obj = language_button.selected_item as Utils.Locales.Locale;
 			if (locale_obj == null || locale_obj.locale == null) return;
 
 			var new_locale = original_libspelling_lang_iso639 == locale_obj.locale

--- a/src/Dialogs/MainWindow.vala
+++ b/src/Dialogs/MainWindow.vala
@@ -161,7 +161,7 @@ public class Tuba.Dialogs.MainWindow: Adw.ApplicationWindow, Saveable {
 
 			((Widgets.BookWyrmPage) book_widget).selectable = true;
 		} catch {
-			if (fallback != null) Host.open_url.begin (fallback);
+			if (fallback != null) Utils.Host.open_url.begin (fallback);
 		}
 	}
 

--- a/src/Dialogs/NewAccount.vala
+++ b/src/Dialogs/NewAccount.vala
@@ -179,7 +179,7 @@ public class Tuba.Dialogs.NewAccount: Adw.Window {
 		var esc_redirect = Uri.escape_string (redirect_uri);
 		var pars = @"scope=$esc_scopes&response_type=code&redirect_uri=$esc_redirect&client_id=$(Uri.escape_string (account.client_id))";
 		var url = @"$(account.instance)/oauth/authorize?$pars";
-		Host.open_url.begin (url);
+		Utils.Host.open_url.begin (url);
 	}
 
 	async void request_token () throws Error {

--- a/src/Dialogs/Preferences.vala
+++ b/src/Dialogs/Preferences.vala
@@ -323,8 +323,8 @@ public class Tuba.Dialogs.Preferences : Adw.PreferencesDialog {
 		uint default_lang_index;
 		if (
 			app.app_locales.list_store.find_with_equal_func (
-				new Tuba.Locales.Locale (default_language, null, null),
-				Tuba.Locales.Locale.compare,
+				new Utils.Locales.Locale (default_language, null, null),
+				Utils.Locales.Locale.compare,
 				out default_lang_index
 			)
 		) {
@@ -349,8 +349,8 @@ public class Tuba.Dialogs.Preferences : Adw.PreferencesDialog {
 
 	private void on_window_closed () {
 		if (lang_changed) {
-			var new_lang = ((Tuba.Locales.Locale) default_language_combo_row.selected_item).locale;
-			if (settings.default_language != ((Tuba.Locales.Locale) default_language_combo_row.selected_item).locale) {
+			var new_lang = ((Utils.Locales.Locale) default_language_combo_row.selected_item).locale;
+			if (settings.default_language != ((Utils.Locales.Locale) default_language_combo_row.selected_item).locale) {
 
 				new Request.PATCH ("/api/v1/accounts/update_credentials")
 					.with_account (accounts.active)

--- a/src/Services/Accounts/Mastodon/Account.vala
+++ b/src/Services/Accounts/Mastodon/Account.vala
@@ -244,7 +244,7 @@ public class Tuba.Mastodon.Account : InstanceAccount {
 			} catch (Error e) {
 				warning (@"Failed to resolve URL \"$url\":");
 				warning (e.message);
-				Host.open_url.begin (url);
+				Utils.Host.open_url.begin (url);
 			}
 		});
 	}

--- a/src/Services/Accounts/SecretAccountStore.vala
+++ b/src/Services/Accounts/SecretAccountStore.vala
@@ -56,8 +56,8 @@ public class Tuba.SecretAccountStore : AccountStore {
 				false,
 				(obj, res) => {
 					if (app.question.end (res).truthy ()) {
-						Host.open_url.begin (wiki_page, (obj, res) => {
-							Host.open_url.end (res);
+						Utils.Host.open_url.begin (wiki_page, (obj, res) => {
+							Utils.Host.open_url.end (res);
 							Process.exit (1);
 						});
 					} else {

--- a/src/Services/Helpers/Blurhash.vala
+++ b/src/Services/Helpers/Blurhash.vala
@@ -2,7 +2,7 @@ public class Tuba.Helper.Blurhash {
 	public static Gdk.Paintable? decode (string? blurhash) {
 		if (blurhash == null) return null;
 
-		var pixbuf = Tuba.Blurhash.blurhash_to_pixbuf (blurhash, 32, 32);
+		var pixbuf = Utils.Blurhash.blurhash_to_pixbuf (blurhash, 32, 32);
 		if (pixbuf != null) {
 			var paintable = Gdk.Texture.for_pixbuf (pixbuf);
 

--- a/src/Utils/Blurhash.vala
+++ b/src/Utils/Blurhash.vala
@@ -1,6 +1,6 @@
 // Blurhash decoding in pure Vala inspired by
 // https://github.com/woltapp/blurhash and https://github.com/mad-gooze/fast-blurhash/
-public class Tuba.Blurhash {
+public class Tuba.Utils.Blurhash {
 	public struct AverageColor {
 		int r;
 		int g;

--- a/src/Utils/Celebrate.vala
+++ b/src/Utils/Celebrate.vala
@@ -1,7 +1,7 @@
 // Celebrate is inspired by Warp's pride.rs
 // https://gitlab.gnome.org/World/warp/-/blob/main/src/ui/pride.rs
 
-public class Tuba.Celebrate {
+public class Tuba.Utils.Celebrate {
 	enum CelebrateStyle {
 		INTERSEX,
 		LESBIAN,

--- a/src/Utils/Counting.vala
+++ b/src/Utils/Counting.vala
@@ -1,4 +1,4 @@
-public class Tuba.Counting {
+public class Tuba.Utils.Counting {
 	static GLib.Regex mention_regex;
 	static construct {
 		try {

--- a/src/Utils/DateTime.vala
+++ b/src/Utils/DateTime.vala
@@ -1,4 +1,4 @@
-public class Tuba.DateTime {
+public class Tuba.Utils.DateTime {
 
 	public static string humanize_left (string? iso8601) {
 		if (iso8601 == null) return "";

--- a/src/Utils/Host.vala
+++ b/src/Utils/Host.vala
@@ -1,5 +1,4 @@
-public class Tuba.Host {
-
+public class Tuba.Utils.Host {
 	// Open a URI in the user's default application
 	public async static bool open_url (string _uri) {
 		var uri = _uri;
@@ -7,7 +6,7 @@ public class Tuba.Host {
 			uri = "file://" + _uri;
 
 		if (settings.strip_tracking)
-			uri = Tracking.strip_utm (uri);
+			uri = Utils.Tracking.strip_utm (uri);
 
 		return yield open_in_default_app (uri);
 	}
@@ -18,7 +17,7 @@ public class Tuba.Host {
 	public async static bool open_uri (Uri uri) {
 		string url;
 		try {
-			url = Tracking.strip_utm_from_uri (uri).to_string ();
+			url = Utils.Tracking.strip_utm_from_uri (uri).to_string ();
 		} catch (Error e) {
 			warning (@"Error while stripping tracking params: $(e.message)");
 			url = uri.to_string ();

--- a/src/Utils/Html.vala
+++ b/src/Utils/Html.vala
@@ -1,8 +1,8 @@
-public class Tuba.HtmlUtils {
+public class Tuba.Utils.Htmlx {
 	public static string remove_tags (string content) {
 		var fixed_paragraphs = content;
 
-		string to_parse = HtmlUtils.replace_with_pango_markup (content);
+		string to_parse = Htmlx.replace_with_pango_markup (content);
 		if (to_parse != "") {
 			var doc = Html.Doc.read_doc (to_parse, "", "utf8");
 			if (doc != null) {

--- a/src/Utils/Locale.vala
+++ b/src/Utils/Locale.vala
@@ -1,4 +1,4 @@
-public class Tuba.Locales : GLib.Object {
+public class Tuba.Utils.Locales : GLib.Object {
 	public class Locale : GLib.Object {
 		public string locale { get; set; }
 		public string en_name { get; set; }

--- a/src/Utils/ShareHandler.vala
+++ b/src/Utils/ShareHandler.vala
@@ -1,4 +1,4 @@
-public class Tuba.ShareHandler {
+public class Tuba.Utils.ShareHandler {
 	public struct ShareResult {
 		public string text;
 		public string? cw;

--- a/src/Utils/TagExtractor.vala
+++ b/src/Utils/TagExtractor.vala
@@ -1,4 +1,4 @@
-public class Tuba.TagExtractor {
+public class Tuba.Utils.TagExtractor {
 	public const int MAX_TAGS_ALLOWED = 20;
 
 	public struct Tag {

--- a/src/Utils/Tracking.vala
+++ b/src/Utils/Tracking.vala
@@ -1,7 +1,7 @@
 // Ported from Chatty
 // https://source.puri.sm/Librem5/chatty/-/merge_requests/1229
 
-public class Tuba.Tracking {
+public class Tuba.Utils.Tracking {
 	/* https://github.com/brave/brave-core/blob/5fcad3e35bac6fea795941fd8189a59d79d488bc/browser/net/brave_site_hacks_network_delegate_helper.cc#L29-L67 */
 	public const string[] TRACKING_IDS = {
 		// Strip any utm_ based ones

--- a/src/Utils/Units.vala
+++ b/src/Utils/Units.vala
@@ -1,4 +1,4 @@
-public class Tuba.Units {
+public class Tuba.Utils.Units {
 	public enum ShortUnitType {
 		NONE,
 		THOUSAND,

--- a/src/Utils/WebApHandler.vala
+++ b/src/Utils/WebApHandler.vala
@@ -1,5 +1,5 @@
 // https://fedilinks.org/spec/en/6-The-web-ap-URI
-public class Tuba.WebApHandler {
+public class Tuba.Utils.WebApHandler {
 	public static string from_uri (Uri uri) {
 		return Uri.join (
 			uri.get_flags (),

--- a/src/Views/Browser.vala
+++ b/src/Views/Browser.vala
@@ -187,12 +187,12 @@ public class Tuba.Views.Browser : Adw.Dialog {
 		}
 
 		private void on_open_in_browser () {
-			Host.open_url.begin (this.subtitle);
+			Utils.Host.open_url.begin (this.subtitle);
 			exit ();
 		}
 
 		private void on_copy_url () {
-			Host.copy (this.subtitle);
+			Utils.Host.copy (this.subtitle);
 			app.toast (_("Copied url to clipboard"));
 		}
 
@@ -334,7 +334,7 @@ public class Tuba.Views.Browser : Adw.Dialog {
 
 	protected void download_in_browser (WebKit.Download download) {
 		download.cancel ();
-		Host.open_url.begin (download.get_request ().uri);
+		Utils.Host.open_url.begin (download.get_request ().uri);
 	}
 
 	protected bool open_new_tab_in_browser (WebKit.PolicyDecision decision, WebKit.PolicyDecisionType type) {
@@ -354,7 +354,7 @@ public class Tuba.Views.Browser : Adw.Dialog {
 					|| response_decision.response.mime_type.has_prefix ("text/")
 				) return false;
 
-				Host.open_url.begin (response_decision.request.uri);
+				Utils.Host.open_url.begin (response_decision.request.uri);
 				response_decision.ignore ();
 				return true;
 			default:
@@ -363,7 +363,7 @@ public class Tuba.Views.Browser : Adw.Dialog {
 	}
 
 	protected Gtk.Widget on_create (WebKit.NavigationAction navigation_action) {
-		Host.open_url.begin (navigation_action.get_request ().get_uri ());
+		Utils.Host.open_url.begin (navigation_action.get_request ().get_uri ());
 
 		// According to the docs, we should return null if
 		// we are not creating a new WebView, but the vapi

--- a/src/Views/MediaViewer.vala
+++ b/src/Views/MediaViewer.vala
@@ -823,7 +823,7 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 		Item? page = safe_get ((int) carousel.position);
 		if (page == null) return;
 
-		Host.copy (page.url);
+		Utils.Host.copy (page.url);
 		app.toast (_("Copied media url to clipboard"));
 	}
 
@@ -831,7 +831,7 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 		Item? page = safe_get ((int) carousel.position);
 		if (page == null) return;
 
-		Host.open_url.begin (page.url);
+		Utils.Host.open_url.begin (page.url);
 	}
 
 	private void save_as () {
@@ -960,7 +960,7 @@ public class Tuba.Views.MediaViewer : Gtk.Widget, Gtk.Buildable, Adw.Swipeable {
 	}
 
 	private async string download_video (string url) throws Error {
-		return yield Host.download (url);
+		return yield Utils.Host.download (url);
 	}
 
 	private bool revealed = false;

--- a/src/Views/Profile.vala
+++ b/src/Views/Profile.vala
@@ -307,7 +307,7 @@ public class Tuba.Views.Profile : Views.Accounts {
 
 		var copy_handle_action = new SimpleAction ("copy_handle", null);
 		copy_handle_action.activate.connect (v => {
-			Host.copy (profile.account.full_handle);
+			Utils.Host.copy (profile.account.full_handle);
 			app.toast (_("Copied handle to clipboard"));
 		});
 		actions.add_action (copy_handle_action);
@@ -321,7 +321,7 @@ public class Tuba.Views.Profile : Views.Accounts {
 				}
 			#endif
 
-			Host.open_url.begin (profile.account.url);
+			Utils.Host.open_url.begin (profile.account.url);
 		});
 		actions.add_action (open_in_browser_action);
 

--- a/src/Views/Search.vala
+++ b/src/Views/Search.vala
@@ -256,7 +256,7 @@ public class Tuba.Views.Search : Views.TabbedBase {
 			};
 
 			lang_dropdown = new Gtk.DropDown (app.app_locales.list_store, null) {
-				expression = new Gtk.PropertyExpression (typeof (Tuba.Locales.Locale), null, "name"),
+				expression = new Gtk.PropertyExpression (typeof (Utils.Locales.Locale), null, "name"),
 				factory = new Gtk.BuilderListItemFactory.from_resource (null, @"$(Build.RESOURCES)gtk/dropdown/language_title.ui"),
 				list_factory = new Gtk.BuilderListItemFactory.from_resource (null, @"$(Build.RESOURCES)gtk/dropdown/language.ui"),
 				enable_search = true,
@@ -313,8 +313,8 @@ public class Tuba.Views.Search : Views.TabbedBase {
 								uint default_lang_index;
 								if (
 									app.app_locales.list_store.find_with_equal_func (
-										new Tuba.Locales.Locale (locale_str, null, null),
-										Tuba.Locales.Locale.compare,
+										new Utils.Locales.Locale (locale_str, null, null),
+										Utils.Locales.Locale.compare,
 										out default_lang_index
 									)
 								) {
@@ -456,7 +456,7 @@ public class Tuba.Views.Search : Views.TabbedBase {
 			}
 
 			if (lang_dropdown.sensitive) {
-				props += @"language:$(((Tuba.Locales.Locale) lang_dropdown.selected_item).locale)";
+				props += @"language:$(((Utils.Locales.Locale) lang_dropdown.selected_item).locale)";
 			}
 
 			result (@"$final_query $(string.joinv (" ", props))");

--- a/src/Views/Thread.vala
+++ b/src/Views/Thread.vala
@@ -222,7 +222,7 @@ public class Tuba.Views.Thread : Views.ContentBase, AccountHolder {
 					app.main_window.open_view (new Views.Thread (status));
 				}
 				else
-					Host.open_url.begin (q);
+					Utils.Host.open_url.begin (q);
 			})
 			.exec ();
 	}

--- a/src/Widgets/Account.vala
+++ b/src/Widgets/Account.vala
@@ -219,7 +219,7 @@ public class Tuba.Widgets.Account : Gtk.ListBoxRow {
 			"%s Post",
 			"%s Posts",
 			(ulong) account.statuses_count
-		).printf (@"<b>$(Tuba.Units.shorten (account.statuses_count))</b>");
+		).printf (@"<b>$(Utils.Units.shorten (account.statuses_count))</b>");
 
 		// translators: Used in profile stats.
 		//              The variable is a shortened number of the amount of followers a user has.
@@ -227,13 +227,13 @@ public class Tuba.Widgets.Account : Gtk.ListBoxRow {
 			"%s Follower",
 			"%s Followers",
 			(ulong) account.statuses_count
-		).printf (@"<b>$(Tuba.Units.shorten (account.followers_count))</b>");
+		).printf (@"<b>$(Utils.Units.shorten (account.followers_count))</b>");
 
 		stats_label.label = "<span allow_breaks=\"false\">%s</span>   <span allow_breaks=\"false\">%s</span>   <span allow_breaks=\"false\">%s</span>".printf (
 			posts_str,
 			// translators: Used in profile stats.
 			//              The variable is a shortened number of the amount of people a user follows.
-			_("%s Following").printf (@"<b>$(Tuba.Units.shorten (account.following_count))</b>"),
+			_("%s Following").printf (@"<b>$(Utils.Units.shorten (account.following_count))</b>"),
 			followers_str
 		);
 

--- a/src/Widgets/Announcement.vala
+++ b/src/Widgets/Announcement.vala
@@ -22,7 +22,7 @@ public class Tuba.Widgets.Announcement : Gtk.ListBoxRow {
 			this.handle_label.get_text ()
 		);
 
-		string aria_date = DateTime.humanize_aria (announcement_date);
+		string aria_date = Utils.DateTime.humanize_aria (announcement_date);
 		string aria_date_prefixed = edited_indicator.visible
 			// translators: This is an accessibility label.
 			//				Screen reader users are going to hear this a lot,
@@ -114,7 +114,7 @@ public class Tuba.Widgets.Announcement : Gtk.ListBoxRow {
 			edited_indicator.visible = false;
 		}
 
-		date_label.label = DateTime.humanize (announcement_date);
+		date_label.label = Utils.DateTime.humanize (announcement_date);
 		date_label.tooltip_text = new GLib.DateTime.from_iso8601 (announcement_date, null).format ("%F %T");
 		date_label.update_property (Gtk.AccessibleProperty.LABEL, date_label.tooltip_text, -1);
 

--- a/src/Widgets/Attachment/Image.vala
+++ b/src/Widgets/Attachment/Image.vala
@@ -104,9 +104,9 @@ public class Tuba.Widgets.Attachment.Image : Widgets.Attachment.Item {
 
 	protected override void copy_media () {
 		debug ("Begin copy-media action");
-		Host.download.begin (entity.url, (obj, res) => {
+		Utils.Host.download.begin (entity.url, (obj, res) => {
 			try {
-				string path = Host.download.end (res);
+				string path = Utils.Host.download.end (res);
 
 				Gdk.Texture texture = Gdk.Texture.from_filename (path);
 				if (texture == null) return;

--- a/src/Widgets/Attachment/Item.vala
+++ b/src/Widgets/Attachment/Item.vala
@@ -17,12 +17,12 @@ public class Tuba.Widgets.Attachment.Item : Adw.Bin {
 	public Tuba.Attachment.MediaType media_kind { get; protected set; }
 
 	private void copy_url () {
-		Host.copy (entity.url);
+		Utils.Host.copy (entity.url);
 		app.toast (_("Copied attachment url to clipboard"));
 	}
 
 	private void open_in_browser () {
-		Host.open_url.begin (entity.url);
+		Utils.Host.open_url.begin (entity.url);
 	}
 
 	private void save_as () {
@@ -225,7 +225,7 @@ public class Tuba.Widgets.Attachment.Item : Adw.Bin {
 	}
 
 	protected async void open () throws Error {
-		var path = yield Host.download (entity.url);
-		Host.open_url.begin (path);
+		var path = yield Utils.Host.download (entity.url);
+		Utils.Host.open_url.begin (path);
 	}
 }

--- a/src/Widgets/AudioPlayer/Visualizer.vala
+++ b/src/Widgets/AudioPlayer/Visualizer.vala
@@ -31,7 +31,7 @@ public class Tuba.Widgets.Audio.Visualizer : Gtk.Widget {
 		context = new Cairo.Context (surface);
 
 		if (blurhash != null && blurhash != "") {
-			var avg = Tuba.Blurhash.get_blurhash_average_color (blurhash);
+			var avg = Utils.Blurhash.get_blurhash_average_color (blurhash);
 			color = {
 				avg.r / 255.0f,
 				avg.g / 255.0f,

--- a/src/Widgets/BookWyrmPage.vala
+++ b/src/Widgets/BookWyrmPage.vala
@@ -69,7 +69,7 @@ public class Tuba.Widgets.BookWyrmPage : Gtk.Box {
 		}
 
 		if (t_obj.description != "") {
-			description.label = HtmlUtils.remove_tags (t_obj.description);
+			description.label = Utils.Htmlx.remove_tags (t_obj.description);
 		} else {
 			description.visible = false;
 		}
@@ -104,11 +104,11 @@ public class Tuba.Widgets.BookWyrmPage : Gtk.Box {
 
 	[GtkCallback]
 	void open_on_openlibrary () {
-		Host.open_url.begin (@"https://openlibrary.org/books/$(book.openlibraryKey)");
+		Utils.Host.open_url.begin (@"https://openlibrary.org/books/$(book.openlibraryKey)");
 	}
 
 	[GtkCallback]
 	void open_on_bw () {
-		Host.open_url.begin (book.id);
+		Utils.Host.open_url.begin (book.id);
 	}
 }

--- a/src/Widgets/HashtagBar.vala
+++ b/src/Widgets/HashtagBar.vala
@@ -8,7 +8,7 @@ public class Tuba.Widgets.HashtagBar : Adw.Bin {
 		}
 
 		string tag;
-		public HashtagButton (TagExtractor.Tag hashtag) {
+		public HashtagButton (Utils.TagExtractor.Tag hashtag) {
 			tag = hashtag.tag;
 			this.child = new Gtk.Label (@"#$tag") {
 				ellipsize = Pango.EllipsizeMode.END
@@ -33,7 +33,7 @@ public class Tuba.Widgets.HashtagBar : Adw.Bin {
 		this.child = wrapbox;
 	}
 
-	public HashtagBar (TagExtractor.Tag[] tags) {
+	public HashtagBar (Utils.TagExtractor.Tag[] tags) {
 		bool should_show_all = tags.length <= MAX_VISIBLE_TAGS + 1;
 
 		for (int i = 0; i < tags.length; i++) {

--- a/src/Widgets/MarkupView.vala
+++ b/src/Widgets/MarkupView.vala
@@ -23,8 +23,8 @@ public class Tuba.Widgets.MarkupView : Gtk.Box {
 	public bool extract_last_tags { get; set; default=false; }
 	public bool has_link { get; set; default=false; }
 
-	TagExtractor.Tag[]? extracted_tags = null;
-	public TagExtractor.Tag[]? get_extracted_tags () {
+	Utils.TagExtractor.Tag[]? extracted_tags = null;
+	public Utils.TagExtractor.Tag[]? get_extracted_tags () {
 		return extracted_tags;
 	}
 
@@ -81,7 +81,7 @@ public class Tuba.Widgets.MarkupView : Gtk.Box {
 			w.destroy ();
 		}
 
-		string to_parse = HtmlUtils.replace_with_pango_markup (content);
+		string to_parse = Utils.Htmlx.replace_with_pango_markup (content);
 		if (to_parse == "") return;
 
 		var doc = Html.Doc.read_doc (to_parse, "", "utf8");
@@ -112,7 +112,7 @@ public class Tuba.Widgets.MarkupView : Gtk.Box {
 
 	void extract_tags () {
 		if (current_chunk == null || !this.has_link) return;
-		var extracted = TagExtractor.from_string (current_chunk);
+		var extracted = Utils.TagExtractor.from_string (current_chunk);
 		if (extracted.input_without_tags == null || extracted.extracted_tags == null) return;
 
 		current_chunk = extracted.input_without_tags;

--- a/src/Widgets/PreviewCard.vala
+++ b/src/Widgets/PreviewCard.vala
@@ -152,7 +152,7 @@ public class Tuba.Widgets.PreviewCard : Gtk.Box {
 		if (author_account != null) {
 			author_account.open ();
 		} else if (author_url != null && author_url != "") {
-			Host.open_url.begin (author_url);
+			Utils.Host.open_url.begin (author_url);
 		}
 	}
 
@@ -196,7 +196,7 @@ public class Tuba.Widgets.PreviewCard : Gtk.Box {
 			if (callback_account != null) {
 				callback_account.open ();
 			} else if (callback_url != null && callback_url != "") {
-				Host.open_url.begin (callback_url);
+				Utils.Host.open_url.begin (callback_url);
 			}
 		}
 	}

--- a/src/Widgets/PreviewCardExplore.vala
+++ b/src/Widgets/PreviewCardExplore.vala
@@ -118,6 +118,6 @@ public class Tuba.Widgets.PreviewCardExplore : Gtk.ListBoxRow {
 	}
 
 	private void on_card_click () {
-		Host.open_url.begin (this.url);
+		Utils.Host.open_url.begin (this.url);
 	}
 }

--- a/src/Widgets/ProfileCover.vala
+++ b/src/Widgets/ProfileCover.vala
@@ -72,7 +72,7 @@ protected class Tuba.Widgets.Cover : Gtk.Box {
 					//				displayed in the list. The singular version will not be used.
 					"Followed by %s & %s Other", "Followed by %s & %s Others",
 					(ulong) others_count
-				).printf (string.joinv (", ", display_named), Units.shorten (others_count));
+				).printf (string.joinv (", ", display_named), Utils.Units.shorten (others_count));
 			} else {
 				string display_name_list;
 				switch (display_named.length) {
@@ -325,7 +325,7 @@ protected class Tuba.Widgets.Cover : Gtk.Box {
 				"%s Post",
 				"%s Posts",
 				(ulong) profile.account.statuses_count
-			).printf (@"<b>$(Tuba.Units.shorten (profile.account.statuses_count))</b>");
+			).printf (@"<b>$(Utils.Units.shorten (profile.account.statuses_count))</b>");
 
 			// translators: Used in profile stats.
 			//              The variable is a shortened number of the amount of followers a user has.
@@ -333,13 +333,13 @@ protected class Tuba.Widgets.Cover : Gtk.Box {
 				"%s Follower",
 				"%s Followers",
 				(ulong) profile.account.statuses_count
-			).printf (@"<b>$(Tuba.Units.shorten (profile.account.followers_count))</b>");
+			).printf (@"<b>$(Utils.Units.shorten (profile.account.followers_count))</b>");
 
 			stats_string = "<span allow_breaks=\"false\">%s</span>   <span allow_breaks=\"false\">%s</span>   <span allow_breaks=\"false\">%s</span>".printf (
 				posts_str,
 				// translators: Used in profile stats.
 				//              The variable is a shortened number of the amount of people a user follows.
-				_("%s Following").printf (@"<b>$(Tuba.Units.shorten (profile.account.following_count))</b>"),
+				_("%s Following").printf (@"<b>$(Utils.Units.shorten (profile.account.following_count))</b>"),
 				followers_str
 			);
 
@@ -505,7 +505,7 @@ protected class Tuba.Widgets.Cover : Gtk.Box {
 				var row = new Gtk.Box (Gtk.Orientation.VERTICAL, 6) {
 					css_classes = {"ttl-profile-field"}
 				};
-				var val = new Widgets.RichLabel (HtmlUtils.simplify (f.val)) {
+				var val = new Widgets.RichLabel (Utils.Htmlx.simplify (f.val)) {
 					use_markup = true,
 					xalign = 0,
 					selectable = true
@@ -649,7 +649,7 @@ protected class Tuba.Widgets.Cover : Gtk.Box {
 		public string label_template { get; set; default = "%s"; }
 		public int64 amount {
 			set {
-				this.label = label_template.printf (Tuba.Units.shorten (value));
+				this.label = label_template.printf (Utils.Units.shorten (value));
 				this.tooltip_text = label_template.printf (value.to_string ());
 			}
 		}

--- a/src/Widgets/RichLabel.vala
+++ b/src/Widgets/RichLabel.vala
@@ -189,9 +189,9 @@ public class Tuba.Widgets.RichLabel : Adw.Bin {
 			}
 		#endif
 		if (uri == null) {
-			Host.open_url.begin (url);
+			Utils.Host.open_url.begin (url);
 		} else {
-			Host.open_uri.begin (uri);
+			Utils.Host.open_uri.begin (uri);
 		}
 	}
 
@@ -208,7 +208,7 @@ public class Tuba.Widgets.RichLabel : Adw.Bin {
 			string? current_uri = widget.get_current_uri ();
 			if (current_uri == null) return;
 
-			Host.open_url.begin (current_uri);
+			Utils.Host.open_url.begin (current_uri);
 		}
 	#endif
 }

--- a/src/Widgets/ScheduledStatus.vala
+++ b/src/Widgets/ScheduledStatus.vala
@@ -124,7 +124,7 @@ public class Tuba.Widgets.ScheduledStatus : Gtk.ListBoxRow {
 		widg.date_label.visible = false;
 		if (widg.poll != null) {
 			widg.poll.usable = false;
-			widg.poll.info_label.label = DateTime.humanize_ago (poll.expires_at);
+			widg.poll.info_label.label = Utils.DateTime.humanize_ago (poll.expires_at);
 		}
 
 		// Re-parse the date into a MONTH DAY, YEAR (separator) HOUR:MINUTES

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -419,12 +419,12 @@
 						settings.copy_private_link_reminder = false;
 					}
 
-					Host.copy (status.formal.url);
+					Utils.Host.copy (status.formal.url);
 					app.toast (_("Copied post url to clipboard"));
 				}
 			);
 		} else {
-			Host.copy (status.formal.url ?? status.formal.account.url);
+			Utils.Host.copy (status.formal.url ?? status.formal.account.url);
 			app.toast (_("Copied post url to clipboard"));
 		}
 	}
@@ -438,7 +438,7 @@
 			}
 		#endif
 
-		Host.open_url.begin (final_url);
+		Utils.Host.open_url.begin (final_url);
 	}
 
 	private void report_status () {
@@ -643,7 +643,7 @@
 
 				return date_parsed.format (@"$date_local $EXPANDED_SEPARATOR %H:%M").replace (" ", ""); // %e prefixes with whitespace on single digits
 			} else {
-				return DateTime.humanize (this.full_date);
+				return Utils.DateTime.humanize (this.full_date);
 			}
 		}
 	}
@@ -833,7 +833,7 @@
 			this.subtitle_text
 		);
 
-		string aria_date = DateTime.humanize_aria (this.full_date);
+		string aria_date = Utils.DateTime.humanize_aria (this.full_date);
 		string aria_date_prefixed = status.formal.is_edited
 			// translators: This is an accessibility label.
 			//				Screen reader users are going to hear this a lot,

--- a/src/Widgets/Status/ActionsRow.vala
+++ b/src/Widgets/Status/ActionsRow.vala
@@ -160,11 +160,11 @@ public class Tuba.Widgets.ActionsRow : Gtk.Box {
 	}
 
 	private void on_reply_button_clicked (Gtk.Button btn) {
-		if (settings.reply_to_old_post_reminder && Tuba.DateTime.is_3_months_old (status.formal.created_at)) {
+		if (settings.reply_to_old_post_reminder && Utils.DateTime.is_3_months_old (status.formal.created_at)) {
 			app.question.begin (
 				// translators: the variable is a datetime with the "old" suffix, e.g. "5 months old", "a day old", "2 years old".
 				//				The "old" suffix is translated on the datetime strings, not here
-				{_("This post is %s").printf (Tuba.DateTime.humanize_old (status.formal.created_at)), false},
+				{_("This post is %s").printf (Utils.DateTime.humanize_old (status.formal.created_at)), false},
 				// translators: you can find this string translated on https://github.com/mastodon/mastodon-android/tree/master/mastodon/src/main/res
 				//				in the `strings.xml` file inside the `values-` folder that matches your locale under the `old_post_sheet_text` key
 				{_("You can still reply, but it may no longer be relevant."), false},

--- a/src/Widgets/StatusActionButton.vala
+++ b/src/Widgets/StatusActionButton.vala
@@ -78,7 +78,7 @@ public class Tuba.Widgets.StatusActionButton : Gtk.Button {
 			return;
 		}
 
-		content.label = Tuba.Units.shorten (new_value);
+		content.label = Utils.Units.shorten (new_value);
 		content.margin_start = 12;
 		content.margin_end = 9;
 	}

--- a/src/Widgets/VoteBox.vala
+++ b/src/Widgets/VoteBox.vala
@@ -287,7 +287,7 @@ public class Tuba.Widgets.VoteBox : Gtk.Box {
 			}
 		}
 
-		string voted_string = Tuba.Units.shorten (poll.votes_count);
+		string voted_string = Utils.Units.shorten (poll.votes_count);
 		string voted_numerical_string = GLib.ngettext (
 			// translators: the variable is the amount of people that voted
 			"%s voted", "%s voted",
@@ -297,8 +297,8 @@ public class Tuba.Widgets.VoteBox : Gtk.Box {
 			info_label.label = "%s · %s".printf (
 				voted_numerical_string,
 				poll.expired
-					? DateTime.humanize_ago (poll.expires_at)
-					: DateTime.humanize_left (poll.expires_at)
+					? Utils.DateTime.humanize_ago (poll.expires_at)
+					: Utils.DateTime.humanize_left (poll.expires_at)
 			);
 		} else {
 			info_label.label = voted_numerical_string;

--- a/tests/Blurhash.test.vala
+++ b/tests/Blurhash.test.vala
@@ -69,7 +69,7 @@ const TestBlurhashData[] BLURHASH_TO_DATA_TESTS = {
 
 public void test_base83_decode () {
 	foreach (var test_base83_decode in BASE83_DECODE_TESTS) {
-		var res = Tuba.Blurhash.Base83.decode (test_base83_decode.encoded);
+		var res = Tuba.Utils.Blurhash.Base83.decode (test_base83_decode.encoded);
 
 		assert_cmpint (res, CompareOperator.EQ, test_base83_decode.decoded);
 	}
@@ -77,7 +77,7 @@ public void test_base83_decode () {
 
 public void test_blurhash_validity () {
 	foreach (var test_blurhash_validity in BLURHASH_VALIDITY_TESTS) {
-		var res = Tuba.Blurhash.is_valid_blurhash (test_blurhash_validity.blurhash, null, null, null, null);
+		var res = Tuba.Utils.Blurhash.is_valid_blurhash (test_blurhash_validity.blurhash, null, null, null, null);
 
 		if (test_blurhash_validity.valid) {
 			assert_true (res);
@@ -91,7 +91,7 @@ public void test_blurhash_ratio () {
 	foreach (var test_blurhash_ratio in BLURHASH_RATIO_TESTS) {
 		var res_x = 0;
 		var res_y = 0;
-		var res = Tuba.Blurhash.is_valid_blurhash (test_blurhash_ratio.blurhash, null, out res_x, out res_y, null);
+		var res = Tuba.Utils.Blurhash.is_valid_blurhash (test_blurhash_ratio.blurhash, null, out res_x, out res_y, null);
 
 		assert_true (res);
 		assert_cmpint (res_x, CompareOperator.EQ, test_blurhash_ratio.x);
@@ -101,7 +101,7 @@ public void test_blurhash_ratio () {
 
 public void test_blurhash_data () {
 	foreach (var test_blurhash_data in BLURHASH_TO_DATA_TESTS) {
-		var res = Tuba.Blurhash.decode_to_data (test_blurhash_data.blurhash, 10, 10);
+		var res = Tuba.Utils.Blurhash.decode_to_data (test_blurhash_data.blurhash, 10, 10);
 
 		if (test_blurhash_data.blurhash == "invalid") {
 			assert (res == null);

--- a/tests/Celebrate.test.vala
+++ b/tests/Celebrate.test.vala
@@ -133,7 +133,7 @@ private TestCelebrate[] get_celebrate_tests () {
 public void test_celebrate () {
 	var tests = get_celebrate_tests ();
 	foreach (var test_celebrate in tests) {
-		var res = Tuba.Celebrate.get_celebration_css_class (test_celebrate.date);
+		var res = Tuba.Utils.Celebrate.get_celebration_css_class (test_celebrate.date);
 
 
 		if (res == "") {

--- a/tests/Counting.test.vala
+++ b/tests/Counting.test.vala
@@ -28,13 +28,13 @@ const TestMention[] MENTIONS = {
 
 public void test_count () {
 	foreach (var test_count in COUNTS) {
-		assert_cmpint (Tuba.Counting.chars (test_count.content), CompareOperator.EQ, test_count.count);
+		assert_cmpint (Tuba.Utils.Counting.chars (test_count.content), CompareOperator.EQ, test_count.count);
 	}
 }
 
 public void test_mention () {
 	foreach (var test_mention in MENTIONS) {
-		assert_cmpstr (Tuba.Counting.replace_mentions (test_mention.content), CompareOperator.EQ, test_mention.without_mentions);
+		assert_cmpstr (Tuba.Utils.Counting.replace_mentions (test_mention.content), CompareOperator.EQ, test_mention.without_mentions);
 	}
 }
 

--- a/tests/DateTime.test.vala
+++ b/tests/DateTime.test.vala
@@ -117,7 +117,7 @@ TestDate[] get_dates () {
 
 public void test_left () {
 	foreach (var test_date in get_dates ()) {
-		var left_date = Tuba.DateTime.humanize_left (test_date.iso8601);
+		var left_date = Tuba.Utils.DateTime.humanize_left (test_date.iso8601);
 
 		assert_cmpstr (left_date, CompareOperator.EQ, test_date.left);
 	}
@@ -125,7 +125,7 @@ public void test_left () {
 
 public void test_ago () {
 	foreach (var test_date in get_dates ()) {
-		var ago_date = Tuba.DateTime.humanize_ago (test_date.iso8601);
+		var ago_date = Tuba.Utils.DateTime.humanize_ago (test_date.iso8601);
 
 		assert_cmpstr (ago_date, CompareOperator.EQ, test_date.ago);
 	}
@@ -133,7 +133,7 @@ public void test_ago () {
 
 public void test_humanize () {
 	foreach (var test_date in get_dates ()) {
-		var human_date = Tuba.DateTime.humanize (test_date.iso8601);
+		var human_date = Tuba.Utils.DateTime.humanize (test_date.iso8601);
 
 		assert_cmpstr (human_date, CompareOperator.EQ, test_date.human);
 	}
@@ -184,7 +184,7 @@ Test3Months[] get_3_months_dates () {
 
 public void test_3_months () {
 	foreach (var test_date in get_3_months_dates ()) {
-		var is_3_months_old = Tuba.DateTime.is_3_months_old (test_date.iso8601);
+		var is_3_months_old = Tuba.Utils.DateTime.is_3_months_old (test_date.iso8601);
 
 		assert_true (is_3_months_old == test_date.res);
 	}

--- a/tests/Html.test.vala
+++ b/tests/Html.test.vala
@@ -41,7 +41,7 @@ const TestContent[] REMOVE_TAGS_TESTS = {
 
 public void test_pango () {
 	foreach (var test_pango in PANGO_TESTS) {
-		var res = Tuba.HtmlUtils.replace_with_pango_markup (test_pango.original);
+		var res = Tuba.Utils.Htmlx.replace_with_pango_markup (test_pango.original);
 
 		assert_cmpstr (res, CompareOperator.EQ, test_pango.sanitized);
 	}
@@ -49,7 +49,7 @@ public void test_pango () {
 
 public void test_restore () {
 	foreach (var test_restore in RESTORE_TESTS) {
-		var res = Tuba.HtmlUtils.restore_entities (test_restore.original);
+		var res = Tuba.Utils.Htmlx.restore_entities (test_restore.original);
 
 		assert_cmpstr (res, CompareOperator.EQ, test_restore.sanitized);
 	}
@@ -57,7 +57,7 @@ public void test_restore () {
 
 public void test_simplify () {
 	foreach (var test_simplify in SIMPLIFY_TESTS) {
-		var res = Tuba.HtmlUtils.simplify (test_simplify.original);
+		var res = Tuba.Utils.Htmlx.simplify (test_simplify.original);
 
 		assert_cmpstr (res, CompareOperator.EQ, test_simplify.sanitized);
 	}
@@ -65,7 +65,7 @@ public void test_simplify () {
 
 public void test_remove_tags () {
 	foreach (var test_remove_tag in REMOVE_TAGS_TESTS) {
-		var res = Tuba.HtmlUtils.remove_tags (test_remove_tag.original);
+		var res = Tuba.Utils.Htmlx.remove_tags (test_remove_tag.original);
 
 		assert_cmpstr (res, CompareOperator.EQ, test_remove_tag.sanitized);
 	}

--- a/tests/ShareHandler.test.vala
+++ b/tests/ShareHandler.test.vala
@@ -1,16 +1,16 @@
 struct TestShare {
 	public string original;
-	public Tuba.ShareHandler.ShareResult? result;
+	public Tuba.Utils.ShareHandler.ShareResult? result;
 }
 
 TestShare[] get_shares () {
 	return {
 		{ "tuba://share", null },
-		{ "tuba://share?text=foo%20bar", Tuba.ShareHandler.ShareResult () { text = "foo bar", cw = null } },
-		{ "tuba://share?text=foo%20BAR&cw=bar%20foo", Tuba.ShareHandler.ShareResult () { text = "foo BAR", cw = "bar foo" } },
-		{ "tuba://share?text=foo%20bar&cw=%26foo%3Dbar", Tuba.ShareHandler.ShareResult () { text = "foo bar", cw = "&foo=bar" } },
+		{ "tuba://share?text=foo%20bar", Tuba.Utils.ShareHandler.ShareResult () { text = "foo bar", cw = null } },
+		{ "tuba://share?text=foo%20BAR&cw=bar%20foo", Tuba.Utils.ShareHandler.ShareResult () { text = "foo BAR", cw = "bar foo" } },
+		{ "tuba://share?text=foo%20bar&cw=%26foo%3Dbar", Tuba.Utils.ShareHandler.ShareResult () { text = "foo bar", cw = "&foo=bar" } },
 		{ "tuba://share?cw=%26foo%3Dbar", null },
-		{ "tuba://share?text=&cw=", Tuba.ShareHandler.ShareResult () { text = "", cw = "" } }
+		{ "tuba://share?text=&cw=", Tuba.Utils.ShareHandler.ShareResult () { text = "", cw = "" } }
 	};
 }
 
@@ -18,7 +18,7 @@ public void test_share_handler () {
 	foreach (var test_share in get_shares ()) {
 		try {
 			var uri = Uri.parse (test_share.original, UriFlags.ENCODED);
-			var result = Tuba.ShareHandler.from_uri (uri);
+			var result = Tuba.Utils.ShareHandler.from_uri (uri);
 
 			if (result == null) {
 				assert_true (test_share.result == null);

--- a/tests/TagExtractor.test.vala
+++ b/tests/TagExtractor.test.vala
@@ -1,15 +1,15 @@
 struct TestExtract {
 	public string source;
-	public Tuba.TagExtractor.Result? extracted;
+	public Tuba.Utils.TagExtractor.Result? extracted;
 }
 
 TestExtract[] get_extractions () {
 	string max_limit_test_tag = "<a href='https://gnome.org/tags/test'>#test</a>";
-	Tuba.TagExtractor.Tag max_limit_test_tag_struct = {"test", "https://gnome.org/tags/test"};
+	Tuba.Utils.TagExtractor.Tag max_limit_test_tag_struct = {"test", "https://gnome.org/tags/test"};
 	string max_limit_test_source = "Testing the tag limit\n\n";
-	Tuba.TagExtractor.Tag[] max_limit_test_tags = {};
+	Tuba.Utils.TagExtractor.Tag[] max_limit_test_tags = {};
 
-	for (int i = 0; i < Tuba.TagExtractor.MAX_TAGS_ALLOWED; i++) {
+	for (int i = 0; i < Tuba.Utils.TagExtractor.MAX_TAGS_ALLOWED; i++) {
 		max_limit_test_source += max_limit_test_tag;
 		max_limit_test_tags += max_limit_test_tag_struct;
 	}
@@ -76,7 +76,7 @@ TestExtract[] get_extractions () {
 
 public void test_extractor () {
 	foreach (var test_extract in get_extractions ()) {
-		var extraction = Tuba.TagExtractor.from_string (test_extract.source);
+		var extraction = Tuba.Utils.TagExtractor.from_string (test_extract.source);
 		if (test_extract.extracted == null) {
 			assert_true (extraction.input_without_tags == null);
 			assert_true (extraction.extracted_tags == null);

--- a/tests/Tracking.test.vala
+++ b/tests/Tracking.test.vala
@@ -80,7 +80,7 @@ TestUrlCleanup[] get_cleanup_urls () {
 
 public void test_strip_utm () {
 	foreach (var test_url in URLS) {
-		var stripped_url = Tuba.Tracking.strip_utm (test_url.original);
+		var stripped_url = Tuba.Utils.Tracking.strip_utm (test_url.original);
 
 		assert_cmpstr (stripped_url, CompareOperator.EQ, test_url.result);
 	}
@@ -89,14 +89,14 @@ public void test_strip_utm () {
 public void test_strip_utm_fallback () {
 	foreach (var test_url in URLS) {
 		if (!("?" in test_url.original)) continue;
-		var stripped_url = Tuba.Tracking.strip_utm_fallback (test_url.original);
+		var stripped_url = Tuba.Utils.Tracking.strip_utm_fallback (test_url.original);
 		assert_cmpstr (stripped_url, CompareOperator.EQ, test_url.result);
 	}
 }
 
 public void test_cleanup () {
 	foreach (var test_url in get_cleanup_urls ()) {
-		GLib.Uri[] extracted_uris = Tuba.Tracking.extract_uris (test_url.content);
+		GLib.Uri[] extracted_uris = Tuba.Utils.Tracking.extract_uris (test_url.content);
 		assert_cmpint (extracted_uris.length, CompareOperator.EQ, test_url.uris.length);
 
 		for (var i=0; i < test_url.uris.length; i++) {
@@ -104,20 +104,20 @@ public void test_cleanup () {
 		}
 
 		assert_cmpstr (
-			Tuba.Tracking.cleanup_content_with_uris (
+			Tuba.Utils.Tracking.cleanup_content_with_uris (
 				test_url.content,
 				test_url.uris,
-				Tuba.Tracking.CleanupType.STRIP_TRACKING
+				Tuba.Utils.Tracking.CleanupType.STRIP_TRACKING
 			),
 			CompareOperator.EQ,
 			test_url.stripped_content
 		);
 
 		assert_cmpstr (
-			Tuba.Tracking.cleanup_content_with_uris (
+			Tuba.Utils.Tracking.cleanup_content_with_uris (
 				test_url.content,
 				test_url.uris,
-				Tuba.Tracking.CleanupType.SPECIFIC_LENGTH,
+				Tuba.Utils.Tracking.CleanupType.SPECIFIC_LENGTH,
 				test_url.characters_reserved_per_url
 			),
 			CompareOperator.EQ,

--- a/tests/Units.test.vala
+++ b/tests/Units.test.vala
@@ -17,8 +17,8 @@ const TestUnits[] UNITS = {
 
 public void test_shorten () {
 	foreach (var test_unit in UNITS) {
-		var shorten_unit = Tuba.Units.shorten (test_unit.original);
-		var shorten_unit_negative = Tuba.Units.shorten (test_unit.original * -1);
+		var shorten_unit = Tuba.Utils.Units.shorten (test_unit.original);
+		var shorten_unit_negative = Tuba.Utils.Units.shorten (test_unit.original * -1);
 
 		assert_cmpstr (shorten_unit, CompareOperator.EQ, test_unit.result);
 		assert_cmpstr (

--- a/tests/WebApHandler.test.vala
+++ b/tests/WebApHandler.test.vala
@@ -18,7 +18,7 @@ public void test_web_ap_handler () {
 		try {
 			var uri = Uri.parse (test_url.original, UriFlags.ENCODED);
 
-			assert_cmpstr (Tuba.WebApHandler.from_uri (uri), CompareOperator.EQ, test_url.result);
+			assert_cmpstr (Tuba.Utils.WebApHandler.from_uri (uri), CompareOperator.EQ, test_url.result);
 		} catch (Error e) {
 			critical (e.message);
 		}


### PR DESCRIPTION
Something that has been annoying me for a while is that the Utils would be directly under the Tuba namespace. That caused issues like Tuba.DateTime and GLib.DateTime conflicting when `DateTime` was used.

They now live under `Tuba.Utils`.

Also finally suppressed the C logs - nothing I can do about C warnings.