### PR TITLE
fix(markupview): set selectable on append

### DIFF
--- a/src/Widgets/MarkupView.vala
+++ b/src/Widgets/MarkupView.vala
@@ -298,6 +298,7 @@ public class Tuba.Widgets.MarkupView : Gtk.Box {
 						visible = true,
 						css_classes = { "ttl-code", "monospace" },
 						use_markup = true,
+						selectable = v.selectable,
 						//  focusable_label = true
 						// markup = MarkupPolicy.DISALLOW
 					};
@@ -325,6 +326,7 @@ public class Tuba.Widgets.MarkupView : Gtk.Box {
 					visible = true,
 					css_classes = { "ttl-code", "italic" },
 					use_markup = true,
+					selectable = v.selectable
 					//  focusable_label = true
 					// markup = MarkupPolicy.DISALLOW
 				};


### PR DESCRIPTION
fix: #1442 

3/3 of #1442 

When making markupview selectable, it only happened in time (loop through children, make them selectable). But if the content gets updated, the new children wouldn't be selectable. It now sets them during append.