### PR TITLE
feat: resolve preview cards, optimize and add more resolvables

### DIFF
--- a/src/Views/Browser.vala
+++ b/src/Views/Browser.vala
@@ -357,6 +357,11 @@ public class Tuba.Views.Browser : Adw.Dialog {
 		}
 	}
 
+
+	public static inline bool can_handle (GLib.Uri? uri, string url) {
+		return uri == null ? can_handle_url (url) : can_handle_uri (uri);
+	}
+
 	public static bool can_handle_uri (GLib.Uri uri) {
 		return uri.get_scheme ().has_prefix ("http");
 	}

--- a/src/Widgets/RichLabel.vala
+++ b/src/Widgets/RichLabel.vala
@@ -167,7 +167,7 @@ public class Tuba.Widgets.RichLabel : Adw.Bin {
 			warning (@"Failed to parse \"$url\": $(e.message)");
 		}
 
-		if (should_resolve_url (url)) {
+		if (should_resolve (uri, url)) {
 			accounts.active.resolve.begin (url, (obj, res) => {
 				try {
 					accounts.active.resolve.end (res).open ();
@@ -203,10 +203,26 @@ public class Tuba.Widgets.RichLabel : Adw.Bin {
 		}
 	}
 
+	public inline static bool should_resolve (GLib.Uri? uri, string url) {
+		return uri != null ? should_resolve_uri (uri) : should_resolve_url (url);
+	}
+
 	public static bool should_resolve_url (string url) {
 		return settings.aggressive_resolving
 			|| url.index_of_char ('@') != -1
-			|| "/user" in url;
+			|| "/users/" in url
+			|| "/notes/" in url
+			|| "/notice/" in url;
+	}
+
+	public static bool should_resolve_uri (GLib.Uri uri) {
+		if (settings.aggressive_resolving) return true;
+
+		string path = uri.get_path ();
+		return path.has_prefix ("/@")
+			|| path.has_prefix ("/users/")
+			|| path.has_prefix ("/notes/")
+			|| path.has_prefix ("/notice/");
 	}
 
 	#if WEBKIT


### PR DESCRIPTION
1.
- misskey: /users/, /notes/
- \*oma: /users/, /notice/

2. we can optimize resolving if we have Uris by getting the path and checking the prefix instead of the whole string
3. some helpers around uri vs url functions were added (union types when)
4. preview cards can now be resolves, above points apply here too

fix: #1555