### PR TITLE
Increased compose window width to accomodate the German translation

### DIFF
--- a/data/ui/dialogs/compose.ui
+++ b/data/ui/dialogs/compose.ui
@@ -3,7 +3,7 @@
 	<requires lib="gtk" version="4.0" />
 	<requires lib="libadwaita" version="1.0" />
 	<template class="TubaDialogsCompose" parent="AdwDialog">
-		<property name="content_width">500</property>
+		<property name="content_width">630</property>
 		<property name="content_height">400</property>
 		<property name="width_request">360</property>
 		<property name="height_request">200</property>


### PR DESCRIPTION
In the current stable and nightly version of Tuba on the compose screen, when the system language is set to German (and possibly other languages with long words), the words on the center 3 buttons in the desktop (wide) configuration are reduce to ellipsis as seen below.

![Bildschirmfoto vom 2025-05-21 18-47-39](https://github.com/user-attachments/assets/9b66a3ef-2c97-46ba-b084-ce49906cd494)

This PR expands the width of the compose window to `630px` to fit these larger words, as seen below
![Bildschirmfoto vom 2025-05-21 18-29-53](https://github.com/user-attachments/assets/a2ea66e2-b91e-4de4-a18b-1b16632a6cb1)

It also works well with English words
![Bildschirmfoto vom 2025-05-21 18-19-00](https://github.com/user-attachments/assets/cee9dc05-bdef-48a2-854c-ab1f15c6082f)

It is worth noting that we cannot set the width property to simply be `-1` (auto-adjust) because GtkCenterBox as of the writing of this PR, it does not evenly split the padding between its 3 children. A proper fix would be a new layout subclass (EqualPaddingLayout/EqualPaddingCenterBox?) that would properly place the 3 widgets along the top side of the AdwDialog. However, this should suffice for now.