### PR TITLE
fix(build): Tuba doesn't compile without libspelling feature enabled

### DIFF
--- a/src/Dialogs/Composer/Editor.vala
+++ b/src/Dialogs/Composer/Editor.vala
@@ -13,7 +13,9 @@ public class Tuba.Dialogs.Composer.Components.Editor : Widgets.SandwichSourceVie
 			if (_locale != value) {
 				_locale = value;
 				count_chars ();
-				update_spelling_lang ();
+				#if LIBSPELLING
+					update_spelling_lang ();
+				#endif
 			}
 		}
 	}


### PR DESCRIPTION
Hey, I noticed that the `update_spelling_lang ()` method is not found if the `LIBSPELLING` feature is disabled, so compilation without it would fail.