### PR TITLE
feat(Visualizer): audio controls match clapper's

### DIFF
--- a/data/style-hc.css
+++ b/data/style-hc.css
@@ -5,3 +5,16 @@
 .ttl-profile-cover.thanks avatar {
 	border-color: alpha(@accent_bg_color, 0.08);
 }
+
+.audio-controls,
+clapper-gtk-lead-container>box {
+	background-color: rgba(38,38,38,1);
+	box-shadow: inset 0 0 0 1px var(--border-color);
+}
+.audio-controls>button:hover,
+.audio-controls>button:checked {
+  background-color: rgba(63,63,63,1);
+}
+.audio-controls>button:active {
+  background-color: rgba(82,82,82,1);
+}

--- a/data/style.css
+++ b/data/style.css
@@ -399,7 +399,7 @@ flowboxchild,
 	padding: 12px;
 }
 
-video > overlay > revealer > controls, .audio-controls {
+video > overlay > revealer > controls {
 	padding: 12px;
 }
 
@@ -839,4 +839,28 @@ list.uniform-border-color row {
 .annual-screenshot-box.style-trans {
 	background-image: linear-gradient(135deg, rgba(92,206,250,0.5) 0%, rgba(246,168,183,0.5) 25%, rgba(255,255,255,0.5) 50%, rgba(246,168,183,0.5) 75%, rgba(92,206,250,0.5) 100%);
 	background-color: var(--window-bg-color);
+}
+
+.audio-controls {
+	background-color: rgba(38,38,38,0.8);
+	border-radius: 9999px;
+	padding: 2px;
+}
+.audio-controls,
+clapper-gtk-lead-container>box {
+	--accent-bg-color: @accent_bg_color;
+	--accent-color: oklab(from var(--accent-bg-color) var(--standalone-color-oklab));
+}
+.audio-controls scale trough highlight {
+	min-height: 6px;
+}
+.audio-controls>button:hover,
+.audio-controls>button:checked {
+	background-color: rgba(63,63,63,0.8);
+}
+.audio-controls>button:active {
+	background-color: rgba(82,82,82,0.8);
+}
+.audio-controls>scalebutton>button {
+	border-radius: 9999px;
 }

--- a/data/ui/widgets/audiocontrols.ui
+++ b/data/ui/widgets/audiocontrols.ui
@@ -20,6 +20,9 @@
 		<!-- <property name="sensitive">0</property> -->
 		<property name="sensitive">1</property>
 		<property name="spacing">6</property>
+		<property name="margin-start">6</property>
+		<property name="margin-end">6</property>
+		<property name="margin-bottom">6</property>
 		<child>
 			<object class="GtkButton" id="play_button">
 				<property name="receives-default">1</property>
@@ -29,6 +32,10 @@
 				<property name="icon-name">media-playback-start-symbolic</property>
 				<property name="tooltip-text" context="media controls tooltip" translatable="yes">Play</property>
 				<signal name="clicked" handler="play_button_clicked" object="TubaWidgetsAudioControls" swapped="no"/>
+				<style>
+					<class name="circular" />
+					<class name="flat" />
+				</style>
 			</object>
 		</child>
 		<child>
@@ -66,6 +73,10 @@
 				<accessibility>
 					<property name="label" translatable="yes" context="media controls">Volume</property>
 				</accessibility>
+				<style>
+					<class name="circular" />
+					<class name="flat" />
+				</style>
 			</object>
 		</child>
 	</template>

--- a/src/Widgets/AudioPlayer/Player.vala
+++ b/src/Widgets/AudioPlayer/Player.vala
@@ -46,9 +46,13 @@ public class Tuba.Widgets.Audio.Player : Adw.Bin {
 		this.bind_property ("ready", controls, "ready", BindingFlags.SYNC_CREATE);
 
 		controls_revealer = new Gtk.Revealer () {
-			child = controls,
-			transition_type = Gtk.RevealerTransitionType.NONE,
-			valign = Gtk.Align.END
+			child = new Adw.Clamp () {
+				child = controls,
+				maximum_size = 1500
+			},
+			transition_type = Gtk.RevealerTransitionType.CROSSFADE,
+			valign = Gtk.Align.END,
+			transition_duration = 800
 		};
 		overlay.add_overlay (controls_revealer);
 
@@ -97,12 +101,8 @@ public class Tuba.Widgets.Audio.Player : Adw.Bin {
 	}
 
 	protected void on_click_gesture () {
-		if (controls_revealer.reveal_child) {
-			controls_revealer.reveal_child = false;
-			revealer_timeout = 0;
-		} else {
-			on_reveal_media_buttons ();
-		}
+		on_reveal_media_buttons ();
+		this.playing = !this.playing;
 	}
 
 	public Player (Gdk.Texture? texture = null, string? blurhash = null) {


### PR DESCRIPTION
\+ feat(Visualizer): clicking video should toggle playing status not reveal state of controls
\+ feat(Clapper): hc border + accented seekbar