### PR TITLE
fix(AttachmentsBin): race condition with adding attachments to the grid

### DIFF
--- a/src/Dialogs/Composer/AttachmentsBin.vala
+++ b/src/Dialogs/Composer/AttachmentsBin.vala
@@ -466,8 +466,8 @@ public class Tuba.Dialogs.Composer.Components.AttachmentsBin : Gtk.Grid, Attacha
 			var attachment = new Composer.Components.Attachment ();
 			attachment.upload_error.connect (on_upload_error);
 			attachment.notify["done"].connect (on_attachment_done);
-			attachment.upload.begin (file13);
 			add_attachment (attachment);
+			attachment.upload.begin (file13);
 		}
 	}
 


### PR DESCRIPTION
fix: #1581 

I assumed that by the time upload (async) starts, the attachment would have made it into the grid but the linked issue proved otherwise. When Tuba doesn't have access to the attachment\* it would reach an upload_error instantly and request for its removal from the grid, but it wasn't in it to begin with. It now adds it to the grid first.

\* this doesn't happen traditionally. If the user opens a file or DnD's it, it normally can access it or gets access to it even in sandboxed environments, but the linked issue was about the older Ubuntu LTS which has some issue with the DnD portal apparently and the app doesn't get access to the file then.