### PR TITLE
feat(metainfo): lock git lfs screenshots

### DIFF
--- a/data/dev.geopjr.Tuba.metainfo.xml.in
+++ b/data/dev.geopjr.Tuba.metainfo.xml.in
@@ -32,31 +32,31 @@
   <url type="contribute">https://github.com/GeopJr/Tuba#contributing</url>
   <screenshots>
     <screenshot type="default">
-      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/main/data/screenshots/screenshot-1.png</image>
+      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/7f919343ea87ab04455d9087f16ca38a0680dc08/data/screenshots/screenshot-1.png</image>
       <caption>Home Timeline</caption>
     </screenshot>
     <screenshot>
-      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/main/data/screenshots/screenshot-2.png</image>
+      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/7f919343ea87ab04455d9087f16ca38a0680dc08/data/screenshots/screenshot-2.png</image>
       <caption>Composer</caption>
     </screenshot>
     <screenshot>
-      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/main/data/screenshots/screenshot-3.png</image>
+      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/7f919343ea87ab04455d9087f16ca38a0680dc08/data/screenshots/screenshot-3.png</image>
       <caption>Profile View</caption>
     </screenshot>
     <screenshot>
-      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/main/data/screenshots/screenshot-4.png</image>
+      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/7f919343ea87ab04455d9087f16ca38a0680dc08/data/screenshots/screenshot-4.png</image>
       <caption>Home Timeline</caption>
     </screenshot>
     <screenshot>
-      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/main/data/screenshots/screenshot-5.png</image>
+      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/7f919343ea87ab04455d9087f16ca38a0680dc08/data/screenshots/screenshot-5.png</image>
       <caption>Schedule Post Dialog</caption>
     </screenshot>
     <screenshot>
-      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/main/data/screenshots/screenshot-6.png</image>
+      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/7f919343ea87ab04455d9087f16ca38a0680dc08/data/screenshots/screenshot-6.png</image>
       <caption>Scheduled Posts</caption>
     </screenshot>
     <screenshot>
-      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/main/data/screenshots/screenshot-7.png</image>
+      <image type="source">https://media.githubusercontent.com/media/GeopJr/Tuba/7f919343ea87ab04455d9087f16ca38a0680dc08/data/screenshots/screenshot-7.png</image>
       <caption>Search View</caption>
     </screenshot>
   </screenshots>


### PR DESCRIPTION
honestly, should have been done already. Screenshots should follow the last release not the last iteration.