### PR TITLE
feat(meson): bump libadwaita

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -72,8 +72,8 @@ i18n = import('i18n')
 gstreamer = false
 webkit = false
 gexiv2 = false
-gtk_dep = dependency('gtk4', version: '>=4.18', required: true)
-libadwaita_dep = dependency('libadwaita-1', version: '>=1.7', required: true)
+gtk_dep = dependency('gtk4', version: '>=4.19', required: true)
+libadwaita_dep = dependency('libadwaita-1', version: '>=1.8', required: true)
 gtksourceview_dep = dependency('gtksourceview-5', required: true, version: '>=5.6.0')
 libwebp_dep = dependency('libwebp', required: false)
 libspelling = dependency('libspelling-1', required: get_option('spelling'))
@@ -90,10 +90,6 @@ endif
 
 if libspelling.found ()
   add_project_arguments(['--define=LIBSPELLING'], language: 'vala')
-endif
-
-if libadwaita_dep.version().version_compare('>=1.7.5')
-  add_project_arguments(['--define=ADW_1_7_5'], language: 'vala')
 endif
 
 if gtksourceview_dep.version().version_compare('>=5.7.1')
@@ -120,10 +116,6 @@ endif
 if webkit_dep.found ()
   add_project_arguments(['--define=WEBKIT'], language: 'vala')
   webkit = true
-endif
-
-if gtk_dep.version().version_compare('>=4.19.1')
-  add_project_arguments(['--define=GTK_4_19_1'], language: 'vala')
 endif
 
 if meson.get_compiler('vala').version().version_compare('>=0.56.19')

--- a/src/Dialogs/Composer/Editor.vala
+++ b/src/Dialogs/Composer/Editor.vala
@@ -361,19 +361,6 @@ public class Tuba.Dialogs.Composer.Components.Editor : Widgets.SandwichSourceVie
 		pop_subpage ();
 	}
 
-	// https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/8477
-	// I don't think it will be backported to 4.18, so this is a
-	// HACK: queue allocate the placeholder's parent
-	// 		 (textviewchild) so it stays in place while scrolling.
-	// NOTE: doesn't seem to work all the time, a full resize is
-	//		 needed
-	#if !GTK_4_19_1
-		public override void size_allocate (int width, int height, int baseline) {
-			base.size_allocate (width, height, baseline);
-			if (placeholder.visible) placeholder.get_parent ().queue_allocate ();
-		}
-	#endif
-
 	// HACK: we need the default dialog size to be wider
 	//		 but still follow the content, so let's set
 	//		 the nat width to this

--- a/src/Widgets/Account.vala
+++ b/src/Widgets/Account.vala
@@ -174,9 +174,6 @@ public class Tuba.Widgets.Account : Gtk.ListBoxRow {
 	private string account_id = "";
 	private ulong open_signal = 0;
 	public Account (API.Account account) {
-		#if !ADW_1_7_5
-			avatar.size = 100;
-		#endif
 		account_id = account.id;
 		open.connect (account.open);
 		background.clicked.connect (account.open);

--- a/src/Widgets/ProfileCover.vala
+++ b/src/Widgets/ProfileCover.vala
@@ -266,9 +266,6 @@ protected class Tuba.Widgets.Cover : Gtk.Box {
 	string stats_string = "";
 	string profile_id;
 	public Cover (Views.Profile.ProfileAccount profile, bool mini = false) {
-		#if !ADW_1_7_5
-			avatar.size = 100;
-		#endif
 		profile_id = profile.account.id;
 		if (settings.scale_emoji_hover)
 			this.add_css_class ("lww-scale-emoji-hover");


### PR DESCRIPTION
As always, when we bump libadwaita, we also bump gtk and glib to match its min versions. This means the removal of the following flags and paths / compile-time fixes for them:

- ADW_1_7_5: avatar sizing changes due to a gtk change
- GTK_4_19_1: attempt at fixing a bug in GTK <= 4.19.0 with the composer placeholder