### PR TITLE
fix: child widget loop removals not removing everything

### DIFF
--- a/src/Views/TabbedBase.vala
+++ b/src/Views/TabbedBase.vala
@@ -162,10 +162,12 @@ public class Tuba.Views.TabbedBase : Views.Base {
 
 	public delegate void TabCB (Views.ContentBase tab);
 	public void foreach_tab (TabCB cb) {
-		for (var w = stack.get_first_child (); w != null; w = w.get_next_sibling ()) {
+		var w = stack.get_first_child ();
+		while (w != null) {
 			var tab = w as Views.ContentBase;
 			if (tab != null)
 				cb (tab);
+			w = w.get_next_sibling ();
 		}
 	}
 

--- a/src/Widgets/MarkupView.vala
+++ b/src/Widgets/MarkupView.vala
@@ -75,14 +75,16 @@ public class Tuba.Widgets.MarkupView : Gtk.Box {
 	void update_aria () {
 		string total_aria = "";
 
-		var w = this.get_first_child ();
-		while (w != null) {
-			var label = w as RichLabel;
-			if (label != null) {
-				total_aria += @"\n$(label.accessible_text)";
-			}
-			w = w.get_next_sibling ();
-		};
+		{
+			var w = this.get_first_child ();
+			while (w != null) {
+				var label = w as RichLabel;
+				if (label != null) {
+					total_aria += @"\n$(label.accessible_text)";
+				}
+				w = w.get_next_sibling ();
+			};
+		}
 
 		this.update_property (Gtk.AccessibleProperty.LABEL, total_aria, -1);
 		this.update_property (Gtk.AccessibleProperty.DESCRIPTION, null, -1);
@@ -93,9 +95,13 @@ public class Tuba.Widgets.MarkupView : Gtk.Box {
 		extracted_tags = null;
 		has_link = false;
 
-		for (var w = get_first_child (); w != null; w = w.get_next_sibling ()) {
-			w.unparent ();
-			w.destroy ();
+		{
+			var w = this.get_first_child ();
+			while (w != null) {
+				var w2 = w.get_next_sibling ();
+				this.remove (w);
+				w = w2;
+			};
 		}
 
 		string to_parse = Utils.Htmlx.replace_with_pango_markup (content);

--- a/src/Widgets/ProfileCover.vala
+++ b/src/Widgets/ProfileCover.vala
@@ -459,11 +459,14 @@ protected class Tuba.Widgets.Cover : Gtk.Box {
 		cover_bot_badge.visible = profile.bot;
 		update_cover_badge ();
 
-		var w = roles.get_first_child ();
-		while (w != null) {
-			roles.remove (w);
-			w = w.get_next_sibling ();
-		};
+		{
+			var w = roles.get_first_child ();
+			while (w != null) {
+				var w2 = w.get_next_sibling ();
+				roles.remove (w);
+				w = w2;
+			};
+		}
 
 		if (profile.roles != null && profile.roles.size > 0) {
 			roles.visible = true;


### PR DESCRIPTION
f2x: #1442 

2/3 of #1442 

When trying to remove all child widgets from a parent widget, we'd do first_child => remove => next_sibling

Obviously, the race condition is that there's no sibling if removed. It now fixes that by doing first_child => temp_sibling => remove_first_child => loop_with_temp_sibling. Also took the liberty to wrap the other loops in blocks if needed since they are self-contained.