### PR TITLE
Make search rounded

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -1,3 +1,11 @@
+.search.rounded {
+	border-radius: 999px;
+	padding-left: 12px;
+	padding-right: 12px;
+	padding-top: 3px;
+	padding-bottom: 3px;
+}
+
 calendar, calendar>header {
 	border: none;
 }

--- a/src/Views/Search.vala
+++ b/src/Views/Search.vala
@@ -17,7 +17,7 @@ public class Tuba.Views.Search : Views.TabbedBase {
 		construct {
 			this.spacing = 9;
 			this.orientation = Gtk.Orientation.HORIZONTAL;
-			this.add_css_class ("search");
+			this.css_classes = {"search", "rounded"};
 
 			entry = new Gtk.Text () {
 				width_chars = 25,


### PR DESCRIPTION
Ever since I saw [Shortwave](https://flathub.org/apps/de.haeckerfelix.Shortwave) do it I thought it should be used more widely. I think it works great in pages like search, but it's fine if you don't want this (yet 🧐)

![Screenshot From 2025-06-23 09-36-57](https://github.com/user-attachments/assets/a5a5868f-351b-4981-a9be-eacb8f21d9db)
