### PR TITLE
fix(Thread): leak with widget

### DIFF
--- a/src/Views/Thread.vala
+++ b/src/Views/Thread.vala
@@ -23,7 +23,7 @@ public class Tuba.Views.Thread : Views.ContentBase, AccountHolder {
 
 	protected InstanceAccount? account { get; set; }
 	public API.Status root_status { get; set; }
-	public Widgets.Status? root_status_widget { get; set; default=null; }
+	private unowned Widgets.Status? root_status_widget { get; set; default=null; }
 
 	public Thread (API.Status status) {
 		Object (
@@ -35,6 +35,7 @@ public class Tuba.Views.Thread : Views.ContentBase, AccountHolder {
 		construct_account_holder ();
 		update_root_status (status.id);
 	}
+
 	~Thread () {
 		debug ("Destroying Thread");
 		destruct_account_holder ();


### PR DESCRIPTION
f1x: #1442 

The reason #1442 was possible to happen in the first place was because the root status widget wasn't being destroyed. As always, ref counting bit us, had to make the root_status_widget unowned (let's hope no segfaults will happen).

But this is only 1/3 of #1442 