### PR TITLE
fix: allow building with Vala 0.56

### DIFF
--- a/src/Dialogs/Composer/Dialog.vala
+++ b/src/Dialogs/Composer/Dialog.vala
@@ -341,7 +341,7 @@ public class Tuba.Dialogs.Composer.Dialog : Adw.Dialog {
 			Adw.BreakpointConditionLengthType.MAX_WIDTH,
 			400, Adw.LengthUnit.SP
 		);
-		var breakpoint = new Adw.Breakpoint (condition);
+		var breakpoint = new Adw.Breakpoint ((owned) condition);
 		breakpoint.add_setter (this, "is-narrow", true);
 		add_breakpoint (breakpoint);
 

--- a/src/Views/Admin/Pages/Accounts.vala
+++ b/src/Views/Admin/Pages/Accounts.vala
@@ -53,7 +53,7 @@ public class Tuba.Views.Admin.Page.Accounts : Views.Admin.Page.Base {
 			Adw.BreakpointConditionLengthType.MAX_WIDTH,
 			450, Adw.LengthUnit.SP
 		);
-		var breakpoint = new Adw.Breakpoint (condition);
+		var breakpoint = new Adw.Breakpoint ((owned) condition);
 		breakpoint.add_setter (revealer_box, "halign", Gtk.Align.FILL);
 		breakpoint.add_setter (entry_box_1, "orientation", Gtk.Orientation.VERTICAL);
 		breakpoint.add_setter (entry_box_2, "orientation", Gtk.Orientation.VERTICAL);

--- a/src/Views/TabbedBase.vala
+++ b/src/Views/TabbedBase.vala
@@ -101,7 +101,7 @@ public class Tuba.Views.TabbedBase : Views.Base {
 
 		if (this.current_breakpoint != null) remove_breakpoint (this.current_breakpoint);
 		this.small = true;
-		var breakpoint = new Adw.Breakpoint (condition);
+		var breakpoint = new Adw.Breakpoint ((owned) condition);
 		breakpoint.add_setter (this, "title-stack-page-visible", true);
 		breakpoint.add_setter (switcher_bar, "reveal", true);
 		add_breakpoint (breakpoint);


### PR DESCRIPTION
Vala 0.56 seems to be stricter about ownership, leading builds to fail with errors such as the following one:
```
  ../../src/Views/TabbedBase.vala:104.40-104.48: error: duplicating `BreakpointCondition' instance, use unowned variable or explicitly invoke copy method
```
This is fixed by explicitly transferring ownership of the breakpoint condition to the breakpoint itself.