### PR TITLE
feat(Status): support mastoquotes

### DIFF
--- a/src/API/Entity.vala
+++ b/src/API/Entity.vala
@@ -31,7 +31,7 @@ public class Tuba.Entity : GLib.Object, Widgetizable, Json.Serializable {
 		freeze_notify ();
 		foreach (ParamSpec spec in specs) {
 			var name = spec.get_name ();
-			var defined = get_class ().find_property (name) != null;
+			var defined = find_property (name) != null;
 			if (defined && is_spec_valid (ref spec)) {
 				var val = Value (spec.value_type);
 				obj.get_property (name, ref val);

--- a/src/API/Quote.vala
+++ b/src/API/Quote.vala
@@ -1,0 +1,17 @@
+public class Tuba.API.Quote : API.Status {
+	public bool tuba_has_quote {
+		get { return this.state == "accepted"; }
+	}
+
+	public string state { get; set; default = "accepted"; }
+	public API.Status? quoted_status {
+		set {
+			if (value == null) {
+				this.state = "pending";
+			} else {
+				value.quote = null;
+				this.patch (value);
+			}
+		}
+	}
+}

--- a/src/API/Status.vala
+++ b/src/API/Status.vala
@@ -25,7 +25,7 @@ public class Tuba.API.Status : Entity, Widgetizable, SearchResult {
 	public string? edited_at { get; set; default = null; }
 	public string visibility { get; set; default = settings.default_post_visibility; }
 	public API.Status? reblog { get; set; default = null; }
-	public API.Status? quote { get; set; default = null; }
+	public API.Quote? quote { get; set; default = null; }
 	//  public API.Akkoma? akkoma { get; set; default = null; }
 	public Gee.ArrayList<API.Mention>? mentions { get; set; default = null; }
 	public Gee.ArrayList<API.EmojiReaction>? reactions { get; set; default = null; }

--- a/src/API/meson.build
+++ b/src/API/meson.build
@@ -21,6 +21,7 @@ sources += files(
     'NotificationFilter.vala',
     'Poll.vala',
     'PollOption.vala',
+    'Quote.vala',
     'Relationship.vala',
     'ScheduledStatus.vala',
     'SearchResult.vala',

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -1017,7 +1017,7 @@
 		content_column.append (actions);
 
 		this.content.bold_text_regex = status.tuba_search_query_regex;
-		this.content.has_quote = status.formal.quote != null;
+		this.content.has_quote = status.formal.quote != null && status.formal.quote.tuba_has_quote;
 		this.content.mentions = status.formal.mentions;
 		this.content.instance_emojis = status.formal.emojis_map;
 
@@ -1028,7 +1028,7 @@
 		}
 
 		if (quoted_status_btn != null) content_box.remove (quoted_status_btn);
-		if (status.formal.quote != null && !is_quote) {
+		if (this.content.has_quote && !is_quote) {
 			var quoted_status = (Widgets.Status) status.formal.quote.to_widget ();
 			quoted_status.is_quote = true;
 			quoted_status.add_css_class ("frame");


### PR DESCRIPTION
\*screams internally\*

Okay so,

akkoma, pleroma and some other software that supported quotes did the very basic thing of extending mastoapi's statuses by adding a `quote` field. That field is of type status aka it's another post.

Now Mastodon is introducing quotes and the approach is different. There's states of the quote, so now the `quote` field is actually not a post but a wrapper around it.

You see where I'm going with this. There's now two different implementations of 'quote' with the same exact key. I'm hacking around this but eventually akko/pleroma will have to catch up. 