### PR TITLE
fix(SecretAccountStore): handle unexpected secrets

### DIFF
--- a/src/Services/Accounts/SecretAccountStore.vala
+++ b/src/Services/Accounts/SecretAccountStore.vala
@@ -279,9 +279,10 @@ public class Tuba.SecretAccountStore : AccountStore {
 			var secret = item.retrieve_secret_sync ();
 			var contents = secret.get_text ();
 			var parser = new Json.Parser ();
-			parser.load_from_data (contents, -1);
+			if (!parser.load_from_data (contents, -1)) return null;
 
 			var root = parser.get_root ();
+			if (root == null || root.get_node_type () != Json.NodeType.OBJECT) return null;
 			var root_obj = root.get_object ();
 
 			// HACK: Partial makeshift secret validation


### PR DESCRIPTION
Since we *have to* read all keyring secrets that match our schema, Tuba reads Turntable's which is an array of object and a critical pops up when attempting to get the root object (since its an array). It now checks if it's an object plus some more null checking.