### PR TITLE
fix(Entity): use dash for params on find_property

### DIFF
--- a/src/API/Entity.vala
+++ b/src/API/Entity.vala
@@ -9,7 +9,7 @@ public class Tuba.Entity : GLib.Object, Widgetizable, Json.Serializable {
 	}
 
 	public override unowned ParamSpec? find_property (string name) {
-		if (name.has_prefix ("tuba_")) return null;
+		if (name.has_prefix ("tuba-")) return null;
 
 		switch (name) {
 			case "type":


### PR DESCRIPTION
the canonical is dashes