### PR TITLE
fix(Thread): segfault when destroying weak refs too quick

### DIFF
--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -456,7 +456,7 @@
 	}
 
 	public void on_edit (API.Status x) {
-		this.status.patch (x);
+		if (this.status != null) this.status.patch (x);
 		bind ();
 	}
 


### PR DESCRIPTION
root status widget is a weak ref to fix a memory leak. That weak ref can be finalized during the update callback and call its on_edit while its properties have also been finalized. This PR creates an owned reference, updates the widgets and clears it afterwards.

fix: #1544