### PR TITLE
fix(status): screen reader getting stuck

### DIFF
--- a/data/ui/widgets/status.ui
+++ b/data/ui/widgets/status.ui
@@ -3,9 +3,6 @@
   <requires lib="gtk" version="4.0" />
   <!-- <template class="TubaWidgetsStatus" parent="AdwBin"> -->
   <template class="TubaWidgetsStatus" parent="GtkListBoxRow">
-    <accessibility>
-      <relation name="described-by">content</relation>
-    </accessibility>
     <property name="child">
       <object class="GtkStack" id="filter_stack">
         <property name="vhomogeneous">0</property>


### PR DESCRIPTION
we had an issue with orca getting stuck on the timeline. When it was time to announce a status, it would rapidly use tons of memory until killed. This is now fixed. It was caused by a relation that wasn't valid.