### PR TITLE
drop `TUBA_SKIP_STRICT_VALIDATION`, optimize Uri filter

### DIFF
--- a/src/Dialogs/NewAccount.vala
+++ b/src/Dialogs/NewAccount.vala
@@ -134,7 +134,6 @@ public class Tuba.Dialogs.NewAccount: Adw.Window {
 		string final_string = instance_entry.text;
 		if (!final_string.contains ("://")) final_string = @"https://$final_string";
 
-		string final_string_no_scheme = final_string;
 		try {
 			GLib.Uri instance_uri = GLib.Uri.parse (final_string, GLib.UriFlags.NONE);
 			final_string = GLib.Uri.build (


### PR DESCRIPTION
By https://github.com/GeopJr/Tuba/pull/1418

1. I think we can drop `TUBA_SKIP_STRICT_VALIDATION` as extra option may confuse new members.

2. Also, I've removed extra steps, looks working for me, could you please test it with Internet DNS, IPv4, etc?
I tested on raw IPv6/Yggdrasil + mastodon.social, and connected there successfully.

3. Not sure about `.substring (3)` removing, please keep in mind if it is really wanted

4. The scheme enforcement removed, because there is alternative protocols available, not HTTP only ([Gemini](https://github.com/dimkr/tootik/) for example)

5. is `instance_uri.get_userinfo ()` in use by ActivityProtocol or we can skip it also by the `null`?