### PR TITLE
feat(gresource): embed all lang specs and styles

### DIFF
--- a/data/gresource.xml.in
+++ b/data/gresource.xml.in
@@ -125,4 +125,12 @@
         <file>ui/dialogs/schedule.ui</file>
         <file>ui/menus.ui</file>
     </gresource>
+    <gresource prefix="/org/gnome/gtksourceview/language-specs">
+      <file preprocess="xml-stripblanks" alias="fedi-basic.lang">langs/fedi-basic.lang</file>
+      <file preprocess="xml-stripblanks" alias="fedi-html.lang">langs/fedi-html.lang</file>
+      <file preprocess="xml-stripblanks" alias="fedi-markdown.lang">langs/fedi-markdown.lang</file>
+    </gresource>
+    <gresource prefix="/org/gnome/gtksourceview/styles">
+      @GRESOURCE_SOURCEVIEW_STYLES_FILES@
+    </gresource>
 </gresources>

--- a/data/meson.build
+++ b/data/meson.build
@@ -28,6 +28,7 @@ install_data(
     ),
 )
 
+gresource_files = ''
 syntax_colors = ['blue', 'teal', 'green', 'yellow', 'orange', 'red', 'pink', 'purple', 'slate']
 foreach color : syntax_colors
   light = configure_file(
@@ -42,45 +43,13 @@ foreach color : syntax_colors
       configuration : {'COLOR': color, 'VARIANT': '2', 'SYNTAX_VARIANT': 'dark', 'OP_SYNTAX_VARIANT': 'light', 'DARK_SUFFIX': '-dark', 'OP_DARK_SUFFIX': ''}
   )
 
-  install_data(
-    light, dark,
-    install_dir: join_paths(
-        get_option('prefix'),
-        get_option('datadir'),
-        'gtksourceview-5',
-        'styles',
-    ),
-  )
+  gresource_files += '<file preprocess="xml-stripblanks" alias="fedi-@0@.xml">@1@/fedi-@0@.xml</file>\n<file preprocess="xml-stripblanks" alias="fedi-@0@-dark.xml">@1@/fedi-@0@-dark.xml</file>\n'.format(color, meson.current_build_dir())
 endforeach
 
-install_data(
-    join_paths('langs', 'fedi-basic.lang'),
-    install_dir: join_paths(
-        get_option('prefix'),
-        get_option('datadir'),
-        'gtksourceview-5',
-        'language-specs',
-    ),
-)
-
-install_data(
-    join_paths('langs', 'fedi-html.lang'),
-    install_dir: join_paths(
-        get_option('prefix'),
-        get_option('datadir'),
-        'gtksourceview-5',
-        'language-specs',
-    ),
-)
-
-install_data(
-    join_paths('langs', 'fedi-markdown.lang'),
-    install_dir: join_paths(
-        get_option('prefix'),
-        get_option('datadir'),
-        'gtksourceview-5',
-        'language-specs',
-    ),
+gresource_file = configure_file(
+    input : 'gresource.xml.in',
+    output : 'gresource.xml',
+    configuration : {'GRESOURCE_SOURCEVIEW_STYLES_FILES': gresource_files}
 )
 
 desktop_file = i18n.merge_file(

--- a/meson.build
+++ b/meson.build
@@ -70,13 +70,6 @@ add_project_arguments (
 gnome = import('gnome')
 i18n = import('i18n')
 
-asresources = gnome.compile_resources(
-    'as-resources',
-    'data/gresource.xml',
-    source_dir: 'data',
-    c_name: 'as',
-)
-
 gstreamer = false
 webkit = false
 gtk_dep = dependency('gtk4', version: '>=4.17.5', required: true)
@@ -140,6 +133,14 @@ final_deps = [
   webkit_dep
 ]
 
+subdir('data')
+asresources = gnome.compile_resources(
+    'as-resources',
+    gresource_file,
+    source_dir: 'data',
+    c_name: 'as',
+)
+
 executable(
     meson.project_name(),
     asresources,
@@ -150,7 +151,6 @@ executable(
 )
 
 subdir('tests')
-subdir('data')
 subdir('po')
 
 # Distributions use their own tooling (e.g. postinst, triggers, etc)


### PR DESCRIPTION
this PR embeds our custom lang specs and styles.

1. it matches upstream's workflow
2. it avoids conflicts
3. it helps package maintainers because they often need to list the usr installed files