### PR TITLE
feat(AccountStore): bypass guess_backend

### DIFF
--- a/src/Services/Accounts/AccountStore.vala
+++ b/src/Services/Accounts/AccountStore.vala
@@ -152,6 +152,8 @@ public abstract class Tuba.AccountStore : GLib.Object {
 	public Gee.ArrayList<BackendTest> backend_tests = new Gee.ArrayList<BackendTest> ();
 
 	public async void guess_backend (InstanceAccount account) throws GLib.Error {
+		account.backend = Mastodon.Account.BACKEND;
+		return;
 		var req = new Request.GET ("/api/v1/instance")
 			.with_account (account);
 		yield req.await ();


### PR DESCRIPTION
rel: #1443 

I'm already working towards actually guessing the backend from nodeinfo but this will do for now. We never really finished the guess_backend implementation because we ended up doing mastoapi extensions automatically.