### PR TITLE
fix(FadeBin): measuring when line height is > 1

### DIFF
--- a/src/Widgets/FadeBin.vala
+++ b/src/Widgets/FadeBin.vala
@@ -121,7 +121,7 @@ public class Tuba.Widgets.FadeBin : Gtk.Widget {
 		}
 
 		int child_for_size;
-		if (this.reveal || orientation == Gtk.Orientation.VERTICAL || for_size < MAX_HEIGHT_OVER || for_size == -1) {
+		if ((this.reveal || for_size < MAX_HEIGHT_OVER || for_size == -1) && orientation == Gtk.Orientation.VERTICAL) {
 			child_for_size = for_size;
 		} else if (this.animation.value == 0.0) {
 			child_for_size = -1;


### PR DESCRIPTION
FadeBin would measure incorrectly when line height was enabled.

This forces the HORIZONTAL measuring to be for_size -1, no idea if that breaks anything else :shrug: 