### PR TITLE
fix(profile): featured streamlining

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -607,6 +607,7 @@ video > overlay > revealer > controls {
 }
 
 /* .ttl-view:not(.large-view) .content .card:first-child { */
+.ttl-view:not(.large-view) .fake-content .toggle-group-17 +.card,
 .ttl-view:not(.large-view) .fake-content .card:first-child {
 	border-top: 1px var(--border-color) solid;
 }
@@ -685,7 +686,7 @@ video > overlay > revealer > controls {
 	border-radius: 9999px;
 	border: solid var(--accent-bg-color) 2px;
 	background-color: var(--accent-bg-color);
-	margin-bottom: 6px;
+	margin-bottom: 10px;
 	opacity: 0;
 }
 
@@ -849,6 +850,8 @@ list.uniform-border-color row {
 .toggle-group-17 {
 	background: none;
 	padding: 0;
+	margin-top: 6px;
+	margin-bottom: 6px;
 }
 
 @keyframes annual-avi-bg {

--- a/src/API/FeaturedTag.vala
+++ b/src/API/FeaturedTag.vala
@@ -24,7 +24,7 @@ public class Tuba.API.FeaturedTag : Entity, Widgetizable {
 			new Gtk.Label (GLib.ngettext (
 				"%s Post",
 				"%s Posts",
-				(ulong) this.statuses_count.to_int ()
+				(ulong) int64.parse (this.statuses_count)
 			).printf (this.statuses_count)) {
 				ellipsize = END,
 				// translators: tooltip on featured hashtags on profiles on a number that

--- a/src/API/Instance/Mastodon/Configuration/Statuses.vala
+++ b/src/API/Instance/Mastodon/Configuration/Statuses.vala
@@ -1,6 +1,6 @@
 public class Tuba.API.Mastodon.Configuration.Statuses : Entity {
 	public int64 max_characters { get; set; }
 	public int64 max_media_attachments { get; set; }
-	public int64 characters_reserved_per_url { get; set; default = 0; }
+	public int characters_reserved_per_url { get; set; default = 0; }
 	public string[]? supported_mime_types { get; set; default = null; }
 }

--- a/src/API/Instance/Mastodon/Configuration/Statuses.vala
+++ b/src/API/Instance/Mastodon/Configuration/Statuses.vala
@@ -1,6 +1,6 @@
 public class Tuba.API.Mastodon.Configuration.Statuses : Entity {
 	public int64 max_characters { get; set; }
 	public int64 max_media_attachments { get; set; }
-	public int characters_reserved_per_url { get; set; default = 0; }
+	public int64 characters_reserved_per_url { get; set; default = 0; }
 	public string[]? supported_mime_types { get; set; default = null; }
 }

--- a/src/API/Tag.vala
+++ b/src/API/Tag.vala
@@ -4,6 +4,7 @@ public class Tuba.API.Tag : Entity, Widgetizable {
 	public string url { get; set; }
 	public Gee.ArrayList<API.TagHistory>? history { get; set; default = null; }
 	public bool following { get; set; default = false; }
+	public bool featuring { get; set; default = false; }
 
 	public override Type deserialize_array_type (string prop) {
 		switch (prop) {

--- a/src/Views/Base.vala
+++ b/src/Views/Base.vala
@@ -98,14 +98,14 @@ public class Tuba.Views.Base : Adw.BreakpointBin {
 			this.update_property (Gtk.AccessibleProperty.LABEL, null, -1);
 
 			if (value == null) {
-				states.visible_child_name = "content";
+				if (states.visible_child_name != "content") states.visible_child_name = "content";
 			} else {
-				states.visible_child_name = "status";
+				if (states.visible_child_name != "status") states.visible_child_name = "status";
 				if (value.loading) {
-					status_stack.visible_child_name = "spinner";
+					if (status_stack.visible_child_name != "spinner") status_stack.visible_child_name = "spinner";
 					this.update_state (Gtk.AccessibleState.BUSY, true, -1);
 				} else {
-					status_stack.visible_child_name = "message";
+					if (status_stack.visible_child_name != "message") status_stack.visible_child_name = "message";
 
 					if (value.title == null) {
 						status_title_label.label = empty_state_title;

--- a/src/Views/Timeline.vala
+++ b/src/Views/Timeline.vala
@@ -192,7 +192,7 @@ public class Tuba.Views.Timeline : AccountHolder, Streamable, Views.ContentBase 
 			return req;
 	}
 
-	bool has_finished_request = false;
+	protected bool has_finished_request { get; private set; default = false; }
 	public virtual void on_request_finish () {
 		has_finished_request = true;
 		base.on_bottom_reached ();

--- a/src/Widgets/ProfileCover.vala
+++ b/src/Widgets/ProfileCover.vala
@@ -677,7 +677,7 @@ protected class Tuba.Widgets.Cover : Gtk.Box {
 		var sizegroup = new Gtk.SizeGroup (Gtk.SizeGroupMode.HORIZONTAL);
 
 		posts_btn = new ProfileStatsButton ();
-		posts_btn.clicked.connect (() => timeline_change ("statuses"));
+		posts_btn.clicked.connect (() => timeline_change ("statuses-like"));
 		sizegroup.add_widget (posts_btn);
 		box.append (posts_btn);
 


### PR DESCRIPTION
continuation of #1465 

1. `endorsements` is a timeline, so there's no need to do all that breaking
2. it now properly handles source changing
3. it now properly handles filter changing
4. other minor css fixes, empty displaying and base status changing