### PR TITLE
fix(FadeBin): lerp on MAX_HEIGHT not OVER

### DIFF
--- a/src/Widgets/FadeBin.vala
+++ b/src/Widgets/FadeBin.vala
@@ -121,7 +121,7 @@ public class Tuba.Widgets.FadeBin : Gtk.Widget {
 		}
 
 		int child_for_size;
-		if ((this.reveal || for_size < MAX_HEIGHT_OVER || for_size == -1) && orientation == Gtk.Orientation.VERTICAL) {
+		if (this.reveal || for_size < MAX_HEIGHT_OVER || for_size == -1 || orientation == Gtk.Orientation.VERTICAL) {
 			child_for_size = for_size;
 		} else if (this.animation.value == 0.0) {
 			child_for_size = -1;
@@ -145,7 +145,7 @@ public class Tuba.Widgets.FadeBin : Gtk.Widget {
 		if (orientation == Gtk.Orientation.VERTICAL && !this.reveal) {
 			minimum_baseline = natural_baseline = -1;
 
-			if (minimum > MAX_HEIGHT_OVER) {
+			if (minimum > MAX_HEIGHT) {
 				minimum = (int) Math.ceil (lerp (
 					MAX_HEIGHT,
 					minimum,
@@ -153,7 +153,7 @@ public class Tuba.Widgets.FadeBin : Gtk.Widget {
 				));
 			}
 
-			if (natural > MAX_HEIGHT_OVER) {
+			if (natural > MAX_HEIGHT) {
 				natural = (int) Math.ceil (lerp (
 					MAX_HEIGHT,
 					natural,


### PR DESCRIPTION
fix: #1484 

During the #1426, I made it so it only fades when the height is MAX_HEIGHT + 100, to avoid cases were the height is like MAX_HEIGHT + 1 and the user revealing it ends up only revealing a single pixel of height. Then I made it so the lerp only runs when the sizes are > MAX_HEIGHT + 100 which ended up causing what #1484 tried to fix.