### PR TITLE
feat(Visualizer): animate changes

### DIFF
--- a/src/Widgets/AudioPlayer/Player.vala
+++ b/src/Widgets/AudioPlayer/Player.vala
@@ -69,14 +69,16 @@ public class Tuba.Widgets.Audio.Player : Adw.Bin {
 		this.playing = false;
 	}
 
+	bool should_hide_controls = true;
 	protected void on_leave () {
-		on_reveal_media_buttons ();
+		should_hide_controls = false;
 	}
 
 	double on_motion_last_x = 0.0;
 	double on_motion_last_y = 0.0;
 	protected void on_motion (double x, double y) {
 		if (on_motion_last_x == x && on_motion_last_y == y) return;
+		should_hide_controls = true;
 
 		on_motion_last_x = x;
 		on_motion_last_y = y;
@@ -93,7 +95,7 @@ public class Tuba.Widgets.Audio.Player : Adw.Bin {
 
 	private bool on_hide_media_buttons () {
 		revealer_timeout = 0;
-		controls_revealer.set_reveal_child (false);
+		if (should_hide_controls) controls_revealer.set_reveal_child (false);
 
 		return GLib.Source.REMOVE;
 	}

--- a/src/Widgets/AudioPlayer/Player.vala
+++ b/src/Widgets/AudioPlayer/Player.vala
@@ -69,16 +69,14 @@ public class Tuba.Widgets.Audio.Player : Adw.Bin {
 		this.playing = false;
 	}
 
-	bool should_hide_controls = true;
 	protected void on_leave () {
-		should_hide_controls = false;
+		on_reveal_media_buttons ();
 	}
 
 	double on_motion_last_x = 0.0;
 	double on_motion_last_y = 0.0;
 	protected void on_motion (double x, double y) {
 		if (on_motion_last_x == x && on_motion_last_y == y) return;
-		should_hide_controls = true;
 
 		on_motion_last_x = x;
 		on_motion_last_y = y;
@@ -95,7 +93,7 @@ public class Tuba.Widgets.Audio.Player : Adw.Bin {
 
 	private bool on_hide_media_buttons () {
 		revealer_timeout = 0;
-		if (should_hide_controls) controls_revealer.set_reveal_child (false);
+		controls_revealer.set_reveal_child (false);
 
 		return GLib.Source.REMOVE;
 	}

--- a/src/Widgets/AudioPlayer/Stream.vala
+++ b/src/Widgets/AudioPlayer/Stream.vala
@@ -1,7 +1,7 @@
 // Smoothing function adapted from https://gitlab.gnome.org/GNOME/gnome-control-center/-/blob/ea8bafc5d1ebb945a0806b03dea0c3abf29c58d9/panels/sound/cc-level-bar.c
 
 public class Tuba.Widgets.Audio.Stream : GLib.Object {
-	const double SMOOTHING = 0.2;
+	const double SMOOTHING = 0.4;
 	Gst.Bin pipeline;
 	Gst.Bus bus;
 	Gst.Element uridecodebin;
@@ -75,10 +75,10 @@ public class Tuba.Widgets.Audio.Stream : GLib.Object {
 
 				double level_sum = 0;
 				foreach (var val in value_array) {
-				  level_sum += val.get_double ();
+				  level_sum += Math.pow (10, val.get_double () / 20);
 				}
 
-				var levels = Math.pow (10, (level_sum / value_array.n_values) / 20);
+				var levels = level_sum / value_array.n_values;
 				level = (levels * SMOOTHING) + (level * (1.0 - SMOOTHING));
 			}
 			break;
@@ -117,7 +117,7 @@ public class Tuba.Widgets.Audio.Stream : GLib.Object {
 
 	uint timeout_id = -1;
 	construct {
-		string pipestr = "uridecodebin name=uridecodebin ! audioconvert ! audio/x-raw,channels=2 ! volume name=volume ! level name=level interval=50000000 ! autoaudiosink name=sink";
+		string pipestr = "uridecodebin name=uridecodebin ! audioconvert ! audio/x-raw,channels=2 ! volume name=volume ! level name=level interval=100000000 ! autoaudiosink name=sink";
 		try {
 			pipeline = (Gst.Bin) Gst.parse_launch (pipestr);
 			uridecodebin = pipeline.get_by_name ("uridecodebin");

--- a/src/Widgets/AudioPlayer/Visualizer.vala
+++ b/src/Widgets/AudioPlayer/Visualizer.vala
@@ -2,20 +2,30 @@ public class Tuba.Widgets.Audio.Visualizer : Gtk.Widget {
 	const float SQR = 256;
 	const int MAX_CIRCLE_HEIGHT = 800;
 	const float ALPHA = 0.5f;
+	const uint ANIMATION_DURATION = 100;
 
 	Cairo.Context context;
 	Gdk.RGBA color;
 	Gdk.Texture cover_texture;
+	Adw.TimedAnimation visualizer_animation;
 	bool animations_enabled = true;
 
 	double _level = 0.0;
 	public double level {
 		get { return _level; }
 		set {
+			if (animations_enabled) {
+				visualizer_animation.value_from = _level;
+				visualizer_animation.value_to = value;
+				visualizer_animation.play ();
+			}
+
 			_level = value;
-			if (animations_enabled)
-				this.queue_draw ();
 		}
+	}
+
+	private void animation_target_cb (double value) {
+		this.queue_draw ();
 	}
 
 	construct {
@@ -24,6 +34,9 @@ public class Tuba.Widgets.Audio.Visualizer : Gtk.Widget {
 
 		var gtk_settings = Gtk.Settings.get_default ();
 		if (gtk_settings != null) animations_enabled = gtk_settings.gtk_enable_animations;
+
+		var target = new Adw.CallbackAnimationTarget (animation_target_cb);
+		visualizer_animation = new Adw.TimedAnimation (this, 0.0, 1.0, ANIMATION_DURATION, target);
 	}
 
 	public Visualizer (Gdk.Texture? texture = null, string? blurhash = null) {
@@ -78,7 +91,7 @@ public class Tuba.Widgets.Audio.Visualizer : Gtk.Widget {
 		snapshot.translate (point);
 
 		if (animations_enabled) {
-			float res = (float) level * (int.min (MAX_CIRCLE_HEIGHT, win_h) - SQR) + SQR;
+			float res = (float) visualizer_animation.value * (int.min (MAX_CIRCLE_HEIGHT, win_h) - SQR) + SQR;
 
         	var rect = Graphene.Rect ().init (- res / 2, - res / 2, res, res);
         	var rounded_rect = Gsk.RoundedRect ().init_from_rect (rect, 9999);


### PR DESCRIPTION
Something that has been bugging me with the visualizer is that the changes are... 'choppy'. To overcome this, I decreased the interval to **50ms**! That was too fast but it *looked* smooth. I now went back to actually do it right.

- Increased to 100ms (which is also the default)
- Linearized all values individually rather than the sum for a more accurate representation
- Started drawing the visualizer using a TimedAnimation with from the previous level to the new value, giving us smooth animations
- Made smoothing 0.4 (doubled), this has a reverse meaning, it made the values less smooth, which is what we wanted since the animation now takes care of the 'big' fluctuations
