### PR TITLE
fix(streaming): actually use streaming_api

### DIFF
--- a/src/API/Instance.vala
+++ b/src/API/Instance.vala
@@ -4,10 +4,15 @@ public class Tuba.API.Instance : Entity {
 		public string text { get; set; default=""; }
 	}
 
+	public class Urls : Entity {
+		public string streaming_api { get; set; default=""; }
+	}
+
 	public string uri { get; set; default=""; }
 	public string title { get; set; default=""; }
 	public string thumbnail { get; set; default=null; }
 	public string? version { get; set; default=null; }
+	public Urls? urls { get; set; default=null; }
 
 	public Gee.ArrayList<string>? languages { get; set; }
 	public API.Mastodon.Configurations? configuration { get; set; default = null; }

--- a/src/Services/Accounts/AccountStore.vala
+++ b/src/Services/Accounts/AccountStore.vala
@@ -136,6 +136,10 @@ public abstract class Tuba.AccountStore : GLib.Object {
 				account.tuba_iceshrimp_api_key = obj.get_string_member ("iceshrimp-api-key");
 		}
 
+		if (obj.has_member ("streaming")) {
+			account.tuba_streaming_url = obj.get_string_member ("streaming");
+		}
+
 		if (account.uuid == null || !GLib.Uuid.string_is_valid (account.uuid)) account.uuid = GLib.Uuid.string_random ();
 		return account;
 	}

--- a/src/Services/Accounts/SecretAccountStore.vala
+++ b/src/Services/Accounts/SecretAccountStore.vala
@@ -209,6 +209,11 @@ public class Tuba.SecretAccountStore : AccountStore {
 			builder.add_string_value (account.tuba_iceshrimp_api_key);
 		}
 
+		if (account.tuba_streaming_url != "" && account.tuba_streaming_url != account.instance) {
+			builder.set_member_name ("streaming");
+			builder.add_string_value (account.tuba_streaming_url);
+		}
+
 		// If display name has emojis it's
 		// better to save and load them
 		// so users don't see their shortcode

--- a/src/Services/Network/Streams.vala
+++ b/src/Services/Network/Streams.vala
@@ -163,6 +163,30 @@ public class Tuba.Streams : Object {
 			event.payload = obj.get_member ("payload");
 		}
 
+		public void upgrade (string new_url) {
+			try {
+				var uri = GLib.Uri.parse (url, GLib.UriFlags.NONE);
+				var new_uri = GLib.Uri.parse (new_url, GLib.UriFlags.NONE);
+				url = GLib.Uri.build (
+					uri.get_flags (),
+					new_uri.get_scheme (),
+					new_uri.get_userinfo (),
+					new_uri.get_host (),
+					new_uri.get_port (),
+					uri.get_path (),
+					uri.get_query (),
+					uri.get_fragment ()
+				).to_string ();
+				if (socket != null) socket.close (0, null);
+			} catch (Error e) {
+				warning (@"Error while upgrading $url to $new_url: $(e.code) $(e.message)");
+			}
+		}
 	}
 
+	public void upgrade (string old_url, string new_url) {
+		connections.foreach ((key, val) => {
+			if (key.has_prefix (@"$old_url/")) val.upgrade (new_url);
+		});
+	}
 }

--- a/src/Views/Bubble.vala
+++ b/src/Views/Bubble.vala
@@ -10,7 +10,7 @@ public class Tuba.Views.Bubble : Views.Timeline {
 
 	public override string? get_stream_url () {
 		return account != null && account.tuba_api_versions.chuckya > 0
-			? @"$(account.instance)/api/v1/streaming?stream=public:bubble&access_token=$(account.access_token)"
+			? @"$(account.tuba_streaming_url)/api/v1/streaming?stream=public:bubble&access_token=$(account.access_token)"
 			: null;
 	}
 }

--- a/src/Views/Conversations.vala
+++ b/src/Views/Conversations.vala
@@ -19,7 +19,7 @@ public class Tuba.Views.Conversations : Views.Timeline {
 
 	public override string? get_stream_url () {
 		return account != null
-			? @"$(account.instance)/api/v1/streaming?stream=direct&access_token=$(account.access_token)"
+			? @"$(account.tuba_streaming_url)/api/v1/streaming?stream=direct&access_token=$(account.access_token)"
 			: null;
 	}
 

--- a/src/Views/Federated.vala
+++ b/src/Views/Federated.vala
@@ -8,7 +8,7 @@ public class Tuba.Views.Federated : Views.Timeline {
 
 	public override string? get_stream_url () {
 		return account != null
-			? @"$(account.instance)/api/v1/streaming?stream=public&access_token=$(account.access_token)"
+			? @"$(account.tuba_streaming_url)/api/v1/streaming?stream=public&access_token=$(account.access_token)"
 			: null;
 	}
 }

--- a/src/Views/Hashtag.vala
+++ b/src/Views/Hashtag.vala
@@ -135,7 +135,7 @@ public class Tuba.Views.Hashtag : Views.Timeline {
 		var split_url = url.split ("/");
 		var tag = split_url[split_url.length - 1];
 		return account != null
-			? @"$(account.instance)/api/v1/streaming?stream=hashtag&tag=$tag&access_token=$(account.access_token)"
+			? @"$(account.tuba_streaming_url)/api/v1/streaming?stream=hashtag&tag=$tag&access_token=$(account.access_token)"
 			: null;
 	}
 

--- a/src/Views/Home.vala
+++ b/src/Views/Home.vala
@@ -129,7 +129,7 @@ public class Tuba.Views.Home : Views.Timeline {
 
 	public override string? get_stream_url () {
 		return account != null
-			? @"$(account.instance)/api/v1/streaming?stream=user&access_token=$(account.access_token)"
+			? @"$(account.tuba_streaming_url)/api/v1/streaming?stream=user&access_token=$(account.access_token)"
 			: null;
 	}
 
@@ -144,6 +144,6 @@ public class Tuba.Views.Home : Views.Timeline {
 	}
 
 	private void forward_to_notifications (Streamable.Event ev) {
-		forward (@"$(account.instance)/api/v1/streaming?stream=user:notification&access_token=$(account.access_token)", ev);
+		forward (@"$(account.tuba_streaming_url)/api/v1/streaming?stream=user:notification&access_token=$(account.access_token)", ev);
 	}
 }

--- a/src/Views/List.vala
+++ b/src/Views/List.vala
@@ -42,7 +42,7 @@ public class Tuba.Views.List : Views.Timeline {
 		if (list == null)
 			return null;
 		return account != null
-			? @"$(account.instance)/api/v1/streaming?stream=list&list=$(list.id)&access_token=$(account.access_token)"
+			? @"$(account.tuba_streaming_url)/api/v1/streaming?stream=list&list=$(list.id)&access_token=$(account.access_token)"
 			: null;
 	}
 }

--- a/src/Views/Local.vala
+++ b/src/Views/Local.vala
@@ -12,7 +12,7 @@ public class Tuba.Views.Local : Views.Federated {
 
 	public override string? get_stream_url () {
 		return account != null
-			? @"$(account.instance)/api/v1/streaming?stream=public:local&access_token=$(account.access_token)"
+			? @"$(account.tuba_streaming_url)/api/v1/streaming?stream=public:local&access_token=$(account.access_token)"
 			: null;
 	}
 }

--- a/src/Views/Notifications.vala
+++ b/src/Views/Notifications.vala
@@ -264,7 +264,7 @@ public class Tuba.Views.Notifications : Views.Timeline, AccountHolder, Streamabl
 
 	public override string? get_stream_url () {
 		return account != null
-			? @"$(account.instance)/api/v1/streaming?stream=user:notification&access_token=$(account.access_token)"
+			? @"$(account.tuba_streaming_url)/api/v1/streaming?stream=user:notification&access_token=$(account.access_token)"
 			: null;
 	}
 


### PR DESCRIPTION
An issue with mastodon.social which I blindly attributed to the websocket mechanism, was that the websockets would constantly discconect, be slow and sometimes not reconnect.

That was probably because we never upgraded to the streaming_api url. Instances advertise a url used for the websockets. 99% of the time it's the same as the instance so it was never an issue I came across but mastodon.social uses a different subdomain. Tuba will now see that, save it to the keyring and automatically update the websockets to use it in the same session without restart.