### PR TITLE
fix(schedule): move validation to code from builder callback

### DIFF
--- a/data/ui/dialogs/schedule.ui
+++ b/data/ui/dialogs/schedule.ui
@@ -79,7 +79,6 @@
 																<property name="margin-end">6</property>
 																<property name="vexpand">1</property>
 																<property name="hexpand">1</property>
-																<signal name="day-selected" handler="validate" />
 															</object>
 														</child>
 													</object>
@@ -110,7 +109,6 @@
 																		<property name="numeric">true</property>
 																		<property name="wrap">true</property>
 																		<property name="adjustment">hour_adjustment</property>
-																		<signal name="value-changed" handler="validate" swapped="no" />
 																	</object>
 																</child>
 																<child>
@@ -131,7 +129,6 @@
 																		<property name="numeric">true</property>
 																		<property name="wrap">true</property>
 																		<property name="adjustment">minutes_adjustment</property>
-																		<signal name="value-changed" handler="validate" swapped="no" />
 																	</object>
 																</child>
 																<child>
@@ -152,7 +149,6 @@
 																		<property name="numeric">true</property>
 																		<property name="wrap">true</property>
 																		<property name="adjustment">seconds_adjustment</property>
-																		<signal name="value-changed" handler="validate" swapped="no" />
 																	</object>
 																</child>
 															</object>
@@ -162,7 +158,6 @@
 												<child>
 													<object class="AdwComboRow" id="timezone_combo_row">
 														<property name="title" translatable="yes">Timezone</property>
-														<signal name="notify::selected" handler="validate" />
 													</object>
 												</child>
 											</object>

--- a/src/Dialogs/Composer/Schedule.vala
+++ b/src/Dialogs/Composer/Schedule.vala
@@ -38,6 +38,11 @@ public class Tuba.Dialogs.Schedule : Adw.NavigationPage {
 
 		if (button_label != null) schedule_button.label = button_label;
 
+		calendar.day_selected.connect (validate);
+		hours_spin_button.value_changed.connect (validate);
+		minutes_spin_button.value_changed.connect (validate);
+		seconds_spin_button.value_changed.connect (validate);
+		timezone_combo_row.notify["selected"].connect (validate);
 		validate ();
 	}
 
@@ -45,11 +50,10 @@ public class Tuba.Dialogs.Schedule : Adw.NavigationPage {
 		schedule_picked (result_dt.format_iso8601 ());
 	}
 
-	[GtkCallback] void validate () {
+	void validate () {
 		bool valid = true;
 		GLib.DateTime now = new GLib.DateTime.now_utc ();
-
-		if (((Gtk.StringObject) timezone_combo_row.selected_item).string == "UTC") {
+		if (timezone_combo_row.selected != Gtk.INVALID_LIST_POSITION && ((Gtk.StringObject) timezone_combo_row.selected_item).string == "UTC") {
 			result_dt = new GLib.DateTime.utc (
 				calendar.year,
 				calendar.month + 1,


### PR DESCRIPTION
fix: #1451

A series of unfortunate race conditions led to this.

1. The selected row can be invalid, check
2. That is because `validate` is a callback in builder files and can get called during construction, before the comborow is done. Moved signal bindings to code.

This was only highlighted on Windows, probably due to everything being slower there, but it still applies.