### PR TITLE
feat: use meson features to control optional dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 .PHONY: all install uninstall build test potfiles
 PREFIX ?= /usr
 
-clapper ?= 1
 msys_sys ?= mingw64
 # Remove the devel headerbar style:
 # make release=1
@@ -11,7 +10,7 @@ all: build
 
 build:
 	meson setup builddir --prefix=$(PREFIX)
-	meson configure builddir -Ddevel=$(if $(release),false,true) -Dclapper=$(if $(clapper),enabled,disabled)
+	meson configure builddir -Ddevel=$(if $(release),false,true)
 	meson compile -C builddir
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: build
 
 build:
 	meson setup builddir --prefix=$(PREFIX)
-	meson configure builddir -Ddevel=$(if $(release),false,true) -Dclapper=$(if $(clapper),true,false)
+	meson configure builddir -Ddevel=$(if $(release),false,true) -Dclapper=$(if $(clapper),enabled,disabled)
 	meson compile -C builddir
 
 install:

--- a/build-aux/dev.geopjr.Tuba.Devel.json
+++ b/build-aux/dev.geopjr.Tuba.Devel.json
@@ -130,7 +130,7 @@
             "buildsystem": "meson",
             "config-opts": [
                 "-Ddevel=true",
-                "-Dclapper=true"
+                "-Dclapper=enabled"
             ],
             "build-options": {
                 "arch": {

--- a/build-aux/dev.geopjr.Tuba.Devel.json
+++ b/build-aux/dev.geopjr.Tuba.Devel.json
@@ -130,7 +130,10 @@
             "buildsystem": "meson",
             "config-opts": [
                 "-Ddevel=true",
-                "-Dclapper=enabled"
+                "-Dclapper=enabled",
+                "-Dspelling=enabled",
+                "-Dgstreamer=enabled",
+                "-Din-app-browser=enabled"
             ],
             "build-options": {
                 "arch": {

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
     'dev.geopjr.Tuba',
     ['c', 'vala'],
     version: '0.9.2',
-    meson_version: '>= 0.56.0',
+    meson_version: '>= 0.60.0',
     default_options: [
         'warning_level=2',
         'werror=false',

--- a/meson.build
+++ b/meson.build
@@ -76,11 +76,11 @@ gtk_dep = dependency('gtk4', version: '>=4.17.5', required: true)
 libadwaita_dep = dependency('libadwaita-1', version: '>=1.7', required: true)
 gtksourceview_dep = dependency('gtksourceview-5', required: true, version: '>=5.6.0')
 libwebp_dep = dependency('libwebp', required: false)
-libspelling = dependency('libspelling-1', required: false)
-clapper_dep = dependency('clapper-0.0', required: false, version: '>=0.8.0')
-clapper_gtk_dep = dependency('clapper-gtk-0.0', required: false)
-gstreamer_dep = dependency('gstreamer-1.0', required: false)
-webkit_dep = dependency('webkitgtk-6.0', required: false)
+libspelling = dependency('libspelling-1', required: get_option('spelling'))
+clapper_dep = dependency('clapper-0.0', required: get_option('clapper'), version: '>=0.8.0')
+clapper_gtk_dep = dependency('clapper-gtk-0.0', required: get_option('clapper'))
+gstreamer_dep = dependency('gstreamer-1.0', required: get_option('gstreamer'))
+webkit_dep = dependency('webkitgtk-6.0', required: get_option('in-app-browser'))
 
 if not libwebp_dep.found ()
   warning('WebP support might be missing, please install webp-pixbuf-loader.')
@@ -99,14 +99,14 @@ if gstreamer_dep.found ()
   gstreamer = true
 endif
 
-if get_option('clapper') and clapper_dep.found () and clapper_dep.version().version_compare('>=0.6.0') and clapper_gtk_dep.found ()
+if clapper_dep.found () and clapper_gtk_dep.found ()
   add_project_arguments(['--define=CLAPPER'], language: 'vala')
   if (clapper_dep.get_variable('features').split().contains('mpris'))
     add_project_arguments(['--define=CLAPPER_MPRIS'], language: 'vala')
   endif
 endif
 
-if get_option('in-app-browser') and webkit_dep.found ()
+if webkit_dep.found ()
   add_project_arguments(['--define=WEBKIT'], language: 'vala')
   webkit = true
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,6 @@
 option('devel', type: 'boolean', value: false)
 option('distro', type: 'boolean', value: false)
 option('spelling', type: 'feature')
-option('clapper', type: 'feature')
+option('clapper', type: 'feature', deprecated: {'true': 'enabled', 'false': 'disabled'})
 option('gstreamer', type: 'feature')
 option('in-app-browser', type: 'feature')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,6 @@
 option('devel', type: 'boolean', value: false)
 option('distro', type: 'boolean', value: false)
-option('clapper', type: 'boolean', value: true)
-option('in-app-browser', type: 'boolean', value: true)
+option('spelling', type: 'feature')
+option('clapper', type: 'feature')
+option('gstreamer', type: 'feature')
+option('in-app-browser', type: 'feature')


### PR DESCRIPTION
Use the standard Meson `feature` options to control optional link-time dependencies, as documented in: https://mesonbuild.com/Build-options.html

More specifically, replace the current boolean options that are already present for some of the dependencies with `feature` type options, and add options for the remaining optional dependencies.  These options integrate with `dependency()` calls automatically, making the resulting code simpler and more reliable.  This also makes it possible to disable all the optional dependencies explicitly.

This fixes a bug that Meson would attempt to link to the dependencies (such as `clapper`) even if they were disabled, since disabling the options did not disable the dependency checks, and the dependencies were used in the `final_deps` unconditionally.

I've left `libwebp` as-is, that is without an option, since it is only used to emit a warning.  I have also removed a redundant `clapper` version check, since the current dependency is higher than that.