### PR TITLE
fix(metadata): add GNOME GitLab profile to doap

### DIFF
--- a/Tuba.doap
+++ b/Tuba.doap
@@ -22,6 +22,12 @@
 					<foaf:accountName>GeopJr</foaf:accountName>
 				</foaf:OnlineAccount>
 			</foaf:account>
+			<foaf:account>
+				<foaf:OnlineAccount>
+					<foaf:accountServiceHomepage rdf:resource="https://gitlab.gnome.org/" />
+					<foaf:accountName>GeopJr</foaf:accountName>
+				</foaf:OnlineAccount>
+			</foaf:account>
 		</foaf:Person>
 	</maintainer>
 </Project>


### PR DESCRIPTION
This makes it possible for the GNOME Circle team to send out automated notices on GitLab for issues that affect Tuba.