### PR TITLE
feat(timelines): refresh only if mapped

### DIFF
--- a/src/Views/Drive.vala
+++ b/src/Views/Drive.vala
@@ -1047,7 +1047,7 @@ public class Tuba.Views.Drive : Views.Base {
 	}
 
 	private void on_refresh () {
-		if (this.working) return;
+		if (this.working || !this.get_mapped ()) return;
 		load_folder (this.current_folder.id);
 		this.working = false;
 	}

--- a/src/Views/Profile.vala
+++ b/src/Views/Profile.vala
@@ -137,7 +137,7 @@ public class Tuba.Views.Profile : Views.Accounts {
 	}
 
 	private void on_featured_refresh_request () {
-		if (this.filter == FEATURED) on_refresh ();
+		if (this.filter == FEATURED && this.get_mapped ()) on_refresh ();
 	}
 
 	public bool append_pinned () {

--- a/src/Views/ScheduledStatuses.vala
+++ b/src/Views/ScheduledStatuses.vala
@@ -9,7 +9,7 @@ public class Tuba.Views.ScheduledStatuses : Views.Timeline {
 		accepts = typeof (API.ScheduledStatus);
 		batch_size_min = 20;
 
-		app.refresh_scheduled_statuses.connect (on_refresh);
+		app.refresh_scheduled_statuses.connect (refresh_if_mapped);
 	}
 
 	public override Gtk.Widget on_create_model_widget (Object obj) {
@@ -18,7 +18,7 @@ public class Tuba.Views.ScheduledStatuses : Views.Timeline {
 
 		if (widget_scheduled != null) {
 			widget_scheduled.deleted.connect (on_deleted_scheduled);
-			widget_scheduled.refresh.connect (on_refresh);
+			widget_scheduled.refresh.connect (refresh_if_mapped);
 		}
 
 		return widget;

--- a/src/Views/Thread.vala
+++ b/src/Views/Thread.vala
@@ -34,11 +34,23 @@ public class Tuba.Views.Thread : Views.ContentBase, AccountHolder {
 		);
 		construct_account_holder ();
 		update_root_status (status.id);
+
+		app.refresh.connect (on_refresh);
 	}
 
 	~Thread () {
 		debug ("Destroying Thread");
 		destruct_account_holder ();
+	}
+
+	private void on_refresh () {
+		if (!this.get_mapped ()) return;
+
+		scrolled.vadjustment.value = 0;
+		status_button.sensitive = false;
+		clear ();
+		base_status = new StatusMessage () { loading = true };
+		GLib.Idle.add (request);
 	}
 
 	private void update_root_status (string status_id = root_status.id) {

--- a/src/Views/Timeline.vala
+++ b/src/Views/Timeline.vala
@@ -94,7 +94,7 @@ public class Tuba.Views.Timeline : AccountHolder, Streamable, Views.ContentBase 
 			reached_close_to_top.connect (finish_queue);
 		#endif
 
-		app.refresh.connect (on_manual_refresh);
+		app.refresh.connect (refresh_if_mapped);
 		status_button.clicked.connect (on_manual_refresh);
 
 		construct_account_holder ();
@@ -131,6 +131,11 @@ public class Tuba.Views.Timeline : AccountHolder, Streamable, Views.ContentBase 
 			entity_queue = {};
 			entity_queue_size = 0;
 		#endif
+	}
+
+	protected void refresh_if_mapped () {
+		if (!this.get_mapped ()) return;
+		on_manual_refresh ();
 	}
 
 	#if !USE_LISTVIEW


### PR DESCRIPTION
This has also been bugging me for a while.

To have a global way to just refresh, there's a void signal on `app` named `refresh`. Timelines and anything that wants to be refreshed when a user presses ctrl+R or activates the refresh action from the menu, could just connect to it and do their refresh processes then.

But there's a problem with that, let's say you do this:

- Are 'Home'
- Open a Profile
- From there open a hashtag
- Open another profile

Let's count how many timelines are connected to app.refresh: Home, first profile, hashtag timeline, second profile. 4 timelines. Now if you refresh, it will refresh all 4 of them, when it should only refresh the one that's visible.

This PR finally fixes it by checking if the timeline is mapped. So in the above example only the second profile is mapped (the difference between `mapped` and `visible` is that mapped means the widget and all its parents are visible, aka it's actually visible, while `visible` is on an individual visible, the other timelines *are* visible individually but their parents aren't).

---

The main reason I didn't fix it earlier is that I wanted to sit down and actually think it through, the other options on the table were detailed signals + uuids and getting the visible page. This solution seems to be the most appropriate one.