### PR TITLE
fix(composer): status box background

### DIFF
--- a/src/Dialogs/Composer/Editor.vala
+++ b/src/Dialogs/Composer/Editor.vala
@@ -244,7 +244,8 @@ public class Tuba.Dialogs.Composer.Components.Editor : Widgets.SandwichSourceVie
 		status_box = new Gtk.Box (VERTICAL, 30) {
 			valign = START,
 			vexpand = true,
-			margin_bottom = 28
+			margin_bottom = 28,
+			css_classes = { "background-none" }
 		};
 
 		status_title = new Gtk.Label (_("New Post")) {


### PR DESCRIPTION
Inline status widgets in the composer had a background color that was only somewhat visible in dark mode in the corners. This PR removes the background from the parent listbox.