### PR TITLE
fix(translations): fix metainfo translations

### DIFF
--- a/po/ca.po
+++ b/po/ca.po
@@ -42,7 +42,8 @@ msgid ""
 msgstr ""
 "Exploreu la web social federada amb tuba per a Gnome. Mantingueu -vos "
 "connectats a les vostres comunitats preferides, familiars i amics amb suport "
-"a plataformes populars de Fediverse com Mastodon, GoToSocial, Akkoma & Més!"
+"a plataformes populars de Fediverse com Mastodon, GoToSocial, Akkoma &amp; "
+"Més!"
 
 #: data/dev.geopjr.Tuba.metainfo.xml.in:12
 msgid ""

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -44,7 +44,7 @@ msgid ""
 msgstr ""
 "Explore the federated social web with Tuba for GNOME. Stay connected to your "
 "favourite communities, family and friends with support for popular Fediverse "
-"platforms like Mastodon, GoToSocial, Akkoma & more!"
+"platforms like Mastodon, GoToSocial, Akkoma &amp; more!"
 
 #: data/dev.geopjr.Tuba.metainfo.xml.in:12
 msgid ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -44,7 +44,7 @@ msgid ""
 msgstr ""
 "Explorez le web social fédéré avec Tuba pour GNOME. Restez connecté à vos "
 "communautés favorites, vos amis et votre famille avec la prise en charge de "
-"plateformes populaires du Fédiverse comme Mastodon, GoToSocial, Akkoma & "
+"plateformes populaires du Fédiverse comme Mastodon, GoToSocial, Akkoma &amp; "
 "plus encore !"
 
 #: data/dev.geopjr.Tuba.metainfo.xml.in:12


### PR DESCRIPTION
Translations of the metainfo description are interpreted by libxml, therefore `&` must actually appear as `&amp;` in those. Fix the 3 languages where this is an issue.