### PR TITLE
feat(FadeBin): have a minimum beyond the fade min

### DIFF
--- a/src/Widgets/FadeBin.vala
+++ b/src/Widgets/FadeBin.vala
@@ -1,5 +1,6 @@
 public class Tuba.Widgets.FadeBin : Gtk.Widget {
 	const int MAX_HEIGHT = 300;
+	const int MAX_HEIGHT_OVER = MAX_HEIGHT + 100;
 	const float FADE_HEIGHT = 125f;
 	const uint ANIMATION_DURATION = 300;
 
@@ -108,7 +109,7 @@ public class Tuba.Widgets.FadeBin : Gtk.Widget {
 		var child_height = int.max (height, child_min_height);
 		this.child.allocate (width, child_height, baseline, null);
 
-		this.should_fade = !this.reveal && child_height >= MAX_HEIGHT;
+		this.should_fade = !this.reveal && child_height > MAX_HEIGHT_OVER;
 	}
 
 	public override void measure (Gtk.Orientation orientation, int for_size, out int minimum, out int natural, out int minimum_baseline, out int natural_baseline) {
@@ -119,7 +120,7 @@ public class Tuba.Widgets.FadeBin : Gtk.Widget {
 		}
 
 		int child_for_size;
-		if (this.reveal || orientation == Gtk.Orientation.VERTICAL || for_size < MAX_HEIGHT || for_size == -1) {
+		if (this.reveal || orientation == Gtk.Orientation.VERTICAL || for_size < MAX_HEIGHT_OVER || for_size == -1) {
 			child_for_size = for_size;
 		} else if (this.animation.value == 0.0) {
 			child_for_size = -1;
@@ -143,7 +144,7 @@ public class Tuba.Widgets.FadeBin : Gtk.Widget {
 		if (orientation == Gtk.Orientation.VERTICAL && !this.reveal) {
 			minimum_baseline = natural_baseline = -1;
 
-			if (minimum > MAX_HEIGHT) {
+			if (minimum > MAX_HEIGHT_OVER) {
 				minimum = (int) Math.ceil (lerp (
 					MAX_HEIGHT,
 					minimum,
@@ -151,7 +152,7 @@ public class Tuba.Widgets.FadeBin : Gtk.Widget {
 				));
 			}
 
-			if (natural > MAX_HEIGHT) {
+			if (natural > MAX_HEIGHT_OVER) {
 				natural = (int) Math.ceil (lerp (
 					MAX_HEIGHT,
 					natural,


### PR DESCRIPTION
Something that has been annoying me with FadeBin and in general all these 'fade' views everywhere is that they get applied even if the only thing they are fading is like half a line.


https://github.com/user-attachments/assets/6c29fa25-7f0c-4fd7-8e0a-c258e60aa9a0

To solve that, I'm introducing `MAX_HEIGHT_OVER`, which is `MAX_HEIGHT` + 100. This is the height amount beyond `MAX_HEIGHT` (= 300) that will trigger the fade, aka:

If the height is 350, it won't show the fade, even though it's above MAX_HEIGHT.
If it's 410, it will show the fade and the fade container will be MAX_HEIGHT tall.

This makes sure that expanding a fade bin will actually reveal enough stuff, otherwise it will just not fade it and show it in full.

The above post will now look like this by default because the stuff the fadebin would hide were < 100 tall:
![Screenshot From 2025-05-19 15-07-18](https://github.com/user-attachments/assets/4bc0d87a-d54c-4c54-9a1b-4fa39c672b5f)

