### PR TITLE
feat(notifications): dont handle unknown types

### DIFF
--- a/src/API/GroupedNotificationsResults.vala
+++ b/src/API/GroupedNotificationsResults.vala
@@ -28,8 +28,26 @@ public class Tuba.API.GroupedNotificationsResults : Entity {
 				case InstanceAccount.KIND_FOLLOW:
 				case InstanceAccount.KIND_ADMIN_SIGNUP:
 					return create_basic_card ();
-				default:
+				case InstanceAccount.KIND_MENTION:
+				case InstanceAccount.KIND_REBLOG:
+				case InstanceAccount.KIND_FAVOURITE:
+				case InstanceAccount.KIND_POLL:
+				case InstanceAccount.KIND_FOLLOW_REQUEST:
+				case InstanceAccount.KIND_REMOTE_REBLOG:
+				case InstanceAccount.KIND_EDITED:
+				case InstanceAccount.KIND_REPLY:
+				case InstanceAccount.KIND_SEVERED_RELATIONSHIPS:
+				case InstanceAccount.KIND_ADMIN_REPORT:
+				case InstanceAccount.KIND_STATUS:
+				case InstanceAccount.KIND_PLEROMA_REACTION:
+				case InstanceAccount.KIND_REACTION:
+				case InstanceAccount.KIND_ANNUAL_REPORT:
+				case InstanceAccount.KIND_MODERATION_WARNING:
+				case InstanceAccount.KIND_QUOTE:
+				case InstanceAccount.KIND_QUOTE_UPDATE:
 					return new Widgets.GroupedNotification (this);
+				default:
+					return base.to_widget ();
 			}
 		}
 

--- a/src/Services/Accounts/InstanceAccount.vala
+++ b/src/Services/Accounts/InstanceAccount.vala
@@ -945,7 +945,8 @@ public class Tuba.InstanceAccount : API.Account, Streamable {
 		sent_notifications.set (id, others);
 
 		obj.to_toast.begin (this, others, (_obj, res) => {
-			app.send_notification (id, obj.to_toast.end (res));
+			GLib.Notification? notification = obj.to_toast.end (res);
+			if (notification != null) app.send_notification (id, notification);
 		});
 	}
 


### PR DESCRIPTION
Tuba would attempt to always *show* a notification, even if we don't implement the type yet which would lead to just a status or an account being there with no explanation. It now displays "Unknown type: $type"

Draft because there must be a better way to handle this than this switch. 