### PR TITLE
feat(status): ellipsize name box

### DIFF
--- a/data/ui/widgets/status.ui
+++ b/data/ui/widgets/status.ui
@@ -97,6 +97,7 @@
                                     <property name="visible">True</property>
                                     <property name="smaller-emoji-pixel-size">True</property>
                                     <property name="use-markup">1</property>
+                                	<property name="ellipsize">1</property>
                                     <style>
                                       <class name="font-bold" />
                                     </style>
@@ -110,9 +111,10 @@
                             </child>
                             <child>
                               <object class="GtkLabel" id="handle_label">
-                                <property name="can-target">0</property>
-                                <property name="label" translatable="no">Handle</property>
+                                <property name="can-target">1</property>
                                 <property name="single_line_mode">1</property>
+                                <property name="lines">2</property>
+                                <property name="ellipsize">end</property>
                                 <property name="xalign">0</property>
                                 <property name="hexpand">1</property>
                                 <property name="wrap">1</property>

--- a/src/Widgets/RichLabel.vala
+++ b/src/Widgets/RichLabel.vala
@@ -29,6 +29,11 @@ public class Tuba.Widgets.RichLabel : Adw.Bin {
 	//  	}
 	//  }
 
+	public bool ellipsize {
+		get { return widget.ellipsize; }
+		set { widget.ellipsize = value; }
+	}
+
 	public bool use_markup {
 		get { return widget.use_markup; }
 		set { widget.use_markup = value; }

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -1106,7 +1106,7 @@
 		status.formal.tuba_spoiler_revealed = !status.formal.has_spoiler || status.formal.tuba_spoiler_revealed;
 		update_spoiler_status_no_transition ();
 
-		handle_label.label = this.subtitle_text;
+		handle_label.label = handle_label.tooltip_text = this.subtitle_text;
 		date_label.label = this.date;
 
 		if (!expanded) {


### PR DESCRIPTION
I've been quite against ellipsizing the name and handle for a long time because... it can lead to impersonators. On the other hand, instances and names are getting longer and longer with many subdomains etc, and on narrow sizes it ends up taking 4-6 lines just to show the handle.

So here's the deal, ellipsize both, handle has a min lines of 2 before ellipsizing.

Case: this is a real instance https://helloeverybodymynameismarkiplierandwelcometofivenightsatfreddys.anindiehorrorgamethatyouguyssuggestedenmasseandisawthatyamimash.playeditandhesaidthatitwasreallyreallygoodsoimveryeagertoseewha.tisupandthatisaterrifyinganimatronicbear.fnaf.stream/

