### PR TITLE
fix: badges position and sizes

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -22,8 +22,10 @@ calendar>header>button, calendar>grid>label {
 	font-weight: bold;
 	font-size: 0.8em;
 	border-radius: 10px;
-	min-width: 0.7em;
-	padding: 2px 5px;
+	min-width: 0.8em;
+	min-height: 0.8em;
+	line-height: 0.8em;
+	padding: 0.4em 5px;
 	background: var(--accent-bg-color);
 	color: @text_view_bg;
 }
@@ -698,7 +700,7 @@ video > overlay > revealer > controls {
 	margin: 3px 0px;
 }
 
-.ttl-account-switcher row:selected avatar {
+.ttl-account-switcher row.active avatar {
 	border: 2px solid var(--accent-bg-color);
 }
 
@@ -707,11 +709,11 @@ video > overlay > revealer > controls {
 	border-radius: 9999px;
 	border: solid var(--accent-bg-color) 2px;
 	background-color: var(--accent-bg-color);
-	margin-bottom: 10px;
+	margin-bottom: 3px;
 	opacity: 0;
 }
 
-.ttl-account-switcher row:selected .blue-checkmark {
+.ttl-account-switcher row.active .blue-checkmark {
 	opacity: 1;
 }
 

--- a/data/ui/views/sidebar/account.ui
+++ b/data/ui/views/sidebar/account.ui
@@ -9,9 +9,11 @@
 
 		<child type="prefix">
 			<object class="GtkOverlay">
+				<property name="valign">center</property>
 				<child>
 					<object class="TubaWidgetsAvatar" id="avatar">
 						<property name="size">42</property>
+						<property name="valign">center</property>
 						<property name="tooltip-text">View Profile</property>
 						<property name="retry-on-network-changes">1</property>
 						<signal name="clicked" handler="on_open" />

--- a/src/Views/Sidebar.vala
+++ b/src/Views/Sidebar.vala
@@ -144,13 +144,24 @@ public class Tuba.Views.Sidebar : Gtk.Widget, AccountHolder {
 		accounts_to_add += new Object ();
 
 		accounts_model.splice (0, 0, accounts_to_add);
-		update_selected_account ();
+		update_selected_account (false);
 	}
 
-	private void update_selected_account () {
+	private void update_selected_account (bool clear = true) {
+		if (clear) {
+			for (int i = 0; i < accounts_model.n_items; i++) {
+				var row = saved_accounts.get_row_at_index ((int) i);
+				if (row == null) break;
+				if (row.has_css_class ("active")) row.remove_css_class ("active");
+			}
+		}
+
 		uint index;
-		if (accounts_model.find (account, out index))
-			saved_accounts.select_row (saved_accounts.get_row_at_index ((int) index));
+		if (accounts_model.find (account, out index)) {
+			var row = saved_accounts.get_row_at_index ((int) index);
+			saved_accounts.select_row (row);
+			row.add_css_class ("active");
+		}
 	}
 
 	public void set_sidebar_selected_item (int index) {


### PR DESCRIPTION
1. Account switcher badges were not in the correct position based on the handle lines, the avatars are now vertically centered so the badges stay in place
2. tab badges were not centered to the background since the font change
3. Account switcher checkmark depended on the selected pseudo but that changed on tab so it now uses a proper class