### PR TITLE
allow raw ip, v6 including

### DIFF
--- a/src/Dialogs/NewAccount.vala
+++ b/src/Dialogs/NewAccount.vala
@@ -137,7 +137,7 @@ public class Tuba.Dialogs.NewAccount: Adw.Window {
 		account.instance = str;
 		instance_entry.text = str;
 
-		if (str.char_count () <= 0 || !("." in account.instance))
+		if (str.char_count () <= 0)
 			throw new Oopsie.USER (_("Please enter a valid instance URL"));
 	}
 


### PR DESCRIPTION
minor correction to allow IPv6

not sure if IP validation by the dot is really wanted here.
if that is host/name validation it could be improved with Glib API, for example [is_valid](https://docs.gtk.org/glib/type_func.Uri.is_valid.html) method instead or maybe something better exists for these needs. removed so as uneffective.