### PR TITLE
feat: 0.10.0

### DIFF
--- a/data/dev.geopjr.Tuba.gschema.xml
+++ b/data/dev.geopjr.Tuba.gschema.xml
@@ -237,7 +237,7 @@
 			<description>Used for keeping track if 2 weeks have passed since the last update</description>
 		</key>
 		<key name="contributors" type="as">
-			<default>['1021928818','2964685538','2486375860','3456423266','1352322503','445941323','3177176442','2813905310','2386917030','987913018','1837154139','4173902237','4223975552','3163563143','3320460562','4233664772','136476033','4041964504','3998595277','580879396']</default>
+			<default>['2964685538','2486375860','3456423266','1352322503','445941323','3177176442','2813905310','1837154139','719735140','2386917030','3163563143','987913018','3320460562','4170269605','3355903820','716517886','4041964504','580879396','4086778421']</default>
 			<!-- translators: this string is only shown in dconf, not in the app, you may leave it untranslated -->
 			<summary>Tuba contributors</summary>
 			<!-- translators: this string is only shown in dconf, not in the app, you may leave it untranslated -->

--- a/data/dev.geopjr.Tuba.metainfo.xml.in
+++ b/data/dev.geopjr.Tuba.metainfo.xml.in
@@ -33,15 +33,31 @@
   <screenshots>
     <screenshot type="default">
       <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/main/data/screenshots/screenshot-1.png</image>
+      <caption>Home Timeline</caption>
     </screenshot>
     <screenshot>
       <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/main/data/screenshots/screenshot-2.png</image>
+      <caption>Composer</caption>
     </screenshot>
     <screenshot>
       <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/main/data/screenshots/screenshot-3.png</image>
+      <caption>Profile View</caption>
     </screenshot>
     <screenshot>
       <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/main/data/screenshots/screenshot-4.png</image>
+      <caption>Home Timeline</caption>
+    </screenshot>
+    <screenshot>
+      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/main/data/screenshots/screenshot-5.png</image>
+      <caption>Schedule Post Dialog</caption>
+    </screenshot>
+    <screenshot>
+      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/main/data/screenshots/screenshot-6.png</image>
+      <caption>Scheduled Posts</caption>
+    </screenshot>
+    <screenshot>
+      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/main/data/screenshots/screenshot-7.png</image>
+      <caption>Search View</caption>
     </screenshot>
   </screenshots>
   <branding>
@@ -63,6 +79,74 @@
     <control>touch</control>
   </recommends>
   <releases>
+    <release version="0.10.0" date="2025-08-03">
+      <description translate="no">
+        <ul>
+            <li>Added new redesigned and featureful composer</li>
+            <li>Added in-app web browser</li>
+            <li>Added the ability to collapse long posts</li>
+            <li>Added grouped notifications</li>
+            <li>Added Clapper enhancers support for playing media from third-party services</li>
+            <li>Added desktop notification withdrawal when viewing the in-app ones</li>
+            <li>Added support for displaying custom emojis on poll options</li>
+            <li>Added tab switching shortcuts</li>
+            <li>Added Quit menu entry</li>
+            <li>Added other apps in the about dialog</li>
+            <li>Added input hints about spellcheck and completion on text inputs</li>
+            <li>Added more reactive scheduled and draft posts views updates</li>
+            <li>Added more fluid layout on horizontal lists like reaction and hashtag bars</li>
+            <li>Added clearing new notifications on the notifications view when scrolling to the top</li>
+            <li>Added showing up to two lines of the handle in the account switcher</li>
+            <li>Added using the most private visibility between the user-default and the replying-to when replying</li>
+            <li>Added instantly saving the proxy settings when changed</li>
+            <li>Added instantly saving settings when closing the window when work-in-background is enabled</li>
+            <li>Added proper instance URI validation and normalization when adding new accounts</li>
+            <li>Added Ctrl+L shortcut for searching</li>
+            <li>Added better audio visualizer controls style</li>
+            <li>Added support for displaying Mastodon quotes</li>
+            <li>Added ability to forward reports to all involved parties' instances</li>
+            <li>Added post action button transitions</li>
+            <li>Added rounded searchbar style</li>
+            <li>Added featured tab on profiles for endorsements and featured hashtags</li>
+            <li>Added the ability to redraft posts</li>
+            <li>Added search history</li>
+            <li>Added favorite hashtags that show up on the sidebar</li>
+            <li>Added endorsing accounts and featuring hashtags</li>
+            <li>Added the ability to post local-only on supported instances</li>
+            <li>Added Iceshrimp Drive and Bubble timeline</li>
+            <li>Added more settings in dconf while removing some from the GUI</li>
+            <li>Added setting that reveals sensitive media by default</li>
+            <li>Added alt text extraction from image file metadata</li>
+            <li>Added enabled more features for Pleroma</li>
+            <li>Added audio visualizer optimizations</li>
+            <li>Added ellipsization on long names and handles</li>
+            <li>Added searching langauges using their English locale name</li>
+            <li>Fixed manually refreshing being triggered for all timelines and not just the visible one</li>
+            <li>Fixed live updates not working reliably when the instance uses a different domain for them</li>
+            <li>Fixed random crashes due to the use of weak references</li>
+            <li>Fixed scrolling to open post when opening a thread</li>
+            <li>Fixed inability to toggle the sidebar when collapsed using gestures</li>
+            <li>Fixed Chinese translation not working due to the default locale name used</li>
+            <li>Fixed some missing icons on some platforms</li>
+            <li>Fixed schedule post dialog being too close to the edges</li>
+            <li>Fixed avatar size bugs</li>
+            <li>Fixed profile errors and empty states not being displayed</li>
+            <li>Fixed list names being blank when containing reserved characters when manipulating them from profiles</li>
+            <li>Fixed hidden followers/following counts being displayed as -1</li>
+            <li>Fixed timelines not being able to infinite scroll when the min batch size was set to too small</li>
+            <li>Fixed open post in a thread getting memory leaked</li>
+            <li>Fixed some widgets not removing all their children when updating</li>
+            <li>Fixed open post in a thread not being selectable after getting updated</li>
+            <li>Fixed spoiler being visible for a millisecond when opening a post in a thread even if it doesn't have a spoiler</li>
+            <li>Fixed sidebar badges not being centered</li>
+            <li>Fixed account switcher badges having the wrong size and position</li>
+            <li>Fixed screen readers freezing on the timeline</li>
+            <li>Removed hacks around labels with custom emojis since the bugs were fixed upstream</li>
+            <li>Updated translations</li>
+            <li>Other minor bug fixes and improvements</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.9.2" date="2025-03-01">
       <description translate="no">
         <ul>

--- a/data/screenshots/screenshot-1.png
+++ b/data/screenshots/screenshot-1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f3fa6148aa80c0ef0d9a080e3628c26d14f81d8aab9edcaa7f5f1b5b738cf69f
-size 424922
+oid sha256:82c33db3f7ca2f4d2b558ac6389be72709408b9fa28f8eba4fc9e739b9b2e5b8
+size 434232

--- a/data/screenshots/screenshot-2.png
+++ b/data/screenshots/screenshot-2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2ba239404b4be917283f0a728fd443587af9f28440198abd35cca6bbaec764c4
-size 122109
+oid sha256:4fbdb719c77dea22c8e100416bdf0fe0a12074e054101ae0c9c13b9f505117e9
+size 90480

--- a/data/screenshots/screenshot-3.png
+++ b/data/screenshots/screenshot-3.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0021b1e1c3ef6d4ef1d672ac490c34759803588d30f6e7d211e2a6da85a983e4
-size 66304
+oid sha256:fe5a5a6adae37e6138ba45f66c186e2b2132ca2457303754ecca5d371da40549
+size 78510

--- a/data/screenshots/screenshot-4.png
+++ b/data/screenshots/screenshot-4.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5fdbbcccd0be55d674db119a9c98ff21d13f064e3fb302b7325d246f6f351939
-size 84110
+oid sha256:bc540c487fe3b0114e2ac972994e864ee477808cabc08fcc8b2be6b7070bba08
+size 89753

--- a/data/screenshots/screenshot-5.png
+++ b/data/screenshots/screenshot-5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb096a980e3ec9a00545e2eef736c0f4cec22751a8b55ffb0883d975b952009e
+size 201459

--- a/data/screenshots/screenshot-6.png
+++ b/data/screenshots/screenshot-6.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02455af150e8cb46662efb076048408df82ba693e4cb61694aab3cfcfa30ae0d
+size 48341

--- a/data/screenshots/screenshot-7.png
+++ b/data/screenshots/screenshot-7.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf11d9b422e27469101a85d0c2141557644cebe30ffcb7ea2ff9393128364c8a
+size 61724

--- a/data/style.css
+++ b/data/style.css
@@ -524,6 +524,10 @@ video > overlay > revealer > controls {
 	transform: scale(2);
 }
 
+.ttl-poll-row {
+	padding: 0;
+}
+
 .ttl-poll-row:first-child {
 	border-top-left-radius: 12px;
 	border-top-right-radius: 12px;

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'dev.geopjr.Tuba',
     ['c', 'vala'],
-    version: '0.9.2',
+    version: '0.10.0',
     meson_version: '>= 0.60.0',
     default_options: [
         'warning_level=2',

--- a/src/Dialogs/Composer/AttachmentsBin.vala
+++ b/src/Dialogs/Composer/AttachmentsBin.vala
@@ -109,7 +109,8 @@ public class Tuba.Dialogs.Composer.Components.AttachmentsBin : Gtk.Grid, Attacha
 				margin_bottom = 6,
 				margin_top = 6,
 				margin_start = 6,
-				margin_end = 6
+				margin_end = 6,
+				input_hints = WORD_COMPLETION | SPELLCHECK | EMOJI
 			};
 			alt_editor.remove_css_class ("view");
 			alt_editor.add_css_class ("reset");

--- a/src/Dialogs/DevConsole.vala
+++ b/src/Dialogs/DevConsole.vala
@@ -25,7 +25,8 @@ public class Tuba.Dialogs.Dev : Adw.PreferencesDialog {
 		new WindowSize (1600, 900),
 		new WindowSize (360, 654),
 		new WindowSize (720, 360),
-		new WindowSize (1000, 700)
+		new WindowSize (1000, 700),
+		new WindowSize (800, 566)
 	};
 
 	construct {

--- a/src/Views/Drive.vala
+++ b/src/Views/Drive.vala
@@ -1416,7 +1416,9 @@ public class Tuba.Views.Drive : Views.Base {
 			if (main_cancellable.is_cancelled ()) break;
 			try {
 				this.progress += step;
+				var progress_before = this.progress;
 				API.Iceshrimp.File is_file = yield upload_file_real (to_folder, file);
+				this.progress = progress_before;
 				if (is_file.id in reserved) {
 					// translators: toast popping up when a user uploads a file that already exists in drive
 					//				The variable is a string filename.

--- a/src/Views/Profile.vala
+++ b/src/Views/Profile.vala
@@ -215,10 +215,6 @@ public class Tuba.Views.Profile : Views.Accounts {
 			widget_filter_group.filter_change.connect (change_filter);
 		}
 
-		if (obj is ErrorMessageRow) {
-			widget.remove_css_class ("card");
-		}
-
 		return widget;
 	}
 


### PR DESCRIPTION
```
# Added

- New composer (#623, thanks [at]bertob)
- In-app web browser (#1323)
- Collapse long posts (#1354, thanks [at]bugaevc)
- Grouped notifications (#1193)
- Clapper is now the default video player (#1308)
- Clapper enhancers are now used to play media from third-party services in-app (#1308, thanks [at]Rafostar)
- Desktop notifications will now be withdrawn when viewing the in-app ones (#1322)
- Polls can now display custom emojis (#1342)
- Mastodon quotes support (#1440)
- Iceshrimp Drive (#1408, thanks [at]pancakesmeow)
- Iceshrimp Bubble Timeline (#1482)
- Ability to forward reports to the instances of all involved parties (#1438)
- Tab switching using <kbd>alt</kbd>+<kbd>1/2/3/N</kbd> (#1352)
- Quit App menu entry (#1358)
- Other apps by GeopJr in the about dialog (#1143, thanks [at]bragefuglseth)
- Input hints about spellcheck and completion on text inputs (#1363, thanks [at]agx)
- More reactive scheduled and draft posts views updates (#1371)
- More fluid convergent horizontal lists by using AdwWrapBox (#1367)
- Use `appstreamcli` over `appstream-glib` for metadata validation (#1379, thanks [at]City-busz)
- Clear new notifications when scrolling to top on the Notifications view (#1382)
- Removed UUID migration fallback (#1384)
- Account switcher handles can now take up to two lines (#1385)
- Enforce `MATCH_NAME` when searching for secrets (#1383)
- When replying use the most private visibility between the user-default and the replying-to (#1392)
- The proxy setting now gets instantly saved in dconf (#1399)
- Windows ARM builds (#1397)
- Proper URI validation and normalization when adding new accounts (#1410)
- <kbd>Ctrl</kbd>+<kbd>L</kbd> shortcut for searching (#1411)
- Language specs and styles are now embeded (#1417)
- Meson options are now actual features (#1423, thanks [at]mgorny)
- Match Audio Visualizer's controls to Clapper's (#1428)
- Transition post action hover style (#1445, thanks [at]TheEvilSkeleton)
- Round search bars (#1449, thanks [at]lo2dev)
- Featured tab on profile that shows endorsed accounts and featured tags (#1465)
- Delete & Redraft (#1313)
- Search history (#1470)
- Adding favorite hashtags to the sidebar (#1472)
- Endorse account (#1473)
- Feature hashtag (#1473)
- Local-only posting when supported (#1475)
- More settings in dconf, less in GUI (#1483)
- Reveal sensitive media by default setting (#1448, thanks [at]accrawford0)
- Hide interaction counters setting (#1487)
- Alt text extraction from image file metadata (#1489)
- Enabled more features for Pleroma (#1498)
- Smooth and optimize audio visualizer updates by animating states (#1505)
- GApplication to parse command line options (#1380, thanks [at]City-busz)
- D-Bus service file (#1381, thanks [at]City-busz)
- Long name and handles will now be ellipsized (#1510)
- Language selector will now use the English locale name for searching (#1514)

# Fixed

- Websockets not connecting right away when the instance uses a different domain for them (#1507)
- Manually refreshing would refresh all constructed timelines instead of just the visible one (#1509)
- Random non-reproducible crashes due to weak references by getting rid of most of them (#1348)
- Scroll to open post when opening a thread (#1353)
- Inability to toggle the sidebar when collapsed using gestures (#1355, thanks [at]DaPigGuy)
- Removed hacks around labels with custom emojis since the bugs have been fixed upstream (#1357, thanks [at]bugaevc)
- Freezing by attempting to create all profile fields rows allowed when editing your profile when the limit was too high by dynamically appending new rows (#1372)
- Chinese translations not being usable due to the default locale name used (#1387)
- Embed missing icon (#1396)
- Instantly save settings in dconf on window close when work-in-background is enabled (#1400)
- Match libadwaita's 1.7 roundness (#1401)
- Schedule post dialog being too close to the edges (#1427)
- Increased (old) composer's width to fit different locales better (#1434, thanks [at]thonkdifferent)
- Avatar size bugs from libadwaita 1.7.5
- Profile view errors and empty state never being displayed (#1465)
- Lists appearing blank when containing reserved characters when editing them from a profile (#1476)
- Hidden following/followers counts being displayed as -1 (#1488)
- Timelines not being able to infinite scroll when the min batch size is too small (#1499)
- Thread open post getting memory leaked (#1501)
- Some widgets not removing all their children when they are getting updated (#1502)
- Open post not being selectable when opening a thread after it gets updated (#1503)
- Spoiler being visible for a millisecond when opening a post in a thread even if it doesn't have a spoiler (#1504)
- Uploading attachments on Windows (#1511)
- Segfault on Windows when opening the scheduling dialog (#1512)
- Account switcher badges being in the wrong position (#1513)
- Sidebar badges not being centered (#1513)
- Screen readers freezing on the timelines (#1520)
- Updated https://tuba.geopjr.dev/

# Package Maintainers

- Clapper (the library) is now used by default for playing videos. It's still optional but Tuba is focused on it moving forward.
- Language specs and styles are now embeded and won't be installed on the host. Please remove any install instructions for them from your packages.
- The meson options now use features with fallbacks, please update your packages to reflect that if needed.
- There's a d-bus service file now per guidelines.
```

Crossing my fingers I didn't forget anything